### PR TITLE
Check for ActiveRecord::Associations and not just ActiveRecord

### DIFF
--- a/lib/rspec/rails/extensions/active_record/proxy.rb
+++ b/lib/rspec/rails/extensions/active_record/proxy.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |rspec|
   # Delay this in order to give users a chance to configure `expect_with`...
   rspec.before(:suite) do
-    if defined?(RSpec::Matchers) && RSpec::Matchers.configuration.syntax.include?(:should) && defined?(ActiveRecord)
+    if defined?(RSpec::Matchers) && RSpec::Matchers.configuration.syntax.include?(:should) && defined?(ActiveRecord::Associations)
       # In Rails 3.0, it was AssociationProxy.
       # In 3.1+, it's CollectionProxy.
       const_name = [:CollectionProxy, :AssociationProxy].find do |const|


### PR DESCRIPTION
I was getting an `ActiveRecord::Associations` constant not defined error. We use a slightly older version of Mongoid with Rails and don't have the full ActiveRecord gem loaded in our codebase. I couldn't run my specs because it was blowing up when trying to detect which Association Proxy class I was using after upgrading to RSpec 2.12

Let me know if you'd like this pull request resubmitted on a topic branch or if any other work needs to be done to bring this patch up to snuff.
