### PR TITLE
Let local render_views override global setting

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -47,7 +47,8 @@ module RSpec
 
         # @api private
         def render_views?
-          metadata_for_rspec_rails[:render_views] || RSpec.configuration.render_views?
+          return RSpec.configuration.render_views? unless metadata_for_rspec_rails.key? :render_views
+          metadata_for_rspec_rails[:render_views]
         end
       end
 

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -54,6 +54,12 @@ module RSpec::Rails
           group.render_views false
           group.new.render_views?.should be_false
         end
+
+        it "overrides the global config if render_views is enabled there" do
+          RSpec.configuration.stub(:render_views?).and_return true
+          group.render_views false
+          group.new.render_views?.should be_false
+        end
       end
 
       context "in a nested group" do


### PR DESCRIPTION
If render_views is enabled globally in the spec_helper, it clobbers attempts to disable it locally for specific examples due to the false || true logic.

Instead, only use the global setting if no local render_views was provided.

My use case: I am working on an old project, where render_views has been enabled globally for a long time. I'm trying to isolate new specs as much as possible, so I wanted to disable render_views for some new controller specs. Unfortunately render_views(false) didn't work as I expected it.

Here is a gist with steps to reproduce the behaviour: https://gist.github.com/2249825

I don't think this is the intended behaviour of render_views, so I'm contributing my patch upstream.
