### PR TITLE
Scaffold namespaced resource support

### DIFF
--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -65,6 +65,24 @@ module Rspec
           "{'these' => 'params'}"
         end
 
+        # support for namespaced-resources
+        def ns_file_name
+          if $ARGV[0].match(/(\w+)\/(\w+)/)
+            "#{$1.underscore}_#{$2.singularize.underscore}"
+          else
+            file_name
+          end
+        end
+
+        # support for namespaced-resources
+        def ns_table_name
+          if $ARGV[0].match(/(\w+)\/(\w+)/)
+            "#{$1.underscore}/#{$2.tableize}"
+          else
+            table_name
+          end
+        end
+
         # Returns the name of the mock. For example, if the file name is user,
         # it returns mock_user.
         #
@@ -81,9 +99,9 @@ module Rspec
           if hash
             method, and_return = hash.to_a.first
             method = orm_instance.send(method).split('.').last.gsub(/\(.*?\)/, '')
-            "mock_#{file_name}(:#{method} => #{and_return})"
+            "mock_#{ns_file_name}(:#{method} => #{and_return})"
           else
-            "mock_#{file_name}"
+            "mock_#{ns_file_name}"
           end
         end
 

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -21,54 +21,54 @@ describe <%= controller_class_name %>Controller do
 
 <% end -%>
   describe "GET show" do
-    it "assigns the requested <%= file_name %> as @<%= file_name %>" do
+    it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
       <%= stub orm_class.find(class_name, "37".inspect) %> { <%= mock_file_name %> }
       get :show, :id => "37"
-      assigns(:<%= file_name %>).should be(<%= mock_file_name %>)
+      assigns(:<%= ns_file_name %>).should be(<%= mock_file_name %>)
     end
   end
 
   describe "GET new" do
-    it "assigns a new <%= file_name %> as @<%= file_name %>" do
+    it "assigns a new <%= ns_file_name %> as @<%= ns_file_name %>" do
       <%= stub orm_class.build(class_name) %> { <%= mock_file_name %> }
       get :new
-      assigns(:<%= file_name %>).should be(<%= mock_file_name %>)
+      assigns(:<%= ns_file_name %>).should be(<%= mock_file_name %>)
     end
   end
 
   describe "GET edit" do
-    it "assigns the requested <%= file_name %> as @<%= file_name %>" do
+    it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
       <%= stub orm_class.find(class_name, "37".inspect) %> { <%= mock_file_name %> }
       get :edit, :id => "37"
-      assigns(:<%= file_name %>).should be(<%= mock_file_name %>)
+      assigns(:<%= ns_file_name %>).should be(<%= mock_file_name %>)
     end
   end
 
   describe "POST create" do
     describe "with valid params" do
-      it "assigns a newly created <%= file_name %> as @<%= file_name %>" do
+      it "assigns a newly created <%= ns_file_name %> as @<%= ns_file_name %>" do
         <%= stub orm_class.build(class_name, params) %> { <%= mock_file_name(:save => true) %> }
-        post :create, :<%= file_name %> => <%= params %>
-        assigns(:<%= file_name %>).should be(<%= mock_file_name %>)
+        post :create, :<%= ns_file_name %> => <%= params %>
+        assigns(:<%= ns_file_name %>).should be(<%= mock_file_name %>)
       end
 
-      it "redirects to the created <%= file_name %>" do
+      it "redirects to the created <%= ns_file_name %>" do
         <%= stub orm_class.build(class_name) %> { <%= mock_file_name(:save => true) %> }
-        post :create, :<%= file_name %> => {}
+        post :create, :<%= ns_file_name %> => {}
         response.should redirect_to(<%= table_name.singularize %>_url(<%= mock_file_name %>))
       end
     end
 
     describe "with invalid params" do
-      it "assigns a newly created but unsaved <%= file_name %> as @<%= file_name %>" do
+      it "assigns a newly created but unsaved <%= ns_file_name %> as @<%= ns_file_name %>" do
         <%= stub orm_class.build(class_name, params) %> { <%= mock_file_name(:save => false) %> }
