### PR TITLE
Prevent inclusion if the directory doesn't exactly match the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See http://github.com/rspec/rspec-rails/issues
 
 # Request Specs
 
-Request specs live in spec/requests, and mix in behavior
+Request specs live in spec/requests, spec/api and spec/integration, and mix in behavior
 [ActionDispatch::Integration::Runner](http://api.rubyonrails.org/classes/ActionDispatch/Integration/Runner.html),
 which is the basis for [Rails' integration
 tests](http://guides.rubyonrails.org/testing.html#integration-testing).  The

--- a/lib/rspec/rails/example.rb
+++ b/lib/rspec/rails/example.rb
@@ -10,7 +10,7 @@ require 'rspec/rails/example/feature_example_group'
 
 RSpec::configure do |c|
   def c.escaped_path(*parts)
-    Regexp.compile(parts.join('[\\\/]'))
+    Regexp.compile(parts.join('[\\\/]') + '[\\\/]')
   end
 
   c.include RSpec::Rails::ControllerExampleGroup, :type => :controller, :example_group => {


### PR DESCRIPTION
References #643
For example spec/apifoobar should not have the RequestExampleGroup included
but spec/api should.
Documents also the two additional paths for integration tests, spec/integration and
spec/api.
