### PR TITLE
remove spec:rcov rake task

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -25,11 +25,14 @@ namespace :spec do
     end
   end
 
-  desc "Run all specs with rcov"
-  RSpec::Core::RakeTask.new(:rcov => spec_prereq) do |t|
-    t.rcov = true
-    t.pattern = "./spec/**/*_spec.rb"
-    t.rcov_opts = '--exclude /gems/,/Library/,/usr/,lib/tasks,.bundle,config,/lib/rspec/,/lib/rspec-,spec'
+  # RCov task only enabled for Ruby 1.8
+  if RUBY_VERSION < '1.9'
+    desc "Run all specs with rcov"
+    RSpec::Core::RakeTask.new(:rcov => spec_prereq) do |t|
+      t.rcov = true
+      t.pattern = "./spec/**/*_spec.rb"
+      t.rcov_opts = '--exclude /gems/,/Library/,/usr/,lib/tasks,.bundle,config,/lib/rspec/,/lib/rspec-,spec'
+    end
   end
 
   task :statsetup do
@@ -42,4 +45,3 @@ namespace :spec do
     end
   end
 end
-


### PR DESCRIPTION
rcov currently does not compile against ruby 2.0.0 or jruby 1.7.3.
The last commit on master is 1 year old.
