### PR TITLE
Added 'application' configuration setting to set a Rack app to allow changing routes in controller specs

### DIFF
--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -1,5 +1,6 @@
 RSpec.configure do |config|
   config.add_setting :infer_base_class_for_anonymous_controllers, :default => false
+  config.add_setting :application, :default => ::Rails.application
 end
 
 module RSpec::Rails
@@ -122,7 +123,7 @@ module RSpec::Rails
       metadata[:type] = :controller
 
       before do
-        @routes = ::Rails.application.routes
+        @routes = RSpec.configuration.application.routes
         ActionController::Base.allow_forgery_protection = false
       end
     end

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -3,10 +3,12 @@ require "spec_helper"
 describe "configuration" do
   before do
     @orig_render_views = RSpec.configuration.render_views?
+    @orig_application = RSpec.configuration.application
   end
 
   after do
     RSpec.configuration.render_views = @orig_render_views
+    RSpec.configuration.application = @orig_application
   end
 
   describe "#render_views?" do
@@ -21,6 +23,12 @@ describe "configuration" do
       RSpec.configuration.render_views
 
       RSpec.configuration.render_views?.should be_true
+    end
+  end
+
+  describe "#application" do
+    it "is Rails.application by default" do
+      RSpec.configuration.application.should eq(::Rails.application)
     end
   end
 end


### PR DESCRIPTION
Currently RSpec hardcodes `Rails.application.routes` in controller specs (https://github.com/rspec/rspec-rails/blob/master/lib/rspec/rails/example/controller_example_group.rb#L125) This makes it hard to run controller specs for Rails engines that provide their own route set.

Currently I need to set routes manually in before block in every test - I can't do it in RSpec config, because before block of `ControllerExampleGroup` runs after before block in RSpec config and overwrites `@route` variable.

With this new setting one can just do:

``` ruby
RSpec.configure do |config|
  config.application = MyApp::Engine
end
```

in engine's spec_helper.rb and it will properly set routing for controller specs. 

Additionally it would be great if it could also do:

``` ruby
RSpec.configure do |config|
  config.include MyApp::Engine.routes.url_helpers
end
```

but it's not included in this commit. 

If you think that the whole idea makes sense, I can add some more detailed tests, because right now I only added tests for the new `application` setting.
