### PR TITLE
Apply the new ::Rails.version approach everywhere it's used

### DIFF
--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -7,7 +7,7 @@ module Rspec
         @_rspec_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'rspec', generator_name, 'templates'))
       end
 
-      if ::Rails.version < '3.1'
+      if Gem::Requirement.new('< 3.1').satisfied_by?(Gem::Version.new(::Rails.version.to_s))
         def module_namespacing
           yield if block_given?
         end

--- a/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
+++ b/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
@@ -8,7 +8,7 @@ require 'rspec/autorun'
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
-<% if ::Rails.version >= '4' -%>
+<% if Gem::Requirement.new('>= 4.0.0beta1').satisfied_by?(Gem::Version.new(::Rails.version.to_s)) -%>
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -113,7 +113,7 @@ describe <%= controller_class_name %>Controller do
         # specifies that the <%= class_name %> created on the previous line
         # receives the :update_attributes message with whatever params are
         # submitted in the request.
-        <%- if Rails.version >= '4' -%>
+        <%- if Gem::Requirement.new('>= 4.0.0beta1').satisfied_by?(Gem::Version.new(::Rails.version.to_s)) -%>
         <%= class_name %>.any_instance.should_receive(:update).with(<%= formatted_hash(example_params_for_update) %>)
         <%- else -%>
         <%= class_name %>.any_instance.should_receive(:update_attributes).with(<%= formatted_hash(example_params_for_update) %>)

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -107,7 +107,7 @@ module RSpec::Rails
       end
 
       def _default_render_options
-        if ::Rails.version >= "3.2"
+        if Gem::Requirement.new('>= 3.2').satisfied_by?(Gem::Version.new(::Rails.version.to_s))
           # pluck the handler, format, and locale out of, eg, posts/index.de.html.haml
           template, *components   = _default_file_to_render.split('.')
           handler, format, locale = *components.reverse

--- a/spec/generators/rspec/install/install_generator_spec.rb
+++ b/spec/generators/rspec/install/install_generator_spec.rb
@@ -16,7 +16,7 @@ describe Rspec::Generators::InstallGenerator do
     File.read( file('spec/spec_helper.rb') ).should =~ /^require 'rspec\/autorun'$/m
   end
 
-  if ::Rails.version >= '4'
+  if Gem::Requirement.new('>= 4.0.0beta1').satisfied_by?(Gem::Version.new(::Rails.version.to_s))
     it "generates spec/spec_helper.rb with a check for pending migrations" do
       run_generator
       File.read( file('spec/spec_helper.rb') ).should =~ /ActiveRecord::Migration\.check_pending!/m

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -118,7 +118,7 @@ module RSpec::Rails
           view_spec.stub(:_default_file_to_render) { "widgets/new.en.html.erb" }
           view_spec.render
 
-          if ::Rails.version >= "3.2"
+          if Gem::Requirement.new('>= 3.2').satisfied_by?(Gem::Version.new(::Rails.version.to_s))
             view_spec.received.first.should == [{:template => "widgets/new", :locales=>['en'], :formats=>['html'], :handlers=>['erb']}, {}, nil]
           else
             view_spec.received.first.should == [{:template => "widgets/new.en.html.erb"}, {}, nil]


### PR DESCRIPTION
This takes the rspec/rspec-rails#723 approach and applies it everywhere we are checking ::Rails.version.
