### PR TITLE
undefined method RSpec.configure

### DIFF
--- a/lib/rspec/rails/matchers.rb
+++ b/lib/rspec/rails/matchers.rb
@@ -1,3 +1,4 @@
+require 'rspec/core'
 require 'rspec/core/deprecation'
 require 'rspec/core/backward_compatibility'
 require 'rspec/matchers'


### PR DESCRIPTION
When I am using cucumber-rails and RSpec in a new-to-Rails-3 application of mine, I came across the `undefined method RSpec.configure` error. It turns out that the require Cucumber does to 'cucumber/rails/rspec' uses `require 'rspec/rails/matchers'` which **does not** `require 'rspec/core'`, which means that _matchers.rb_ _creates_ the RSpec module rather than using the one from _core.rb_. This is bad, because we'd like to use the RSpec.configure method.

The attached patch fixes this issue.
