### PR TITLE
Fix render_views for anonymous controllers on 1.8.7.

### DIFF
--- a/features/controller_specs/anonymous_controller.feature
+++ b/features/controller_specs/anonymous_controller.feature
@@ -328,3 +328,33 @@ Feature: anonymous controller
     """
     When I run `rspec spec`
     Then the examples should all pass
+
+  Scenario: rendering views
+    Given a file named "spec/controllers/application_controller_spec.rb" with:
+      """
+      require "spec_helper"
+
+      describe ApplicationController do
+        render_views
+
+        controller do
+          def index
+            @name = "Bob"
+          end
+        end
+
+        describe "#index" do
+          it "greets the user" do
+            get :index
+            response.body.should =~ /Hello there, Bob/
+          end
+        end
+      end
+      """
+    And a file named "app/views/anonymous/index.html.erb" with:
+      """
+      Hello there, <%= @name %>
+      """
+    When I run `rspec spec`
+    Then the examples should all pass
+

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -58,10 +58,10 @@ module RSpec::Rails
                          controller_class :
                          ApplicationController
 
-        metadata[:example_group][:described_class] = Class.new(base_class, &body)
-        metadata[:example_group][:described_class].singleton_class.class_eval do
-          def name; "AnonymousController" end
+        metadata[:example_group][:described_class] = Class.new(base_class) do
+          def self.name; "AnonymousController"; end
         end
+        metadata[:example_group][:described_class].class_eval(&body)
 
         before do
           @orig_routes, @routes = @routes, ActionDispatch::Routing::RouteSet.new


### PR DESCRIPTION
Rails uses a controller's class name to determine the layout to use when
rendering views but it does so with an inherited hook. This means that
setting the name of a class _after_ it inherits is too late. This is not
an issue in Ruby 1.9.2 as the name of an anonymous module is set to nil
but in 1.8.7 it is set to the empty string (which, of course, is a
truthy value). This causes Rails to throw a "can't convert nil into
String" error when attempting to render views from an anonymous
controller.

We can fix this by declaring an anonymous controller's name _on
creation_ and then evaluating the body of the controller with
`class_eval`.

This fixes issue #450.
