### PR TITLE
Fix mistake in check to see if ActiveRecord is defined

### DIFF
--- a/lib/rspec/rails/matchers/relation_match_array.rb
+++ b/lib/rspec/rails/matchers/relation_match_array.rb
@@ -1,3 +1,3 @@
-if defined?(:ActiveRecord)
+if defined?(ActiveRecord)
   RSpec::Matchers::OperatorMatcher.register(ActiveRecord::Relation, '=~', RSpec::Matchers::MatchArray)
 end


### PR DESCRIPTION
My bad here .. I just learned that `defined?` is an operator and not a method, so the correct way to check if a constant exists is `defined?(Constant)`, not `defined?(:Constant)`

In fact, `defined?(:ActiveRecord)` is a truism.
