### PR TITLE
Add patch to routing helpers

### DIFF
--- a/lib/rspec/rails/matchers/routing_matchers.rb
+++ b/lib/rspec/rails/matchers/routing_matchers.rb
@@ -97,7 +97,7 @@ module RSpec::Rails::Matchers
     end
 
     module RouteHelpers
-      %w(get post put delete options head).each do |method|
+      %w(get post put patch delete options head).each do |method|
         define_method method do |path|
           { method.to_sym => path }
         end


### PR DESCRIPTION
Using Rails 4 Beta, noticed that PATCH is the primary HTTP method for updates.

Adding PATCH to the route helpers for Rails 4 support.

http://weblog.rubyonrails.org/2012/2/25/edge-rails-patch-is-the-new-primary-http-method-for-updates/
