### PR TITLE
Fix for ror 301

### DIFF
--- a/lib/rspec/rails/view_assigns.rb
+++ b/lib/rspec/rails/view_assigns.rb
@@ -13,14 +13,14 @@ module RSpec
           _encapsulated_assigns[key] = value
         end
 
-        if ::Rails::VERSION::STRING == "3.0.0"
+        if ::Rails::VERSION::STRING =~ /3\.0\.[01]/
           def _assigns
             super.merge(_encapsulated_assigns)
           end
           def view_assigns
             _assigns
           end
-        else # >= 3.0.1
+        else # >= 3.0.2 maybe...
           def view_assigns
             super.merge(_encapsulated_assigns)
           end


### PR DESCRIPTION
Seems to me that the latest release of RoR still needs `_assigns` to have working view specs.
