### PR TITLE
Reset ActionController::Base.allow_forgery_protection in controller specs

### DIFF
--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -121,7 +121,12 @@ module RSpec::Rails
 
       before do
         @routes = ::Rails.application.routes
+        @previous_allow_forgery_protection_value = ActionController::Base.allow_forgery_protection
         ActionController::Base.allow_forgery_protection = false
+      end
+
+      after do
+        ActionController::Base.allow_forgery_protection = @previous_allow_forgery_protection_value
       end
     end
   end


### PR DESCRIPTION
The controller_example_group adds a before block to tests that sets the class variable ActionController::Base.allow_forgery_protection to false, but never resets it.  This means that if a controller spec is run before any other spec that expects csrf protection to be enabled the second test will fail.  This commit adds an after block that sets ActionController::Base.allow_forgery_protection class variable back to what it was before.

There is not a test case added for this because we could not find any tests for the ActionController::Base.allow_forgery_protection setting in the first place.  If you can suggest the correct way to test this we will gladly add it.
