### PR TITLE
Allow routing specs to access engine routes

### DIFF
--- a/features/routing_specs/engine_routes.feature
+++ b/features/routing_specs/engine_routes.feature
@@ -1,0 +1,37 @@
+Feature: engine routes
+
+  Routing specs can specify the routeset that will be used for the example
+  group. This is most useful when testing Rails engines.
+
+  Scenario: specify engine route
+    Given a file named "spec/routing/engine_routes_spec.rb" with:
+    """ruby
+    require "spec_helper"
+
+    # A very simple Rails engine
+    module MyEngine
+      class Engine < ::Rails::Engine
+        isolate_namespace MyEngine
+      end
+
+      Engine.routes.draw do
+        resources :widgets, only: [:index]
+      end
+
+      class WidgetsController < ::ActionController::Base
+        def index
+        end
+      end
+    end
+
+    describe MyEngine::WidgetsController do
+      routes { MyEngine::Engine.routes }
+
+      it "routes to the list of all widgets" do
+        expect(:get => widgets_path).
+          to route_to(:controller => "my_engine/widgets", :action => "index")
+      end
+    end
+    """
+    When I run `rspec spec`
+    Then the examples should all pass

--- a/lib/rspec/rails/example/routing_example_group.rb
+++ b/lib/rspec/rails/example/routing_example_group.rb
@@ -8,16 +8,42 @@ module RSpec::Rails
     include RSpec::Rails::Matchers::RoutingMatchers::RouteHelpers
     include RSpec::Rails::AssertionDelegator.new(ActionDispatch::Assertions::RoutingAssertions)
 
+    module ClassMethods
+      # Specifies the routeset that will be used for the example group. This
+      # is most useful when testing Rails engines.
+      #
+      # @example
+      #
+      #     describe MyEngine::PostsController do
+      #       routes { MyEngine::Engine.routes }
+      #
+      #       it "routes posts#index" do
+      #         expect(:get => "/posts").to
+      #           route_to(:controller => "my_engine/posts", :action => "index")
+      #       end
+      #     end
+      def routes(&blk)
+        before do
+          self.routes = blk.call
+        end
+      end
+    end
+
     included do
       metadata[:type] = :routing
 
       before do
-        @routes = ::Rails.application.routes
-        assertion_instance.instance_variable_set(:@routes, @routes)
+        self.routes = ::Rails.application.routes
       end
     end
 
     attr_reader :routes
+
+    # @api private
+    def routes=(routes)
+      @routes = routes
+      assertion_instance.instance_variable_set(:@routes, routes)
+    end
 
     private
 


### PR DESCRIPTION
I have a Rails Engine with routes defined in my app.
After upgrade all routing tests fail with _No route matches..._

I was trying to debug the MyEngine::Engine.routes.router and here's the diff
On latest rspec-rails `@ast` is always nil.

``` diff
@@ -1,13 +1,14 @@
 pry(#<RSpec::Core::ExampleGroup::Nested_14::Nested_1>)> @routes.router
-=> #<Journey::Router:0xa1eb388
+=> #<Journey::Router:0xa4e6150
  @options=
   {:parameters_key=>"action_dispatch.request.path_parameters",
    :request_class=>ActionDispatch::Request},
  @params_key="action_dispatch.request.path_parameters",
  @request_class=ActionDispatch::Request,
  @routes=
-  #<Journey::Routes:0xa1eb3ec
-   @ast=nil,
+  #<Journey::Routes:0xa4e61b4
+   @ast=
+    /signup(.:format)|/login(.:format)|/logout(.:format)|/signup(.:format)|/login(.:format)|/start(.:format)|/start(.:format)|/sessions(.:format)|/sessions/new(.:format)|/sessions/:id(.:format)|/passwords(.:form
    @named_routes=
     {"signup"=>
-      #<Journey::Route:0xc685004
\ No newline at end of file
+      #<Journey::Route:0xa6d40c0
\ No newline at end of file
```
