### PR TITLE
Fix bare #render in view specs on Rails 3.1

### DIFF
--- a/features/view_specs/view_spec.feature
+++ b/features/view_specs/view_spec.feature
@@ -73,6 +73,38 @@ Feature: view spec
     When I run `rspec spec/views`
     Then the examples should all pass
 
+  Scenario: passing spec with a description that includes the format and handler
+    Given a file named "spec/views/widgets/widget.xml.erb_spec.rb" with:
+      """ruby
+      require "spec_helper"
+
+      describe "widgets/widget.html.erb" do
+        it "renders the HTML template" do
+          render
+
+          expect(rendered).to match /HTML/
+        end
+      end
+
+      describe "widgets/widget.xml.erb" do
+        it "renders the XML template" do
+          render
+
+          expect(rendered).to match /XML/
+        end
+      end
+      """
+    And a file named "app/views/widgets/widget.html.erb" with:
+      """
+      HTML
+      """
+    And a file named "app/views/widgets/widget.xml.erb" with:
+      """
+      XML
+      """
+    When I run `rspec spec/views`
+    Then the examples should all pass
+
   Scenario: passing spec with rendering of locals in a partial
     Given a file named "spec/views/widgets/_widget.html.erb_spec.rb" with:
       """ruby

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -99,16 +99,20 @@ module RSpec::Rails
       end
 
       def _default_render_options
-        # pluck the handler, format, and locale out of, eg, posts/index.de.html.haml
-        template, *components = _default_file_to_render.split('.')
-        handler, format, locale = *components.reverse
+        if ::Rails.version >= "3.2"
+          # pluck the handler, format, and locale out of, eg, posts/index.de.html.haml
+          template, *components   = _default_file_to_render.split('.')
+          handler, format, locale = *components.reverse
 
-        render_options = {:template => template}
-        render_options[:handlers] = [handler] if handler
-        render_options[:formats] = [format] if format
-        render_options[:locales] = [locale] if locale
+          render_options = {:template => template}
+          render_options[:handlers] = [handler] if handler
+          render_options[:formats] = [format] if format
+          render_options[:locales] = [locale] if locale
 
-        render_options
+          render_options
+        else
+          {:template => _default_file_to_render}
+        end
       end
 
       def _path_parts

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -113,10 +113,16 @@ module RSpec::Rails
           view_spec.render
           view_spec.received.first.should == [{:template => "widgets/new"},{}, nil]
         end
+
         it "converts the filename components into render options" do
           view_spec.stub(:_default_file_to_render) { "widgets/new.en.html.erb" }
           view_spec.render
-          view_spec.received.first.should == [{:template => "widgets/new", :locales=>['en'], :formats=>['html'], :handlers=>['erb']},{}, nil]
+
+          if ::Rails.version >= "3.2"
+            view_spec.received.first.should == [{:template => "widgets/new", :locales=>['en'], :formats=>['html'], :handlers=>['erb']}, {}, nil]
+          else
+            view_spec.received.first.should == [{:template => "widgets/new.en.html.erb"}, {}, nil]
+          end
         end
       end
 


### PR DESCRIPTION
656ff3 made this compatible with 3.2 by splitting the name of the template in
the description into its base name, locale, format and handler components,
but in doing so broke compatibility with 3.1 and earlier, which does not
support the extra options.
