### PR TITLE
Update obsolete link to fixture documentation

### DIFF
--- a/lib/generators/rspec/model/templates/fixtures.yml
+++ b/lib/generators/rspec/model/templates/fixtures.yml
@@ -1,4 +1,4 @@
-# Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
 
 <% unless attributes.empty? -%>
 one:


### PR DESCRIPTION
The ar.rubyonrails.org servers will be going away at some point and are outdated anyway
