### PR TITLE
Question regarding Capybara::DSL

### DIFF
--- a/lib/rspec/rails/vendor/capybara.rb
+++ b/lib/rspec/rails/vendor/capybara.rb
@@ -11,7 +11,6 @@ end
 if defined?(Capybara)
   RSpec.configure do |c|
     if defined?(Capybara::DSL)
-      c.include Capybara::DSL, :type => :controller
       c.include Capybara::DSL, :type => :feature
     end
 


### PR DESCRIPTION
I'm using Capybara 2.0.2 and rspec-rails 2.12.2 and I was noticing that Capybara::DSL was being include in my controllers tests. I read here in the [Capybara 2.0](https://github.com/rspec/rspec-rails/blob/master/Capybara.md) section of rspec-rails that in theory this shouldn't happen. However when I go to https://github.com/rspec/rspec-rails/blob/master/lib/rspec/rails/vendor/capybara.rb, I'm seeing that Capybara::DSL in being included in the controllers as well. 

Am I missing something here? 

Cheers!
