### PR TITLE
makes controller tests also work with rails 3 respond_with(model) coding style

### DIFF
--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -91,6 +91,7 @@ describe <%= controller_class_name %>Controller do
       it "assigns a newly created but unsaved <%= ns_file_name %> as @<%= ns_file_name %>" do
         # Trigger the behavior that occurs when invalid params are submitted
         <%= class_name %>.any_instance.stub(:save).and_return(false)
+        <%= class_name %>.any_instance.stub(:errors).and_return(:some => ["errors"])
         post :create, {:<%= ns_file_name %> => {}}, valid_session
         assigns(:<%= ns_file_name %>).should be_a_new(<%= class_name %>)
       end
@@ -98,6 +99,7 @@ describe <%= controller_class_name %>Controller do
       it "re-renders the 'new' template" do
         # Trigger the behavior that occurs when invalid params are submitted
         <%= class_name %>.any_instance.stub(:save).and_return(false)
+        <%= class_name %>.any_instance.stub(:errors).and_return(:some => ["errors"])
         post :create, {:<%= ns_file_name %> => {}}, valid_session
         response.should render_template("new")
       end
@@ -134,6 +136,7 @@ describe <%= controller_class_name %>Controller do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         # Trigger the behavior that occurs when invalid params are submitted
         <%= class_name %>.any_instance.stub(:save).and_return(false)
+        <%= class_name %>.any_instance.stub(:errors).and_return(:some => ["errors"])
         put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => {}}, valid_session
         assigns(:<%= ns_file_name %>).should eq(<%= file_name %>)
       end
@@ -142,6 +145,7 @@ describe <%= controller_class_name %>Controller do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         # Trigger the behavior that occurs when invalid params are submitted
         <%= class_name %>.any_instance.stub(:save).and_return(false)
+        <%= class_name %>.any_instance.stub(:errors).and_return(:some => ["errors"])
         put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => {}}, valid_session
         response.should render_template("edit")
       end


### PR DESCRIPTION
Today I decided to only write my resourceful controllers with the new responders implemented in rails 3.
However I got two bugs https://gist.github.com/2921167/0a4f464cd49f45147968fbf3f785a69b16d3b48b
This patch makes the default spec controllers generated on scaffold work with both coding styles.
There were other friends of mine involved in finding this solution.
