### PR TITLE
autotest can't stop loop because of update detection "log/test.log"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'jeweler'
 gem 'webrat', ">= 0.7.2.beta.1"
 gem 'sqlite3-ruby', :require => 'sqlite3'
 
+gem 'autotest'
+
 case RUBY_VERSION
 when /^1\.9/
   gem 'ruby-debug19'

--- a/lib/autotest/rails_rspec2.rb
+++ b/lib/autotest/rails_rspec2.rb
@@ -34,7 +34,7 @@ class Autotest::RailsRspec2 < Autotest::Rspec2
 
   def setup_rails_rspec2_mappings
     %w{config/ coverage/ db/ doc/ log/ public/ script/ tmp/ vendor/rails vendor/plugins vendor/gems}.each do |exception|
-      at.add_exception(/^([\.\/]*)?#{exception}/)
+      add_exception(/^([\.\/]*)?#{exception}/)
     end
 
     clear_mappings

--- a/spec/autotest/rails_rspec2_spec.rb
+++ b/spec/autotest/rails_rspec2_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+require "autotest/rails_rspec2"
+
+describe Autotest::RailsRspec2 do
+  before(:each) do
+    rails_rspec2_autotest = Autotest::RailsRspec2.new
+    @re = rails_rspec2_autotest.exceptions
+  end
+
+  it "should match './log/test.log'" do
+    @re.should match('./log/test.log')
+  end
+
+  it "should match 'log/test.log'" do
+    @re.should match('log/test.log')
+  end
+
+  it "should not match './spec/models/user_spec.rb'" do
+    @re.should_not match('./spec/models/user_spec.rb')
+  end
+
+  it "should not match 'spec/models/user_spec.rb'" do
+    @re.should_not match('spec/models/user_spec.rb')
+  end
+end


### PR DESCRIPTION
After the commit e93fd08a4c3e90bd22671c8df50e96c1c916a32f, autotest exception changes regexp, so autotest detects update of "./log/test.log" that is obtained from Autotest.find_files. Therefore, if test fails, last failing test is ran repeatedly.

This patch is to detect "./log/test.log".
