### PR TITLE
Fix typo in readme: 'click_buton' to 'click_button'

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ describe "home page" do
     visit "/login"
     fill_in "Username", :with => "jdoe"
     fill_in "Password", :with => "secret"
-    click_buton "Log in"
+    click_button "Log in"
 
     page.should have_selector(".header .username", :text => "jdoe")
   end


### PR DESCRIPTION
I was following the readme for implementing request specs and when trying to use the 'click_buton' method I received a Method Not Found error. Turns out there's a typo in the readme, the methos is 'click_button' (two t's). Thought I'd update the document so that other didn't encounter any confusion.
