### PR TITLE
use eq matcher instead of eql

### DIFF
--- a/spec/rspec/rails/example/feature_example_group_spec.rb
+++ b/spec/rspec/rails/example/feature_example_group_spec.rb
@@ -10,7 +10,7 @@ module RSpec::Rails
         include FeatureExampleGroup
       end
 
-      expect(group.metadata[:type]).to eql(:feature)
+      expect(group.metadata[:type]).to eq(:feature)
     end
 
     it "includes Rails route helpers" do
@@ -22,8 +22,8 @@ module RSpec::Rails
         include FeatureExampleGroup
       end
 
-      expect(group.new.foo_path).to eql("/foo")
-      expect(group.new.foo_url).to eql("http://www.example.com/foo")
+      expect(group.new.foo_path).to eq("/foo")
+      expect(group.new.foo_url).to eq("http://www.example.com/foo")
     end
 
     describe "#visit" do
@@ -49,7 +49,7 @@ module RSpec::Rails
           include FeatureExampleGroup
         end
 
-        expect(group.new.visit("/foo")).to eql("success: /foo")
+        expect(group.new.visit("/foo")).to eq("success: /foo")
       end
     end
   end

--- a/spec/rspec/rails/mocks/stub_model_spec.rb
+++ b/spec/rspec/rails/mocks/stub_model_spec.rb
@@ -112,7 +112,7 @@ describe "stub_model" do
 
     describe "alternate primary key" do
       it "has the correct primary_key name" do
-        stub_model(AlternatePrimaryKeyModel).class.primary_key.to_s.should eql('my_id')
+        stub_model(AlternatePrimaryKeyModel).class.primary_key.to_s.should eq('my_id')
       end
 
       it "has a primary_key" do


### PR DESCRIPTION
- the eq matcher is the default matcher for equality. It redirects to
  ==, whereas the eql matcher redirects to eql?, which has varied
  semantics across types.
