### PR TITLE
built-in scaffold generator already runs the hook for helper

### DIFF
--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -35,11 +35,6 @@ module Rspec
         copy_view :show
       end
 
-      # Invoke the helper using the controller name (pluralized)
-      hook_for :helper, :as => :scaffold do |invoked|
-        invoke invoked, [ controller_name ]
-      end
-
       def generate_routing_spec
         return unless options[:routing_specs]
 


### PR DESCRIPTION
Remove hook_for :helper. Can't get specs running locally so hoping travis can help here. 
