### PR TITLE
Correcting issue #197

### DIFF
--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -8,15 +8,13 @@ if defined?(ActiveRecord)
         include RSpec::Rails::TestUnitAssertionAdapter
 
         included do
-          if RSpec.configuration.use_transactional_fixtures
-            # TODO - figure out how to move this outside the included block
-            include ActiveRecord::TestFixtures
+          # TODO - figure out how to move this outside the included block
+          include ActiveRecord::TestFixtures
 
-            self.fixture_path = RSpec.configuration.fixture_path
-            self.use_transactional_fixtures = RSpec.configuration.use_transactional_fixtures
-            self.use_instantiated_fixtures  = RSpec.configuration.use_instantiated_fixtures
-            fixtures RSpec.configuration.global_fixtures if RSpec.configuration.global_fixtures
-          end
+          self.fixture_path = RSpec.configuration.fixture_path
+          self.use_transactional_fixtures = RSpec.configuration.use_transactional_fixtures
+          self.use_instantiated_fixtures  = RSpec.configuration.use_instantiated_fixtures
+          fixtures RSpec.configuration.global_fixtures if RSpec.configuration.global_fixtures
         end
       end
     end


### PR DESCRIPTION
I just digged out rspec-rails code and found that the `ActiveRecord::TestFixtures` was being included only if transactional fixtures were off. That's the only cause of the bug described on http://github.com/rspec/rspec-rails/issues#issue/197. Actually, I cannot figure why the condition was even there, so I removed it and everything worked fine, including the specs. But since they were working before too, I think it's better to make a spec to test this. In fact I tried, but I found out I don't know how to test a test framework. =D
