### PR TITLE
Routing specs can set their own routes

### DIFF
--- a/lib/rspec/rails/example/routing_example_group.rb
+++ b/lib/rspec/rails/example/routing_example_group.rb
@@ -12,12 +12,26 @@ module RSpec::Rails
       metadata[:type] = :routing
 
       before do
-        @routes = ::Rails.application.routes
-        assertion_instance.instance_variable_set(:@routes, @routes)
+        self.routes = ::Rails.application.routes
       end
     end
 
     attr_reader :routes
+
+    # Explicitly sets the routes. This is most often useful when testing a
+    # routes for a Rails engine.
+    #
+    # @example
+    #
+    #     describe "MyEngine routing" do
+    #       before { self.routes = MyEngine::Engine.routes }
+    #
+    #       # ...
+    #     end
+    def routes=(routes)
+      @routes = routes
+      assertion_instance.instance_variable_set(:@routes, @routes)
+    end
 
     private
 

--- a/spec/rspec/rails/example/routing_example_group_spec.rb
+++ b/spec/rspec/rails/example/routing_example_group_spec.rb
@@ -5,19 +5,18 @@ module RSpec::Rails
     it { should be_included_in_files_in('./spec/routing/') }
     it { should be_included_in_files_in('.\\spec\\routing\\') }
 
-    it "adds :type => :routing to the metadata" do
-      group = RSpec::Core::ExampleGroup.describe do
+    let(:group) {
+      RSpec::Core::ExampleGroup.describe do
         include RoutingExampleGroup
       end
+    }
+
+    it "adds :type => :routing to the metadata" do
       group.metadata[:type].should eq(:routing)
     end
 
     describe "named routes" do
       it "delegates them to the route_set" do
-        group = RSpec::Core::ExampleGroup.describe do
-          include RoutingExampleGroup
-        end
-
         example = group.new
 
         # Yes, this is quite invasive
@@ -26,6 +25,18 @@ module RSpec::Rails
         example.stub(:routes => routes)
 
         example.foo_path.should == "foo"
+      end
+    end
+
+    describe "#routes=" do
+      it "sets the routes used during the test" do
+        example = group.new
+
+        routes = ActionDispatch::Routing::RouteSet.new
+        routes.draw { resources :foos }
+        example.routes = routes
+
+        expect(example.foos_path).to eq("/foos")
       end
     end
   end


### PR DESCRIPTION
(For example, to test Rails engines)

Prior to 2.12.1, routing specs could override the routeset by setting
the ivar `@routes`. However, after putting a delegation layer between us
and Rails, this no longer worked correctly. I do not think that setting
`@routes` was necessarily supposed to be a public interface, so I do not
think we have a duty to support it.

This pull request exposes a `routes` setter that can correctly override
the routeset, and adds it explicitly as a public interface.

I'm still mulling over the solution and the aesthetic of the setter, but
I figured I'd get something out there for feedback.

@myronmarston, @dchelimsky, what do you think?

Related: #668