-        post :create, :<%= file_name %> => <%= params %>
-        assigns(:<%= file_name %>).should be(<%= mock_file_name %>)
+        post :create, :<%= ns_file_name %> => <%= params %>
+        assigns(:<%= ns_file_name %>).should be(<%= mock_file_name %>)
       end
 
       it "re-renders the 'new' template" do
         <%= stub orm_class.build(class_name) %> { <%= mock_file_name(:save => false) %> }
-        post :create, :<%= file_name %> => {}
+        post :create, :<%= ns_file_name %> => {}
         response.should render_template("new")
       end
     end
@@ -76,19 +76,19 @@ describe <%= controller_class_name %>Controller do
 
   describe "PUT update" do
     describe "with valid params" do
-      it "updates the requested <%= file_name %>" do
+      it "updates the requested <%= ns_file_name %>" do
         <%= stub orm_class.find(class_name, "37".inspect) %> { <%= mock_file_name %> }
         mock_<%= should_receive orm_instance.update_attributes(params) %>
-        put :update, :id => "37", :<%= file_name %> => <%= params %>
+        put :update, :id => "37", :<%= ns_file_name %> => <%= params %>
       end
 
-      it "assigns the requested <%= file_name %> as @<%= file_name %>" do
+      it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
         <%= stub orm_class.find(class_name) %> { <%= mock_file_name(:update_attributes => true) %> }
         put :update, :id => "1"
-        assigns(:<%= file_name %>).should be(<%= mock_file_name %>)
+        assigns(:<%= ns_file_name %>).should be(<%= mock_file_name %>)
       end
 
-      it "redirects to the <%= file_name %>" do
+      it "redirects to the <%= ns_file_name %>" do
         <%= stub orm_class.find(class_name) %> { <%= mock_file_name(:update_attributes => true) %> }
         put :update, :id => "1"
         response.should redirect_to(<%= table_name.singularize %>_url(<%= mock_file_name %>))
@@ -96,10 +96,10 @@ describe <%= controller_class_name %>Controller do
     end
 
     describe "with invalid params" do
-      it "assigns the <%= file_name %> as @<%= file_name %>" do
+      it "assigns the <%= ns_file_name %> as @<%= ns_file_name %>" do
         <%= stub orm_class.find(class_name) %> { <%= mock_file_name(:update_attributes => false) %> }
         put :update, :id => "1"
-        assigns(:<%= file_name %>).should be(<%= mock_file_name %>)
+        assigns(:<%= ns_file_name %>).should be(<%= mock_file_name %>)
       end
 
       it "re-renders the 'edit' template" do
@@ -111,7 +111,7 @@ describe <%= controller_class_name %>Controller do
   end
 
   describe "DELETE destroy" do
-    it "destroys the requested <%= file_name %>" do
+    it "destroys the requested <%= ns_file_name %>" do
       <%= stub orm_class.find(class_name, "37".inspect) %> { <%= mock_file_name %> }
       mock_<%= should_receive orm_instance.destroy %>
       delete :destroy, :id => "37"

--- a/lib/generators/rspec/scaffold/templates/edit_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/edit_spec.rb
@@ -1,29 +1,29 @@
 require 'spec_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-describe "<%= table_name %>/edit.html.<%= options[:template_engine] %>" do
+describe "<%= ns_table_name %>/edit.html.<%= options[:template_engine] %>" do
   before(:each) do
