### PR TITLE
autotest mapping for spec/support/*.rb

### DIFF
--- a/lib/autotest/rails_rspec2.rb
+++ b/lib/autotest/rails_rspec2.rb
@@ -71,7 +71,7 @@ class Autotest::RailsRspec2 < Autotest::Rspec2
     add_mapping(%r%^config/database\.yml$%) { |_, m|
       files_matching %r%^spec/models/.*_spec\.rb$%
     }
-    add_mapping(%r%^(spec/(spec_helper|shared/.*)|config/(boot|environment(s/test)?))\.rb$%) {
+    add_mapping(%r%^(spec/(spec_helper|support/.*)|config/(boot|environment(s/test)?))\.rb$%) {
       files_matching %r%^spec/(models|controllers|routing|views|helpers)/.*_spec\.rb$%
     }
     add_mapping(%r%^lib/(.*)\.rb$%) { |_, m|

--- a/spec/autotest/rails_rspec2_spec.rb
+++ b/spec/autotest/rails_rspec2_spec.rb
@@ -2,24 +2,43 @@ require "spec_helper"
 require "autotest/rails_rspec2"
 
 describe Autotest::RailsRspec2 do
-  before(:each) do
-    rails_rspec2_autotest = Autotest::RailsRspec2.new
-    @re = rails_rspec2_autotest.exceptions
+  before do
+    @rails_rspec2_autotest = Autotest::RailsRspec2.new
   end
 
-  it "should match './log/test.log'" do
-    @re.should match('./log/test.log')
+  describe 'exceptions' do
+    before do
+      @re = @rails_rspec2_autotest.exceptions
+    end
+
+    it "should match './log/test.log'" do
+      @re.should match('./log/test.log')
+    end
+
+    it "should match 'log/test.log'" do
+      @re.should match('log/test.log')
+    end
+
+    it "should not match './spec/models/user_spec.rb'" do
+      @re.should_not match('./spec/models/user_spec.rb')
+    end
+
+    it "should not match 'spec/models/user_spec.rb'" do
+      @re.should_not match('spec/models/user_spec.rb')
+    end
   end
 
-  it "should match 'log/test.log'" do
-    @re.should match('log/test.log')
-  end
+  describe 'mappings' do
+    before do
+      @rails_rspec2_autotest.find_order = %w(
+        spec/models/user_spec.rb
+        spec/support/blueprints.rb
+      )
+    end
 
-  it "should not match './spec/models/user_spec.rb'" do
-    @re.should_not match('./spec/models/user_spec.rb')
-  end
-
-  it "should not match 'spec/models/user_spec.rb'" do
-    @re.should_not match('spec/models/user_spec.rb')
+    it 'runs model specs when support files change' do
+      @rails_rspec2_autotest.test_files_for('spec/support/blueprints.rb').should(
+        include('spec/models/user_spec.rb'))
+    end
   end
 end


### PR DESCRIPTION
Hi, all --

I just happened to notice that autotest wasn't re-running specs when I changed `spec/support/blueprints.rb`.

It seems that, while the generated `spec_helper.rb` suggests `spec/support`, the autotest mappings say `spec/shared` instead.

This patch updates the autotest mappings to say `spec/support`, which I'm assuming is a good idea, since cucumber also uses the word "support" for this kind of subdirectory.

All the best,  -- Matthew
