### PR TITLE
Fix rendering deprecations in view specs

### DIFF
--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -42,7 +42,7 @@ module RSpec::Rails
       #       end
       #     end
       def render(options={}, local_assigns={}, &block)
-        options = {:template => _default_file_to_render} if Hash === options and options.empty?
+        options = _default_render_options if Hash === options and options.empty?
         super(options, local_assigns, &block)
       end
 
@@ -96,6 +96,19 @@ module RSpec::Rails
 
       def _default_file_to_render
         example.example_group.top_level_description
+      end
+
+      def _default_render_options
+        # pluck the handler, format, and locale out of, eg, posts/index.de.html.haml
+        template, *components = _default_file_to_render.split('.')
+        handler, format, locale = *components.reverse
+
+        render_options = {:template => template}
+        render_options[:handlers] = [handler] if handler
+        render_options[:formats] = [format] if format
+        render_options[:locales] = [locale] if locale
+
+        render_options
       end
 
       def _path_parts

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -108,10 +108,15 @@ module RSpec::Rails
       end
 
       context "given no input" do
-        it "sends render(:file => (described file)) to the view" do
-          view_spec.stub(:_default_file_to_render) { "widgets/new.html.erb" }
+        it "sends render(:template => (described file)) to the view" do
+          view_spec.stub(:_default_file_to_render) { "widgets/new" }
           view_spec.render
-          view_spec.received.first.should == [{:template => "widgets/new.html.erb"},{}, nil]
+          view_spec.received.first.should == [{:template => "widgets/new"},{}, nil]
+        end
+        it "converts the filename components into render options" do
+          view_spec.stub(:_default_file_to_render) { "widgets/new.en.html.erb" }
+          view_spec.render
+          view_spec.received.first.should == [{:template => "widgets/new", :locales=>['en'], :formats=>['html'], :handlers=>['erb']},{}, nil]
         end
       end
 


### PR DESCRIPTION
render(:template=>'new.erb') is now deprecated and should be render(:template=>'new', :handlers=>['erb']).  This patch takes the default template name supplied in the spec and breaks it up into its separate components before calling render().

See https://github.com/rspec/rspec-rails/issues/485 for background.

For some reason I thought just running 'rake' in rspec-dev ran the specs against a variety of rails versions, but scanning through the code I can't see where that's done.  So at the moment, this is only tested against 3.2.2 - any tips on testing the others, or do we not care?