-    @<%= file_name %> = assign(:<%= file_name %>, stub_model(<%= class_name %><%= output_attributes.empty? ? '))' : ',' %>
+    @<%= ns_file_name %> = assign(:<%= ns_file_name %>, stub_model(<%= class_name %><%= output_attributes.empty? ? '))' : ',' %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>
       :<%= attribute.name %> => <%= attribute.default.inspect %><%= attribute_index == output_attributes.length - 1 ? '' : ','%>
 <% end -%>
 <%= output_attributes.empty? ? "" : "    ))\n" -%>
   end
 
-  it "renders the edit <%= file_name %> form" do
+  it "renders the edit <%= ns_file_name %> form" do
     render
 
 <% if webrat? -%>
-    rendered.should have_selector("form", :action => <%= file_name %>_path(@<%= file_name %>), :method => "post") do |form|
+    rendered.should have_selector("form", :action => <%= ns_file_name %>_path(@<%= ns_file_name %>), :method => "post") do |form|
 <% for attribute in output_attributes -%>
-      form.should have_selector("<%= attribute.input_type -%>#<%= file_name %>_<%= attribute.name %>", :name => "<%= file_name %>[<%= attribute.name %>]")
+      form.should have_selector("<%= attribute.input_type -%>#<%= ns_file_name %>_<%= attribute.name %>", :name => "<%= ns_file_name %>[<%= attribute.name %>]")
 <% end -%>
     end
 <% else -%>
     # Run the generator again with the --webrat flag if you want to use webrat matchers
-    assert_select "form", :action => <%= index_helper %>_path(@<%= file_name %>), :method => "post" do
+    assert_select "form", :action => <%= index_helper %>_path(@<%= ns_file_name %>), :method => "post" do
 <% for attribute in output_attributes -%>
-      assert_select "<%= attribute.input_type -%>#<%= file_name %>_<%= attribute.name %>", :name => "<%= file_name %>[<%= attribute.name %>]"
+      assert_select "<%= attribute.input_type -%>#<%= ns_file_name %>_<%= attribute.name %>", :name => "<%= ns_file_name %>[<%= attribute.name %>]"
 <% end -%>
     end
 <% end -%>

--- a/lib/generators/rspec/scaffold/templates/index_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/index_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-describe "<%= table_name %>/index.html.<%= options[:template_engine] %>" do
+describe "<%= ns_table_name %>/index.html.<%= options[:template_engine] %>" do
   before(:each) do
     assign(:<%= table_name %>, [
 <% [1,2].each_with_index do |id, model_index| -%>
@@ -16,7 +16,7 @@ describe "<%= table_name %>/index.html.<%= options[:template_engine] %>" do
     ])
   end
 
-  it "renders a list of <%= table_name %>" do
+  it "renders a list of <%= ns_table_name %>" do
     render
 <% for attribute in output_attributes -%>
 <% if webrat? -%>

--- a/lib/generators/rspec/scaffold/templates/new_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/new_spec.rb
@@ -1,28 +1,28 @@
 require 'spec_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-describe "<%= table_name %>/new.html.<%= options[:template_engine] %>" do
+describe "<%= ns_table_name %>/new.html.<%= options[:template_engine] %>" do
   before(:each) do
-    assign(:<%= file_name %>, stub_model(<%= class_name %><%= output_attributes.empty? ? ').as_new_record)' : ',' %>
+    assign(:<%= ns_file_name %>, stub_model(<%= class_name %><%= output_attributes.empty? ? ').as_new_record)' : ',' %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>
       :<%= attribute.name %> => <%= attribute.default.inspect %><%= attribute_index == output_attributes.length - 1 ? '' : ','%>
 <% end -%>
 <%= !output_attributes.empty? ? "    ).as_new_record)\n  end" : "  end" %>
 
-  it "renders new <%= file_name %> form" do
+  it "renders new <%= ns_file_name %> form" do
     render
 
 <% if webrat? -%>
     rendered.should have_selector("form", :action => <%= table_name %>_path, :method => "post") do |form|
 <% for attribute in output_attributes -%>
-      form.should have_selector("<%= attribute.input_type -%>#<%= file_name %>_<%= attribute.name %>", :name => "<%= file_name %>[<%= attribute.name %>]")
+      form.should have_selector("<%= attribute.input_type -%>#<%= ns_file_name %>_<%= attribute.name %>", :name => "<%= ns_file_name %>[<%= attribute.name %>]")
 <% end -%>
     end
 <% else -%>
     # Run the generator again with the --webrat flag if you want to use webrat matchers
     assert_select "form", :action => <%= index_helper %>_path, :method => "post" do
 <% for attribute in output_attributes -%>
-      assert_select "<%= attribute.input_type -%>#<%= file_name %>_<%= attribute.name %>", :name => "<%= file_name %>[<%= attribute.name %>]"
+      assert_select "<%= attribute.input_type -%>#<%= ns_file_name %>_<%= attribute.name %>", :name => "<%= ns_file_name %>[<%= attribute.name %>]"
 <% end -%>
     end
 <% end -%>

--- a/lib/generators/rspec/scaffold/templates/routing_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/routing_spec.rb
@@ -5,32 +5,32 @@ describe <%= controller_class_name %>Controller do
 
 <% unless options[:singleton] -%>
     it "recognizes and generates #index" do
-      { :get => "/<%= table_name %>" }.should route_to(:controller => "<%= table_name %>", :action => "index")
+      { :get => "/<%= ns_table_name %>" }.should route_to(:controller => "<%= ns_table_name %>", :action => "index")
     end
 
 <% end -%>
     it "recognizes and generates #new" do
-      { :get => "/<%= table_name %>/new" }.should route_to(:controller => "<%= table_name %>", :action => "new")
+      { :get => "/<%= ns_table_name %>/new" }.should route_to(:controller => "<%= ns_table_name %>", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "/<%= table_name %>/1" }.should route_to(:controller => "<%= table_name %>", :action => "show", :id => "1")
+      { :get => "/<%= ns_table_name %>/1" }.should route_to(:controller => "<%= ns_table_name %>", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "/<%= table_name %>/1/edit" }.should route_to(:controller => "<%= table_name %>", :action => "edit", :id => "1")
+      { :get => "/<%= ns_table_name %>/1/edit" }.should route_to(:controller => "<%= ns_table_name %>", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "/<%= table_name %>" }.should route_to(:controller => "<%= table_name %>", :action => "create")
+      { :post => "/<%= ns_table_name %>" }.should route_to(:controller => "<%= ns_table_name %>", :action => "create")
     end
 
     it "recognizes and generates #update" do
-      { :put => "/<%= table_name %>/1" }.should route_to(:controller => "<%= table_name %>", :action => "update", :id => "1")
+      { :put => "/<%= ns_table_name %>/1" }.should route_to(:controller => "<%= ns_table_name %>", :action => "update", :id => "1")
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "/<%= table_name %>/1" }.should route_to(:controller => "<%= table_name %>", :action => "destroy", :id => "1")
+      { :delete => "/<%= ns_table_name %>/1" }.should route_to(:controller => "<%= ns_table_name %>", :action => "destroy", :id => "1")
     end
 
   end

--- a/lib/generators/rspec/scaffold/templates/show_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/show_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-describe "<%= table_name %>/show.html.<%= options[:template_engine] %>" do
+describe "<%= ns_table_name %>/show.html.<%= options[:template_engine] %>" do
   before(:each) do
-    @<%= file_name %> = assign(:<%= file_name %>, stub_model(<%= class_name %><%= output_attributes.empty? ? '))' : ',' %>
+    @<%= ns_file_name %> = assign(:<%= ns_file_name %>, stub_model(<%= class_name %><%= output_attributes.empty? ? '))' : ',' %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>
       :<%= attribute.name %> => <%= value_for(attribute) %><%= attribute_index == output_attributes.length - 1 ? '' : ','%>
 <% end -%>


### PR DESCRIPTION
I've added support for generating specs that pass out of the box when generating a scaffold for a namespaced resource.

See https://github.com/rspec/rspec-rails/issues/#issue/281 for more info.  Sorry I took so long.

Cheers,
Tim
