### PR TITLE
Hi - I found a typo.

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -41,7 +41,7 @@ namespace :spec do
     ::CodeStatistics::TEST_TYPES << "Controller specs" if File.exist?('spec/controllers')
     ::CodeStatistics::TEST_TYPES << "Helper specs" if File.exist?('spec/helpers')
     ::CodeStatistics::TEST_TYPES << "Library specs" if File.exist?('spec/lib')
-    ::CodeStatistics::TEST_TYPES << "Mailer specs" if File.exist?('spec/mailer')
+    ::CodeStatistics::TEST_TYPES << "Mailer specs" if File.exist?('spec/mailers')
     ::CodeStatistics::TEST_TYPES << "Routing specs" if File.exist?('spec/routing')
     ::CodeStatistics::TEST_TYPES << "Request specs" if File.exist?('spec/requests')
   end


### PR DESCRIPTION
spec/mailer I expect needs to be spec/mailers

Not sure if this code is dead or not - but for the sake of keeping the details real - here is a baby patch.
