### PR TITLE
optionally specify a controller name

### DIFF
--- a/features/controller_specs/anonymous_controller.feature
+++ b/features/controller_specs/anonymous_controller.feature
@@ -328,3 +328,21 @@ Feature: anonymous controller
     """
     When I run `rspec spec`
     Then the examples should all pass
+
+  Scenario: override anonymous controller name
+    Given a file named "spec/controllers/override_anonymous_controller_name_spec.rb" with:
+    """
+      require "spec_helper"
+
+      class ApplicationController < ActionController::Base; end
+      class ApplicationControllerSubclass < ActionController::Base; end
+
+
+      describe ApplicationController do
+        controller(ApplicationControllerSubclass, "MyAnonymousController") {}
+
+        specify { controller.class.name.should == "MyAnonymousController" }
+      end
+      """
+    When I run `rspec spec`
+    Then the examples should all pass

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -53,14 +53,25 @@ module RSpec::Rails
       #     controller(ApplicationControllerSubclass) do
       #       # ....
       #     end
-      def controller(base_class = nil, &body)
+      #
+      # You may also optionally specify the anonymous controller's name:
+      #
+      #     controller(ApplicationControllerSubclass, "MyAnonymousController") do
+      #       # ....
+      #     end
+      def controller(base_class = nil, controller_name = "AnonymousController", &body)
         base_class ||= RSpec.configuration.infer_base_class_for_anonymous_controllers? ?
                          controller_class :
                          ApplicationController
 
         metadata[:example_group][:described_class] = Class.new(base_class) do
-          def self.name; "AnonymousController"; end
+          (class << self; self; end).module_eval do
+            define_method :name do
+              controller_name
+            end
+          end
         end
+
         metadata[:example_group][:described_class].class_eval(&body)
 
         before do


### PR DESCRIPTION
Needed to test a module that gets included into controllers and does interesting things based on the name of the controller. Thus, needed a way to name the anonymous controller.

``` cucumber
Scenario: override anonymous controller name
  Given a file named "spec/controllers/override_anonymous_controller_name_spec.rb" with:
  """
    require "spec_helper"

    class ApplicationController < ActionController::Base; end
    class ApplicationControllerSubclass < ActionController::Base; end


    describe ApplicationController do
      controller(ApplicationControllerSubclass, "MyAnonymousController") {}

      specify { controller.class.name.should == "MyAnonymousController" }
    end
    """
  When I run `rspec spec`
  Then the examples should all pass
```
