### PR TITLE
Added AR extension error_messages_for to enable model.error_messages_for(:attribute).should for better validation testing

### DIFF
--- a/features/model_specs/error_messages_on.feature
+++ b/features/model_specs/error_messages_on.feature
@@ -1,0 +1,122 @@
+Feature: error_messages_on
+
+  Scenario: without validation for an attribute
+    Given a file named "spec/models/widget_spec.rb" with:
+      """
+      require "spec_helper"
+
+      class ValidatingWidget < ActiveRecord::Base
+        set_table_name :widgets
+      end
+
+      describe ValidatingWidget do
+        it "has no validation error message for non existing attribute (using error_message_on)" do
+					ValidatingWidget.new.error_message_on(:foo).should be_blank
+					ValidatingWidget.new.error_message_on(:foo).should be_nil
+        end
+
+        it "has no validation error message non existing attribute (using error_messages_on)" do
+					ValidatingWidget.new.error_messages_on(:foo).should be_blank
+					ValidatingWidget.new.error_messages_on(:foo).should be_nil
+        end
+      end
+      """
+    When I run "rspec spec/models/widget_spec.rb"
+    Then the examples should all pass
+
+  Scenario: with no validation errors for an attribute
+    Given a file named "spec/models/widget_spec.rb" with:
+      """
+      require "spec_helper"
+
+      class ValidatingWidget < ActiveRecord::Base
+        set_table_name :widgets
+        validates_presence_of :name
+      end
+
+      describe ValidatingWidget do
+        it "has no validation error message (using error_message_on)" do
+					ValidatingWidget.new(:name => 'Yo').error_message_on(:name).should be_blank
+					ValidatingWidget.new(:name => 'Yo').error_message_on(:name).should be_nil
+        end
+
+        it "has no validation error message (using error_messages_on)" do
+					ValidatingWidget.new(:name => 'Yo').error_messages_on(:name).should be_blank
+					ValidatingWidget.new(:name => 'Yo').error_messages_on(:name).should be_nil
+        end
+	    end
+      """
+    When I run "rspec spec/models/widget_spec.rb"
+    Then the examples should all pass
+
+  Scenario: with no validation errors for an attribute but other attributes fail validation
+    Given a file named "spec/models/widget_spec.rb" with:
+      """
+      require "spec_helper"
+
+      class ValidatingWidget < ActiveRecord::Base
+        set_table_name :widgets
+        validates_presence_of :name
+      end
+
+      describe ValidatingWidget do
+        it "has no validation error message (using error_message_on)" do
+					ValidatingWidget.new.error_message_on(:foo).should be_blank
+					ValidatingWidget.new.error_message_on(:foo).should be_nil
+        end
+
+        it "has no validation error message (using error_messages_on)" do
+					ValidatingWidget.new.error_messages_on(:foo).should be_blank
+					ValidatingWidget.new.error_messages_on(:foo).should be_nil
+        end
+	    end
+      """
+    When I run "rspec spec/models/widget_spec.rb"
+    Then the examples should all pass
+
+  Scenario: with one validation error for an attribute
+    Given a file named "spec/models/widget_spec.rb" with:
+      """
+      require "spec_helper"
+
+      class ValidatingWidget < ActiveRecord::Base
+        set_table_name :widgets
+        validates_presence_of :name, :message => 'our error'
+      end
+
+      describe ValidatingWidget do
+        it "has validation error message (using error_message_on)" do
+          ValidatingWidget.new.error_message_on(:name).should == 'our error'	
+        end
+
+        it "has validation error message (using error_messages_on)" do
+          ValidatingWidget.new.error_messages_on(:name).should == 'our error'	
+        end
+      end
+      """
+    When I run "rspec spec/models/widget_spec.rb"
+    Then the examples should all pass
+
+  Scenario: with two validation errors for an attribute
+    Given a file named "spec/models/widget_spec.rb" with:
+      """
+      require "spec_helper"
+
+      class ValidatingWidget < ActiveRecord::Base
+        set_table_name :widgets
+			  validates_length_of :name, :within => 10..20, :too_long => "pick a shorter name", :too_short => "pick a longer name"
+				validates_format_of :name, :with => /^[a-zA-Z]*$/, :message => "can only contain letters"
+      end
+
+      describe ValidatingWidget do
+        it "has validation error message array (using error_message_on)" do
+          ValidatingWidget.new(:name => '1').error_message_on(:name).should eq([ 'pick a longer name','can only contain letters'])
+        end
+
+        it "has validation error message array (using error_messages_on)" do
+          ValidatingWidget.new(:name => '1').error_messages_on(:name).should eq([ 'pick a longer name','can only contain letters']) 
+        end
+      end
+      """
+    When I run "rspec spec/models/widget_spec.rb"
+    Then the examples should all pass

--- a/spec/rspec/rails/extensions/active_model/error_messages_on_spec.rb
+++ b/spec/rspec/rails/extensions/active_model/error_messages_on_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe "error_messages_on" do
+  let(:klass) do
+    Class.new do
+      include ActiveModel::Validations
+    end
+  end
+
+  it "calls valid?" do
+    model = klass.new
+    model.should_receive(:valid?)
+    model.errors_on(:foo)
+  end
+
+  it "returns nil on attribute when the entire model is valid" do
+    model = klass.new
+    model.error_message_on(:bar).should be_nil
+    model.error_message_on(:bar).should be_blank
+  end
+
+  it "returns nil on attribute when model is invalid but this attribute is valid" do
+    model = klass.new
+    model.stub(:errors) do
+      { :foo => ['a'], :bar => [] }
+    end
+    model.error_message_on(:bar).should be_nil
+    model.error_message_on(:bar).should be_blank
+  end
+
+  it "returns error message on attribute when there is one error message for it" do
+    model = klass.new
+    model.stub(:errors) do
+      { :foo => ['a'] }
+    end
+    model.error_message_on(:foo).should == 'a'
+  end
+
+  it "returns error message array on attribute when there are two error messages for it" do
+    model = klass.new
+    model.stub(:errors) do
+      { :foo => ['a', 'b'] }
+    end
+    model.error_messages_on(:foo).should eq(['a','b'])
+  end
+
+  it "returns error message array on attribute when there are more than two error messages for it" do
+    model = klass.new
+    model.stub(:errors) do
+      { :foo => ['a', 'b', 'c'] }
+    end
+    model.error_messages_on(:foo).should eq(['a','b','c'])
+  end
+
+end


### PR DESCRIPTION
Extension to enhance AR Model instances allowing attribute validation by checking the validation message itself, instead of the attribute's error count.

```
model.error_message_on(:attribute).should == 'msg'
```

Is equivalent to, yet more natural sounding, than what you can do today:

```
model.errors[:attribute].should include('msg') 
```

Reasoning: If there are two or more validations for :attribute, each should be tested.  Simply calling model.should have(1).error_on(:attribute) could yield false positives if the wrong validation fires.  It's better to check that the proper validation was triggered via the validation message 

For zero errors, nil is returned (allowing a be_blank check).  For one error message, the AR infused array is dropped, returning just a string, making the test should more natural (e.g. == 'msg' instead of eq(['msg']).  For two or more errors, the standard string array is returned.

One could argue that this is not an rspec-rails method, and belongs instead in a active record extension library.  Therefore, I'll not be offended it the pull request is denied for that (or any other reason)

Thanks
Brian
