### PR TITLE
Readme update for Capybara syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ describe "home page" do
     fill_in "Password", :with => "secret"
     click_buton "Log in"
 
-    page.should have_selector(".header .username", :content => "jdoe")
+    page.should have_selector(".header .username", :text => "jdoe")
   end
 end
 ```


### PR DESCRIPTION
Capybara uses :text, not :content as the option to have_selector. Anything passed via :content is ignored entirely, leading to lots of incorrectly passing tests. The docs should probably reflect this, as this is pretty confusing. See this Capybara issue for more details: https://github.com/jnicklas/capybara/issues/525
