### PR TITLE
#should method on CollectionProxy

### DIFF
--- a/lib/rspec/rails/extensions/active_record/base.rb
+++ b/lib/rspec/rails/extensions/active_record/base.rb
@@ -38,3 +38,16 @@ module ::ActiveModel::Validations
   end
   alias :error_on :errors_on
 end
+
+class ::ActiveRecord::Associations::CollectionProxy
+  # Since CollectionProxy is blank slate and it removes almost all methods we
+  # need to force it to have #should and #should_not methods. Otherwise it will
+  # delegate to its target object.
+  def should(matcher=nil, message=nil, &block)
+    RSpec::Expectations::PositiveExpectationHandler.handle_matcher(self, matcher, message, &block)
+  end
+
+  def should_not(matcher=nil, message=nil, &block)
+    RSpec::Expectations::NegativeExpectationHandler.handle_matcher(self, matcher, message, &block)
+  end
+end


### PR DESCRIPTION
It's a patch for issue #443, but I didn't create tests.
Also since this code duplicates extensions of Kernel module in rspec-core it would be good move methods `#should` and `#should_not` to some other module and just include it into Kernel and CollectionProxy.

Something like this:

``` ruby

module RSpec::ShouldMethods
  def should ...
  def should_not ...
end

module Kernel
  include  RSpec::ShouldMethods
end

class ::ActiveRecord::Associations::CollectionProxy
  include  RSpec::ShouldMethods
end

```
