### PR TITLE
Use a null template handler when stubbing out views

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -73,7 +73,7 @@ module RSpec
             ::ActionView::Template.new(
               "",
               template.identifier,
-              lambda { |template| "" },
+              lambda { |template| %[ "" ] },
               {
                 :virtual_path => template.virtual_path,
                 :format => template.formats


### PR DESCRIPTION
I have a custom template handler that does some work up-front, even when the template source is empty. I'd rather avoid having the handler called at all when the view layer is supposedly stubbed out. I think it makes more sense to just add a null handler for the templates that are resolved in the specs.

I had trouble getting the gems bundled and thus couldn't run the specs, but this PR should not change any expected behavior as far as I can tell.
