### PR TITLE
Use the correct Travis CI status image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 rspec-2 for rails-3 with lightweight extensions to each
 
-[![build status](https://travis-ci.org/rspec/rspec-rails.png)](http://travis-ci.org/rspec/rspec-rails)
+[![build status](https://secure.travis-ci.org/rspec/rspec-rails.png)](http://travis-ci.org/rspec/rspec-rails)
 
 NOTE: rspec-2 does _not_ support rails-2. Use rspec-rails-1.3.x for rails-2.
 


### PR DESCRIPTION
The SSL certificate for travis-ci.org is actually issued for heroku.com so most browsers will silently fail to load that image. On the other hand, secure.travis-ci.org has a proper SSL certificate and the image loads just fine (and travis-ci.org recommends using that subdomain anyway).
