### PR TITLE
Add #to_s method to rails version

### DIFF
--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -7,7 +7,7 @@ module Rspec
         @_rspec_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'rspec', generator_name, 'templates'))
       end
 
-      if ::Rails.version < '3.1'
+      if ::Rails.version.to_s < '3.1'
         def module_namespacing
           yield if block_given?
         end


### PR DESCRIPTION
Rails.version returns an instance of Gem::Version
ref rails/rails#8501, https://travis-ci.org/rails/rails/jobs/5750326
