### PR TITLE
Fix typo in README (Articles -> Article)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ rendered.should xxx
 Model specs live in spec/models.
 
 ```ruby
-describe Articles do
+describe Article do
   describe ".recent" do
     it "includes articles published less than one week ago" do
       article = Article.create!(:published_at => Date.today - 1.week + 1.second)


### PR DESCRIPTION
Potentially confusing typo in README.
