### PR TITLE
Replaced tilde's with >= to work with Rails 3.1

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.require_path     = "lib"
 
-  s.add_runtime_dependency(%q<activesupport>, ["~> 3.0"])
-  s.add_runtime_dependency(%q<actionpack>, ["~> 3.0"])
-  s.add_runtime_dependency(%q<railties>, ["~> 3.0"])
+  s.add_runtime_dependency(%q<activesupport>, [">= 3.0"])
+  s.add_runtime_dependency(%q<actionpack>, [">= 3.0"])
+  s.add_runtime_dependency(%q<railties>, [">= 3.0"])
   if RSpec::Rails::Version::STRING =~ /[a-zA-Z]+/
     s.add_runtime_dependency "rspec", "= #{RSpec::Rails::Version::STRING}"
   else


### PR DESCRIPTION
Replaced tilde's with >= to work with Rails 3.1 gems. thx
