### PR TITLE
Remove config.mock_with :rspec, avoid config-after-examples error.

### DIFF
--- a/lib/generators/rspec/install/templates/spec/spec_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/spec_helper.rb
@@ -16,7 +16,6 @@ RSpec.configure do |config|
   # config.mock_with :mocha
   # config.mock_with :flexmock
   # config.mock_with :rr
-  config.mock_with :rspec
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
The `config.mock_with :rspec` statement configures RSpec to do what it would do anyway, and triggers errors regarding RSpec.configure being called after examples have been defined.

See: rspec/rspec-rails#371
See: rspec/rspec-core#455
