### PR TITLE
For passing the test using "redirect_to"  in before_filter

### DIFF
--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -68,7 +68,7 @@ module RSpec::Rails
           @routes.draw { resources :anonymous }
 
           routes = @routes
-          described_class.send(:define_method, :_routes) { routes }
+          described_class.send(:define_method, :routes) { routes }
         end
 
         after do


### PR DESCRIPTION
When using "redirect_to :root"  in before_filter, the rspec test occurs ActionController::RoutingError exception.

In order to pass the test, change methods _routes to route at controller_example_group.rb.

My modification might not meet the views of "https://github.com/rspec/rspec-rails/commit/648ba097eced24f5bbf70dd0d97b02ad6464f19e".
