### PR TITLE
Checking for existence of ActiveRecord in proxy.rb before getting constants from it.

### DIFF
--- a/lib/rspec/rails/extensions/active_record/proxy.rb
+++ b/lib/rspec/rails/extensions/active_record/proxy.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |rspec|
   # Delay this in order to give users a chance to configure `expect_with`...
   rspec.before(:suite) do
-    if defined?(RSpec::Matchers) && RSpec::Matchers.configuration.syntax.include?(:should)
+    if defined?(RSpec::Matchers) && RSpec::Matchers.configuration.syntax.include?(:should) && defined?(ActiveRecord)
       # In Rails 3.0, it was AssociationProxy.
       # In 3.1+, it's CollectionProxy.
       const_name = [:CollectionProxy, :AssociationProxy].find do |const|


### PR DESCRIPTION
I'm using Mongoid and just got this error on HEAD due to the addition of proxy.rb. Projects that use Mongoid don't use ActiveRecord. This checks for ActiveRecord in the proxy.rb file. I tested on my project and it appears to fix the issue.

``` ruby
/Users/jonathan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rspec-rails-fb55955687e2/lib/rspec/rails/extensions/active_record/proxy.rb:8:in `block (3 levels) in <top (required)>': uninitialized constant ActiveRecord (NameError)
```
