### PR TITLE
Allow custom capybara initialization

### DIFF
--- a/lib/rspec/rails/vendor/capybara.rb
+++ b/lib/rspec/rails/vendor/capybara.rb
@@ -1,11 +1,13 @@
-begin
-  require 'capybara/rspec'
-rescue LoadError
-end
-
-begin
-  require 'capybara/rails'
-rescue LoadError
+[
+  'capybara/dsl',
+  'capybara/rspec/matchers',
+  'capybara/rspec/features',
+  'capybara/rails'
+].each do |dependency|
+  begin
+    require dependency
+  rescue LoadError
+  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
Problem: I need make custom capybara rspec hooks initialization. Now if capybara gem is installed with rspec it got initialized automatically. This patch prevent such behavior
Drawback: People who uses rspec with captbara and does not explicitly require capybara
```require 'capybara/rspec'

```
in spec_helper.rb or elsewhere wont get capybara properly loaded

I'm not sure is this the proper change from compatibility perspective, but current solution lack flexibility I desire.
If there are another ways to solve problem please advise

```
