### PR TITLE
restored the ability to use method missing matchers like be_blank or be_t

### DIFF
--- a/lib/rspec/rails/example/routing_example_group.rb
+++ b/lib/rspec/rails/example/routing_example_group.rb
@@ -9,7 +9,10 @@ module RSpec::Rails
     include RSpec::Rails::Matchers::RoutingMatchers::RouteHelpers
 
     module InstanceMethods
-      attr_reader :routes
+      
+      def routes
+        @routes ||= ::Rails.application.routes
+      end
 
       private
 
@@ -20,10 +23,6 @@ module RSpec::Rails
 
     included do
       metadata[:type] = :routing
-
-      before do
-        @routes = ::Rails.application.routes
-      end
     end
   end
 end


### PR DESCRIPTION
restored the ability to use method missing matchers like be_blank or be_true in before blocks for routing example groups

be_blank invoked the method missing within lib/rspec/rails/example/routing_example_group.rb which would try and check routes.url_helpers.respond_to? but routes is nil in before blocks that run before the before block in that same file.

NoMethodError: undefined method `url_helpers' for nil:NilClass
