### PR TITLE
Update README.md with the latest version of rspec_rails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add `rspec-rails` to the `:test` and `:development` groups in the Gemfile:
 
 ```ruby
 group :test, :development do
-  gem "rspec-rails", "~> 2.9.0"
+  gem "rspec-rails", "~> 2.0"
 end
 ```
 


### PR DESCRIPTION
2.9.0 is the latest version of rspec_rails. I also use the same version numbering the rubygems.org recommends for Gemfile.
