### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ gem install rspec-rails
 This installs the following gems:
 
 ```
-rspec
 rspec-core
 rspec-expectations
 rspec-mocks


### PR DESCRIPTION
'rspec' is not longer installed:
https://github.com/rspec/rspec-rails/commit/f5a573518420629b80f10bf1b8a01faf54ae1e1d
