### PR TITLE
rails gem deps

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -57,7 +57,9 @@ Gem::Specification.new do |s|
 **************************************************
 }
 
-  s.add_runtime_dependency "rails", "~> 3.0.0"
+  s.add_runtime_dependency(%q<activesupport>, ["~> 3.0.0"])
+  s.add_runtime_dependency(%q<actionpack>, ["~> 3.0.0"])
+  s.add_runtime_dependency(%q<railties>, ["~> 3.0.0"])
   s.add_runtime_dependency "rspec", "~> #{RSpec::Rails::Version::STRING.split('.')[0..1].join('.')}"
 end
 


### PR DESCRIPTION
Hey,

I removed dependency on the monolithic rails gem and replaced that with an explicit dependency on railties, actionpack and activesupport gems. This is what we've got in dm-rails gem because we don't want to have activerecord and arel pulled in if we're using DataMapper. It's the same case here with rspec-rails. I have an app that uses DataMapper and RSpec. I upgraded today to RSpec 2.2.0 and got active record and arel pulled in as new dependencies.

Thanks
# solnic
