### PR TITLE
stub "new_record?" method on stub_model

### DIFF
--- a/lib/rspec/rails/mocks.rb
+++ b/lib/rspec/rails/mocks.rb
@@ -150,6 +150,7 @@ EOM
         # Stubs `persisted` to return false and `id` to return nil
         def as_new_record
           self.stub(:persisted?)  { false }
+          self.stub(:new_record?) { true }
           self.stub(:id)          { nil }
           self
         end
@@ -217,6 +218,7 @@ EOM
           else
             stubs = stubs.reverse_merge(:id => next_id)
             stubs = stubs.reverse_merge(:persisted? => !!stubs[:id])
+            stubs = stubs.reverse_merge(:new_record? => !stubs[:persisted?])
           end
           stubs = stubs.reverse_merge(:blank? => false)
           stubs.each do |k,v|

--- a/spec/rspec/rails/mocks/stub_model_spec.rb
+++ b/spec/rspec/rails/mocks/stub_model_spec.rb
@@ -27,6 +27,22 @@ describe "stub_model" do
         end
       end
     end
+    
+    describe "#new_record?" do
+      context "default" do
+        it "returns false" do
+          model = stub_model(model_class)
+          model.should_not be_a_new_record
+        end
+      end
+
+      context "with as_new_record" do
+        it "returns false" do
+          model = stub_model(model_class).as_new_record
+          model.should be_a_new_record
+        end
+      end
+    end
 
     it "increments the value returned by to_param" do
       first = stub_model(model_class)


### PR DESCRIPTION
In **Mongoid 2.4.0** `#to_param` return an error because this version override `#to_key`.

**ActiveModel** `#to_key` call `#persisted?` while **Mongoid 2.4.0** `#to_key` call `#new_record?`.

Issue from mongoid/mongoid#1510.
