### PR TITLE
Mock and stub models shouldn't be blank

### DIFF
--- a/lib/rspec/rails/mocks.rb
+++ b/lib/rspec/rails/mocks.rb
@@ -81,6 +81,7 @@ EOM
         stubs = stubs.reverse_merge(:persisted? => !!stubs[:id])
         stubs = stubs.reverse_merge(:destroyed? => false)
         stubs = stubs.reverse_merge(:marked_for_destruction? => false)
+        stubs = stubs.reverse_merge(:blank? => false)
 
         mock("#{model_class.name}_#{stubs[:id]}", stubs).tap do |m|
           m.extend ActiveModelInstanceMethods
@@ -192,6 +193,7 @@ EOM
             stubs = stubs.reverse_merge(:id => next_id)
             stubs = stubs.reverse_merge(:persisted? => !!stubs[:id])
           end
+          stubs = stubs.reverse_merge(:blank? => false)
           stubs.each do |k,v|
             m.__send__("#{k}=", stubs.delete(k)) if m.respond_to?("#{k}=")
           end

--- a/spec/rspec/rails/mocks/mock_model_spec.rb
+++ b/spec/rspec/rails/mocks/mock_model_spec.rb
@@ -260,6 +260,12 @@ describe "mock_model(RealModel)" do
     end
   end
 
+  describe "#blank?" do
+    it "is false" do
+      mock_model(MockableModel).should_not be_blank
+    end
+  end
+
   describe "ActiveModel Lint tests" do
     require 'test/unit/assertions'
     require 'active_model/lint'

--- a/spec/rspec/rails/mocks/stub_model_spec.rb
+++ b/spec/rspec/rails/mocks/stub_model_spec.rb
@@ -35,6 +35,11 @@ describe "stub_model" do
       second.to_param.to_i.should == (first.to_param.to_i + 1)
     end
 
+    describe "#blank?" do
+      it "is false" do
+        stub_model(model_class).should_not be_blank
+      end
+    end
   end
 
   context "with ActiveModel (not ActiveRecord)" do


### PR DESCRIPTION
I ran into this issue when checking whether or not an instance variable was assigned in a controller. I would mock a model with .as_null_object and because that returned a string for #blank?, it was evaluating to true, instead of false. 

If this is not the proper way to fix this, let me know and I'll be happy to change it. 
