### PR TITLE
Excluding spec folder from rcov metrics

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -23,7 +23,7 @@ namespace :spec do
   RSpec::Core::RakeTask.new(:rcov => spec_prereq) do |t|
     t.rcov = true
     t.pattern = "./spec/**/*_spec.rb"
-    t.rcov_opts = '--exclude /gems/,/Library/,/usr/,lib/tasks,.bundle,config,/lib/rspec/,/lib/rspec-'
+    t.rcov_opts = '--exclude /gems/,/Library/,/usr/,lib/tasks,.bundle,config,/lib/rspec/,/lib/rspec-,spec'
   end
 
   task :statsetup do


### PR DESCRIPTION
I don't know if there is a purpose on not excluding the spec folder from the rcov metrics, as it doesn't make sense to me.
