### PR TITLE
added generator specs for model_generator using the ammeter gem

### DIFF
--- a/gemfiles/base.rb
+++ b/gemfiles/base.rb
@@ -21,6 +21,7 @@ module GemfileBase
       gem "aruba", "~> 0.3.6"
       gem "growl", "1.0.3"
       gem "ZenTest", "~> 4.4.2"
+      gem 'ammeter', '~> 0'
 
       # gem "webrat", "0.7.3"
       # gem "capybara", "~> 0.4"

--- a/spec/generators/model_generator_spec.rb
+++ b/spec/generators/model_generator_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+# Generators are not automatically loaded by Rails
+require 'generators/rspec/model/model_generator'
+
+describe Rspec::Generators::ModelGenerator do
+  # Tell the generator where to put its output (what it thinks of as Rails.root)
+  destination File.expand_path("../../../tmp", __FILE__)
+  before do
+    prepare_destination
+  end
+
+  # using mocks to ensure proper methods are called
+  it 'should run both the model and fixture tasks' do
+    gen = generator %w(posts)
+    gen.should_receive :create_model_spec
+    gen.should_receive :create_fixture_file
+    capture(:stdout) { gen.invoke_all }
+  end
+
+  describe 'the generated files' do
+    describe 'with fixtures' do
+      before do
+        run_generator %w(posts --fixture)
+      end
+      describe 'the spec' do
+        subject { file('spec/models/posts_spec.rb') }
+        it { should exist }
+        it { should contain /require 'spec_helper'/ }
+        it { should contain /describe Posts/ }
+      end
+      describe 'the fixtures' do
+        subject { file('spec/fixtures/posts.yml') }
+        it { should contain Regexp.new '# Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html' }
+      end
+    end
+    describe 'without fixtures' do
+      before do
+        run_generator %w(posts)
+      end
+      describe 'the fixtures' do
+        subject { file('spec/fixtures/posts.yml') }
+        it { should_not exist } 
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ module RSpecRails
 end
 
 require 'rspec/rails'
+require 'ammeter'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 


### PR DESCRIPTION
Following on to pull #350 and the suggestion by @justinko I extracted the ability to write specs for a rails generator into a gem https://rubygems.org/gems/ammeter.

This pull adds as a development dependency on that gem and includes some specs for the model_generator in rspec-rails.  If you guys accept this I'm happy to write some more specs for the other generators.
