### PR TITLE
Support validation contexts when using #errors_on

### DIFF
--- a/features/model_specs/errors_on.feature
+++ b/features/model_specs/errors_on.feature
@@ -9,6 +9,8 @@ Feature: errors_on
         set_table_name :widgets
         validates_presence_of :name
         attr_accessible :name
+
+        validates_length_of :name, :minimum => 5, :on => :publication
       end
 
       describe ValidatingWidget do
@@ -22,6 +24,16 @@ Feature: errors_on
 
         it "fails validation with no name expecting a specific message" do
           expect(ValidatingWidget.new.errors_on(:name)).to include("can't be blank")
+        end
+
+        it "fails validation with a short name (using a validation context)" do
+          expect(ValidatingWidget.new(:name => 'foo')).
+            to have(1).errors_on(:name, :context => :publication)
+        end
+
+        it "passes validation with a longer name (using a validation context)" do
+          expect(ValidatingWidget.new(:name => 'a longer name')).
+            to have(0).errors_on(:name, :context => :publication)
         end
 
         it "passes validation with a name (using 0)" do

--- a/lib/rspec/rails/extensions/active_record/base.rb
+++ b/lib/rspec/rails/extensions/active_record/base.rb
@@ -26,7 +26,8 @@ end
 
 module ::ActiveModel::Validations
   # Extension to enhance `should have` on AR Model instances.  Calls
-  # model.valid? in order to prepare the object's errors object. 
+  # model.valid? in order to prepare the object's errors object. Accepts
+  # a :context option to specify the validation context.
   #
   # You can also use this to specify the content of the error messages.
   #
@@ -35,10 +36,11 @@ module ::ActiveModel::Validations
   #     model.should have(:no).errors_on(:attribute)
   #     model.should have(1).error_on(:attribute)
   #     model.should have(n).errors_on(:attribute)
+  #     model.should have(n).errors_on(:attribute, context: :create)
   #
   #     model.errors_on(:attribute).should include("can't be blank")
-  def errors_on(attribute)
-    self.valid?
+  def errors_on(attribute, options = {})
+    options.has_key?(:context) ? self.valid?(options[:context]) : self.valid?
     [self.errors[attribute]].flatten.compact
   end
   alias :error_on :errors_on


### PR DESCRIPTION
Previously, Model#errors_on calls Model#valid?, which will both clear
the errors hash and run validations in the default context. This adds an
:on option to #errors_on that gets passed to #valid?, allowing using
errors_on with validation contexts.

Exmaple usage:

```
class Foo
  validates :name, length: {minimum: 20}, on: :publication
end

describe Foo
  it 'should have a name greater than 20 characters on publication' do
    subject.name = 'too short'
    subject.name.should have(1).error_on(:name, on: :publication)
  end
end
```
