### PR TITLE
adding tags to cucumber features, a rake task to create tags automatically, and a rake task to cucumber run guided by tag

### DIFF
--- a/features/controller_specs/anonymous_controller.feature
+++ b/features/controller_specs/anonymous_controller.feature
@@ -1,3 +1,5 @@
+@controller_specs
+@anonymous_controller
 Feature: anonymous controller
 
   Use the `controller` method to define an anonymous controller derived from

--- a/features/controller_specs/controller_spec.feature
+++ b/features/controller_specs/controller_spec.feature
@@ -1,3 +1,5 @@
+@controller_specs
+@controller_spec
 Feature: controller spec
 
 

--- a/features/controller_specs/isolation_from_views.feature
+++ b/features/controller_specs/isolation_from_views.feature
@@ -1,3 +1,5 @@
+@controller_specs
+@isolation_from_views
 Feature: views are stubbed by default
 
   By default, controller specs stub views with a template that renders an empty

--- a/features/controller_specs/render_views.feature
+++ b/features/controller_specs/render_views.feature
@@ -1,3 +1,5 @@
+@controller_specs
+@render_views
 Feature: render_views
 
   You can tell a controller example group to render views with the

--- a/features/helper_specs/helper_spec.feature
+++ b/features/helper_specs/helper_spec.feature
@@ -1,3 +1,5 @@
+@helper_specs
+@helper_spec
 Feature: helper spec
   
   Helper specs live in `spec/helpers`, or any example group with `:type =>

--- a/features/mailer_specs/url_helpers.feature
+++ b/features/mailer_specs/url_helpers.feature
@@ -1,3 +1,5 @@
+@mailer_specs
+@url_helpers
 Feature: URL helpers in mailer examples
 
   Scenario: using URL helpers with default options

--- a/features/matchers/new_record_matcher.feature
+++ b/features/matchers/new_record_matcher.feature
@@ -1,3 +1,5 @@
+@matchers
+@new_record_matcher
 Feature: be_a_new matcher
 
   The `be_a_new` matcher accepts a class and passes if the subject is an

--- a/features/matchers/redirect_to_matcher.feature
+++ b/features/matchers/redirect_to_matcher.feature
@@ -1,3 +1,5 @@
+@matchers
+@redirect_to_matcher
 Feature: redirect_to matcher
 
   The `redirect_to` matcher is used to specify that the redirect called in the

--- a/features/matchers/render_template_matcher.feature
+++ b/features/matchers/render_template_matcher.feature
@@ -1,3 +1,5 @@
+@matchers
+@render_template_matcher
 Feature: render_template matcher
 
   This matcher just delegates to the Rails assertion method

--- a/features/mocks/mock_model.feature
+++ b/features/mocks/mock_model.feature
@@ -1,3 +1,5 @@
+@mocks
+@mock_model
 Feature: mock_model
 
   The mock_model method generates a test double that acts like an Active Model

--- a/features/mocks/stub_model.feature
+++ b/features/mocks/stub_model.feature
@@ -1,3 +1,5 @@
+@mocks
+@stub_model
 Feature: stub_model
   
   The stub_model method generates an instance of a Active Model model.

--- a/features/model_specs/errors_on.feature
+++ b/features/model_specs/errors_on.feature
@@ -1,3 +1,5 @@
+@model_specs
+@errors_on
 Feature: errors_on
 
   Scenario: with one validation error

--- a/features/model_specs/transactional_examples.feature
+++ b/features/model_specs/transactional_examples.feature
@@ -1,3 +1,5 @@
+@model_specs
+@transactional_examples
 Feature: transactional examples
 
   Scenario: run in transactions (default)

--- a/features/routing_specs/be_routable_matcher.feature
+++ b/features/routing_specs/be_routable_matcher.feature
@@ -1,3 +1,5 @@
+@routing_specs
+@be_routable_matcher
 Feature: be_routable matcher
 
   The `be_routable` matcher is best used with `should_not` to specify that a

--- a/features/routing_specs/named_routes.feature
+++ b/features/routing_specs/named_routes.feature
@@ -1,3 +1,5 @@
+@routing_specs
+@named_routes
 Feature: named routes
 
   Routing specs have access to named routes.

--- a/features/routing_specs/route_to_matcher.feature
+++ b/features/routing_specs/route_to_matcher.feature
@@ -1,3 +1,5 @@
+@routing_specs
+@route_to_matcher
 Feature: route_to matcher
 
   The `route_to` matcher specifies that a request (verb + path) is routable.

--- a/features/view_specs/inferred_controller_path.feature
+++ b/features/view_specs/inferred_controller_path.feature
@@ -1,3 +1,5 @@
+@view_specs
+@inferred_controller_path
 Feature: view spec infers controller path and action
 
   Scenario: infer controller path

--- a/features/view_specs/stub_template.feature
+++ b/features/view_specs/stub_template.feature
@@ -1,3 +1,5 @@
+@view_specs
+@stub_template
 Feature: stub template
 
   In order to isolate view specs from the partials rendered by the primary

--- a/features/view_specs/view_spec.feature
+++ b/features/view_specs/view_spec.feature
@@ -1,3 +1,5 @@
+@view_specs
+@view_spec
 Feature: view spec
 
   View specs live in spec/views and render view templates in isolation.

--- a/lib/task_helpers/create_tags_helper.rb
+++ b/lib/task_helpers/create_tags_helper.rb
@@ -1,0 +1,2 @@
+require "task_helpers/create_tags_helper/feature_archive"
+require "task_helpers/create_tags_helper/tags_extractor_method"

--- a/lib/task_helpers/create_tags_helper/feature_archive.rb
+++ b/lib/task_helpers/create_tags_helper/feature_archive.rb
@@ -1,0 +1,50 @@
+module CreateTagsHelper
+  class FeatureArchive
+    attr_reader :content
+
+    def self.build_from(path)
+      path_origin = path
+      content = File.readlines path
+      new(content,path_origin)
+    end
+    
+    def initialize(content,path)
+      @content = content
+      @path_origin = path
+    end
+
+    def add_tag!(tagname)
+      @content.insert(0,"@#{tagname}\n")
+    end
+
+    def have_tag?(tagname)
+      @content.each do |line|
+        return false if line.include?("Feature:")
+        return true if line.include?("@#{tagname}")
+      end
+    end
+
+    def try_add_tag!(tagname)
+      if self.have_tag?(tagname)
+        puts "@#{tagname} already exists in #{@path_origin}"
+      else
+        self.add_tag! tagname
+      end
+    end
+
+    def try_add_all_tags!(tags)
+      tags.each do |tagname|
+        self.try_add_tag!(tagname)
+      end
+    end
+
+    def save!
+      begin
+        file = File.open(@path_origin,"w")
+        file << @content.join
+      ensure
+        file.close
+      end
+    end
+  end
+end

--- a/lib/task_helpers/create_tags_helper/tags_extractor_method.rb
+++ b/lib/task_helpers/create_tags_helper/tags_extractor_method.rb
@@ -1,0 +1,12 @@
+module CreateTagsHelper
+  module TagsExtractorMethod
+    def extract_tags_from(path)
+      tags = []
+      tags << File.basename(path,".feature")
+      directories_chain = File.dirname(path).split("/")
+      directories_chain.delete "features"
+      directories_chain.each{|directory| tags << directory}
+      tags
+    end
+  end
+end


### PR DESCRIPTION
Hello,
Developing in rspec-rails I note that doesn't exist tags to features in cucumber, making hard to test just the feature that being implemented.
Thinking about this, I create a rake task:

```
rake cucumber:create_tags
```

This task add tags in feature files based in directory hierarchy, by example:

```
- features/
  - routing_spec/
    - route_to_matcher.rb
    - be_routable_matcher.rb
```

after run the task, route_to_matcher.rb and be_routable_matcher.rb will appear with something like this:

```
# route_to_matcher.rb
@routing_spec
@route_to_matcher
Feature: ...

# be_routable_matcher.rb
@routing_spec
@be_routable_matcher
Feature: ...
```

but even with tags, when I run by example:

```
cucumber --tags @routing_spec
```

all tests fails, I don't know why. =/
so I catch one task from another project to do this:

```
cucumber:tag routing_spec
```

Its important to tell that the task to create_tags detects when the tags exist avoiding repetition of tags when the task is runned more then one time. ;)

Thank you for attention, I hope this help and sorry about my bad english. :)
