### PR TITLE
More flexible rake tasks

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -13,10 +13,16 @@ desc "Run all specs in spec directory (excluding plugin specs)"
 RSpec::Core::RakeTask.new(:spec => spec_prereq)
 
 namespace :spec do
-  [:features, :requests, :models, :controllers, :views, :helpers, :mailers, :lib, :routing].each do |sub|
-    desc "Run the code examples in spec/#{sub}"
-    RSpec::Core::RakeTask.new(sub => spec_prereq) do |t|
-      t.pattern = "./spec/#{sub}/**/*_spec.rb"
+
+  def types
+    dirs = Dir[ './spec/**/*_spec.rb' ].map { |f| f.sub(/^\.\/(spec\/\w+)\/.*/, '\\1') }.uniq
+    Hash[ dirs.map { |d| [d.split('/').last, d] } ]
+  end
+
+  types.each do |type, dir|
+    desc "Run the code examples in #{dir}"
+    RSpec::Core::RakeTask.new(type => spec_prereq) do |t|
+      t.pattern = "./#{dir}/**/*_spec.rb"
     end
   end
 
@@ -29,24 +35,12 @@ namespace :spec do
 
   task :statsetup do
     require 'rails/code_statistics'
-    ::STATS_DIRECTORIES << %w(Model\ specs spec/models) if File.exist?('spec/models')
-    ::STATS_DIRECTORIES << %w(View\ specs spec/views) if File.exist?('spec/views')
-    ::STATS_DIRECTORIES << %w(Controller\ specs spec/controllers) if File.exist?('spec/controllers')
-    ::STATS_DIRECTORIES << %w(Helper\ specs spec/helpers) if File.exist?('spec/helpers')
-    ::STATS_DIRECTORIES << %w(Library\ specs spec/lib) if File.exist?('spec/lib')
-    ::STATS_DIRECTORIES << %w(Mailer\ specs spec/mailers) if File.exist?('spec/mailers')
-    ::STATS_DIRECTORIES << %w(Routing\ specs spec/routing) if File.exist?('spec/routing')
-    ::STATS_DIRECTORIES << %w(Request\ specs spec/requests) if File.exist?('spec/requests')
-    ::STATS_DIRECTORIES << %w(Feature\ specs spec/features) if File.exist?('spec/features')
-    ::CodeStatistics::TEST_TYPES << "Model specs" if File.exist?('spec/models')
-    ::CodeStatistics::TEST_TYPES << "View specs" if File.exist?('spec/views')
-    ::CodeStatistics::TEST_TYPES << "Controller specs" if File.exist?('spec/controllers')
-    ::CodeStatistics::TEST_TYPES << "Helper specs" if File.exist?('spec/helpers')
-    ::CodeStatistics::TEST_TYPES << "Library specs" if File.exist?('spec/lib')
-    ::CodeStatistics::TEST_TYPES << "Mailer specs" if File.exist?('spec/mailers')
-    ::CodeStatistics::TEST_TYPES << "Routing specs" if File.exist?('spec/routing')
-    ::CodeStatistics::TEST_TYPES << "Request specs" if File.exist?('spec/requests')
-    ::CodeStatistics::TEST_TYPES << "Feature specs" if File.exist?('spec/features')
+    types.each do |type, dir|
+      name = type.singularize.capitalize
+
+      ::STATS_DIRECTORIES << ["#{name} specs", dir]
+      ::CodeStatistics::TEST_TYPES << "#{name} specs"
+    end
   end
 end
 


### PR DESCRIPTION
Hi,

I thought the rake task was not flexible enough when running specs in a certain directory or, more importantly, fetching stats. What I sometimes have is a dedicated directory for a part of my application, e.g. 'api' or 'mobile', which then holds the usual subdirectory structure of rspec. Running `rake stats` would ignore those dirs and I would like them to being included automatically. So I thought making the tasks adapt to it would be a nice addition.
