### PR TITLE
Use index_helper instead of table_name

### DIFF
--- a/lib/generators/rspec/integration/templates/request_spec.rb
+++ b/lib/generators/rspec/integration/templates/request_spec.rb
@@ -4,10 +4,10 @@ describe "<%= class_name.pluralize %>" do
   describe "GET /<%= table_name %>" do
     it "works! (now write some real specs)" do
 <% if webrat? -%>
-      visit <%= table_name %>_path
+      visit <%= index_helper %>_path
 <% else -%>
       # Run the generator again with the --webrat flag if you want to use webrat methods/matchers
-      get <%= table_name %>_path
+      get <%= index_helper %>_path
 <% end -%>
       response.status.should be(200)
     end

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -120,7 +120,7 @@ describe <%= controller_class_name %>Controller do
     it "redirects to the <%= table_name %> list" do
       <%= stub orm_class.find(class_name) %> { <%= mock_file_name %> }
       delete :destroy, :id => "1"
-      response.should redirect_to(<%= table_name %>_url)
+      response.should redirect_to(<%= index_helper %>_url)
     end
   end
 

--- a/lib/generators/rspec/scaffold/templates/edit_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/edit_spec.rb
@@ -21,7 +21,7 @@ describe "<%= table_name %>/edit.html.<%= options[:template_engine] %>" do
     end
 <% else -%>
     # Run the generator again with the --webrat flag if you want to use webrat matchers
-    assert_select "form", :action => <%= file_name %>_path(@<%= file_name %>), :method => "post" do
+    assert_select "form", :action => <%= index_helper %>_path(@<%= file_name %>), :method => "post" do
 <% for attribute in output_attributes -%>
       assert_select "<%= attribute.input_type -%>#<%= file_name %>_<%= attribute.name %>", :name => "<%= file_name %>[<%= attribute.name %>]"
 <% end -%>

--- a/lib/generators/rspec/scaffold/templates/new_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/new_spec.rb
@@ -20,7 +20,7 @@ describe "<%= table_name %>/new.html.<%= options[:template_engine] %>" do
     end
 <% else -%>
     # Run the generator again with the --webrat flag if you want to use webrat matchers
-    assert_select "form", :action => <%= table_name %>_path, :method => "post" do
+    assert_select "form", :action => <%= index_helper %>_path, :method => "post" do
 <% for attribute in output_attributes -%>
       assert_select "<%= attribute.input_type -%>#<%= file_name %>_<%= attribute.name %>", :name => "<%= file_name %>[<%= attribute.name %>]"
 <% end -%>


### PR DESCRIPTION
Hi,
Because I need to use Indonesian language that use singular form for controller names (and paths), I modify the rspec scaffold generators to use index_helper from railties' NamedBase generator (already inherited by RSpec's Base generator) to give correct result.

I can't give additional cukes feature 'cause I failed to correctly run the cukes. Perhaps it's related to (apparently) custom arel in the Gemfile.

Regards
