### PR TITLE
Accept namespace with double-colon

### DIFF
--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -73,7 +73,7 @@ module Rspec
 
         def ns_parts
           @ns_parts ||= begin
-                          matches = ARGV[0].to_s.match(/\A(\w+)\/(\w+)/)
+                          matches = ARGV[0].to_s.match(/\A(\w+)(?:\/|::)(\w+)/)
                           matches ? [matches[1], matches[2]] : []
                         end
         end


### PR DESCRIPTION
Hi.

When scaffolding, currently namespace is supported only with slash(/).
What about to accept namespace with double-colon(::)?

eg:

```
$ r g scaffold_controller admin/posts
$ r g scaffold_controller admin::posts 
```

Thanks.
