### PR TITLE
Added ability for rake spec to use db:test:clone_structure

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -2,7 +2,12 @@ require 'rspec/core'
 require 'rspec/core/rake_task'
 Rake.application.instance_variable_get('@tasks')['default'].prerequisites.delete('test')
 
-spec_prereq = Rails.configuration.generators.options[:rails][:orm] == :active_record ?  "db:test:prepare" : :noop
+orm_setting = Rails.configuration.generators.options[:rails][:orm]
+spec_prereq = if(orm_setting == :active_record)
+  Rails.configuration.active_record[:schema_format] == :schema ? "db:test:prepare" : "db:test:clone_structure"
+else
+  :noop
+end
 task :noop do; end
 task :default => :spec
 


### PR DESCRIPTION
I modifed the rake file to set the spec_prereq based on the configuration of active record's schema format if ar is the designated orm.  

rspec spec works fine but rake spec was failing for me b/c I have a full text index on a table.  Because of that, I have to set config.activerecord.schema_format to be :sql. Unfortunately, rake spec was ignoring that and always running rake db:test:prepare which will fail for that type of table structure.
