### PR TITLE
Fix error in constant name

### DIFF
--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -67,7 +67,7 @@ module Rspec
 
         # support for namespaced-resources
         def ns_file_name
-          if $ARGV[0].match(/(\w+)\/(\w+)/)
+          if ARGV[0].match(/(\w+)\/(\w+)/)
             "#{$1.underscore}_#{$2.singularize.underscore}"
           else
             file_name
@@ -76,7 +76,7 @@ module Rspec
 
         # support for namespaced-resources
         def ns_table_name
-          if $ARGV[0].match(/(\w+)\/(\w+)/)
+          if ARGV[0].match(/(\w+)\/(\w+)/)
             "#{$1.underscore}/#{$2.tableize}"
           else
             table_name


### PR DESCRIPTION
Not sure if `$ARGV` is supposed to work, but it was just raising an error for me on MRI 1.9.2-p180.  Seems like `ARGV` was intended.
