### PR TITLE
Don't generate views if there is no template engine

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 ### dev
 [full changelog](http://github.com/rspec/rspec-rails/compare/v2.13.0...master)
 
+Bug fixes
+
+* View specs are no longer generated if no template engine is specified (Kevin Glowacz)
+
 Enhancements
 
 * `ActionController::Base.allow_forgery_protection` is set to its original

--- a/lib/generators/rspec/controller/controller_generator.rb
+++ b/lib/generators/rspec/controller/controller_generator.rb
@@ -18,7 +18,7 @@ module Rspec
 
       def generate_view_specs
         return if actions.empty?
-        return unless options[:view_specs]
+        return unless options[:view_specs] && options[:template_engine]
 
         empty_directory File.join("spec", "views", file_path)
 

--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -27,7 +27,7 @@ module Rspec
       end
 
       def generate_view_specs
-        return unless options[:view_specs]
+        return unless options[:view_specs] && options[:template_engine]
 
         copy_view :edit
         copy_view :index unless options[:singleton]

--- a/spec/generators/rspec/controller/controller_generator_spec.rb
+++ b/spec/generators/rspec/controller/controller_generator_spec.rb
@@ -50,6 +50,17 @@ describe Rspec::Generators::ControllerGenerator do
           it { should_not exist }
         end
       end
+
+      describe 'with --no-template-engine' do
+        before do
+          run_generator %w(posts index --no-template-engine)
+        end
+
+        describe 'index.html.erb' do
+          subject { file('spec/views/posts/index.html._spec.rb') }
+          it { should_not exist }
+        end
+      end
     end
 
     describe 'are generated' do

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -72,6 +72,29 @@ describe Rspec::Generators::ScaffoldGenerator do
       end
     end
 
+    describe 'with --no-template-engine' do
+      before { run_generator %w(posts --no-template-engine) }
+      describe 'edit' do
+        subject { file("spec/views/posts/edit.html._spec.rb") }
+        it { should_not exist }
+      end
+
+      describe 'index' do
+        subject { file("spec/views/posts/index.html._spec.rb") }
+        it { should_not exist }
+      end
+
+      describe 'new' do
+        subject { file("spec/views/posts/new.html._spec.rb") }
+        it { should_not exist }
+      end
+
+      describe 'show' do
+        subject { file("spec/views/posts/show.html._spec.rb") }
+        it { should_not exist }
+      end
+    end
+
     describe 'with --no-view-specs' do
       before { run_generator %w(posts --no-view-specs) }
 


### PR DESCRIPTION
rails-api disables view generation by setting template_engine to nil, but rspec still generates view specs.

This patch will prevent rspec from generating view specs when no views are being generated.
