### PR TITLE
[Fixes #380] Fix #mock_model to enable stubbing of to_s

### DIFF
--- a/lib/rspec/rails/mocks.rb
+++ b/lib/rspec/rails/mocks.rb
@@ -114,10 +114,14 @@ EOM
             def @object.class
               #{model_class}
             end
-            def @object.to_s
-              "#{model_class.name}_#{to_param}"
-            end
           CODE
+          unless stubs.has_key? :to_s
+            m.__send__(:__mock_proxy).instance_eval(<<-CODE, __FILE__, __LINE__)
+              def @object.to_s
+                "#{model_class.name}_#{to_param}"
+              end
+            CODE
+          end
           yield m if block_given?
         end
       end

--- a/spec/rspec/rails/mocks/mock_model_spec.rb
+++ b/spec/rspec/rails/mocks/mock_model_spec.rb
@@ -189,6 +189,21 @@ describe "mock_model(RealModel)" do
     end
   end
 
+  describe "#to_s" do
+    before(:each) do
+      @param = to_param
+      @model = mock_model(MockableModel)
+    end
+    it "returns class name underscore rspec context id" do
+      @model.to_s.should == "MockableModel_#{@param}"
+    end
+    context "stubbed to return 'foobar'" do
+      it "returns 'foobar'" do
+        mock_model(MockableModel, :to_s => 'foobar').to_s.should == 'foobar'
+      end
+    end
+  end
+
   describe "#destroyed?" do
     context "default" do
       it "returns false" do


### PR DESCRIPTION
Fix #mock_model to enable stubbing of to_s
