### PR TITLE
add an it block to ensure that model should have a db column for all initial attributes

### DIFF
--- a/lib/generators/rspec/model/templates/model_spec.rb
+++ b/lib/generators/rspec/model/templates/model_spec.rb
@@ -2,6 +2,17 @@ require 'spec_helper'
 
 <% module_namespacing do -%>
 describe <%= class_name %> do
-  pending "add some examples to (or delete) #{__FILE__}"
+	
+	pending "add some examples to (or delete) #{__FILE__}"
+
+	<% unless attributes.empty? %>
+	it "should have <%= attributes.map(&:name).join(', ') %> columns in the database" do
+		<% attributes.each do |attribute| %>
+		should have_db_column(:<%= attribute.name %>)
+		<% end  %>  
+	end		 
+	<% end -%>
+
+
 end
 <% end -%>

--- a/spec/generators/rspec/model/model_generator_spec.rb
+++ b/spec/generators/rspec/model/model_generator_spec.rb
@@ -17,6 +17,23 @@ describe Rspec::Generators::ModelGenerator do
   end
 
   describe 'the generated files' do
+
+    describe 'it includes should have_db_column for all attributes ' do
+      before do
+        run_generator %w(posts title:string content:text)
+      end
+
+      describe 'the spec' do
+        subject { file('spec/models/posts_spec.rb') }
+
+        it { should exist }
+        it { should contain(/require 'spec_helper'/) }
+        it { should contain(/describe Posts/) }
+        it { should contain('should have_db_column(:title)') }
+        it { should contain('should have_db_column(:content)') }
+      end
+    end
+
     describe 'with fixtures' do
       before do
         run_generator %w(posts --fixture)
@@ -48,5 +65,6 @@ describe Rspec::Generators::ModelGenerator do
         it { should_not exist }
       end
     end
+
   end
 end


### PR DESCRIPTION
When  i generate a new new model with your super awesome Rspec there is no failing test at all even if i generate the model with some attributes like **rails g model post title:string** .

I added a feature where the generated spec file include some should have_db_column directives to ensure that if a member of my team drops a column accidentally there i'll be a failing spec!

Thanks again for the super awesome rspec! 
It made me a better dev!
