### PR TITLE
guard against calling prerequisites on nil

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -1,6 +1,8 @@
 require 'rspec/core'
 require 'rspec/core/rake_task'
-Rake.application.instance_variable_get('@tasks')['default'].prerequisites.delete('test')
+if default = Rake.application.instance_variable_get('@tasks')['default']
+  default.prerequisites.delete('test')
+end
 
 spec_prereq = Rails.configuration.generators.options[:rails][:orm] == :active_record ?  "db:test:prepare" : :noop
 task :noop do; end


### PR DESCRIPTION
Just generated a new test app with rails edge and rspec-rails 2.6 to debug some other stuff, and saw rake blowing up on me. Can't be 100% certain default task is now gone, but this small patch makes sure we don't try to call something on nil and blow everything up. 

Tried to run rake to make sure all tests still pass, and ran into some issues:

git/rspec-rails handle_nil_default_task > thor gemfile:use 3.0.7
Using gemfiles/rails-3.0.7
bundle install --binstubs
Fetching source index for http://rubygems.org/
Could not find gem 'rspec-expectations (~> 2.4.0)', required by 'rspec', in any of the sources

so just sending over anyway given the tiny change. 
