### PR TITLE
Using contain in the View specs example is misleading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ describe "events/show" do
       :location => "Chicago"
     ))
     render
-    expect(rendered).to contain("Chicago")
+    expect(rendered).to include("Chicago")
   end
 end
 ```


### PR DESCRIPTION
Using contain in the View specs example is misleading because it does not work without including an extra gem.

I had to google around to figure out why my expectations did not work.

``` ruby
  expect(rendered).to contain("Chicago") 
```

had to be changed to 

``` ruby
expect(rendered).to include("Chicago")
```
