### PR TITLE
Update how Rails.version is checked

### DIFF
--- a/features/model_specs/errors_on.feature
+++ b/features/model_specs/errors_on.feature
@@ -10,7 +10,7 @@ Feature: errors_on
         validates_presence_of :name
 
         # In Rails 4, mass assignment protection is implemented on controllers
-        attr_accessible :name if Gem::Requirement.new('< 4').satisfied_by?(Gem::Version.new(::Rails.version.to_s))
+        attr_accessible :name if RSpec::Rails::Version.rails_version?('< 4.0.0.beta1')
 
         validates_length_of :name, :minimum => 10, :on => :publication
       end

--- a/features/support/rails_versions.rb
+++ b/features/support/rails_versions.rb
@@ -1,4 +1,4 @@
 Around "@unsupported-on-rails-3-0" do |scenario, block|
   require 'rails'
-  scenario.skip_invoke! if Gem::Requirement.new('~>3.0.0').satisfied_by?(Gem::Version.new(::Rails.version.to_s))
+  scenario.skip_invoke! if RSpec::Rails::Version.rails_version?('~>3.0.0')
 end

--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -7,7 +7,7 @@ module Rspec
         @_rspec_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'rspec', generator_name, 'templates'))
       end
 
-      if Gem::Requirement.new('< 3.1').satisfied_by?(Gem::Version.new(::Rails.version.to_s))
+      if RSpec::Rails::Version.rails_version?('< 3.1')
         def module_namespacing
           yield if block_given?
         end

--- a/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
+++ b/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
@@ -8,7 +8,7 @@ require 'rspec/autorun'
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
-<% if Gem::Requirement.new('>= 4.0.0.beta1').satisfied_by?(Gem::Version.new(::Rails.version.to_s)) -%>
+<% if RSpec::Rails::Version.rails_version?('>= 4.0.0.beta1') -%>
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -113,7 +113,7 @@ describe <%= controller_class_name %>Controller do
         # specifies that the <%= class_name %> created on the previous line
         # receives the :update_attributes message with whatever params are
         # submitted in the request.
-        <%- if Gem::Requirement.new('>= 4.0.0.beta1').satisfied_by?(Gem::Version.new(::Rails.version.to_s)) -%>
+        <%- if RSpec::Rails::Version.rails_version?('>= 4.0.0.beta1') -%>
         <%= class_name %>.any_instance.should_receive(:update).with(<%= formatted_hash(example_params_for_update) %>)
         <%- else -%>
         <%= class_name %>.any_instance.should_receive(:update_attributes).with(<%= formatted_hash(example_params_for_update) %>)

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -107,7 +107,7 @@ module RSpec::Rails
       end
 
       def _default_render_options
-        if Gem::Requirement.new('>= 3.2').satisfied_by?(Gem::Version.new(::Rails.version.to_s))
+        if RSpec::Rails::Version.rails_version?('>= 3.2')
           # pluck the handler, format, and locale out of, eg, posts/index.de.html.haml
           template, *components   = _default_file_to_render.split('.')
           handler, format, locale = *components.reverse

--- a/lib/rspec/rails/version.rb
+++ b/lib/rspec/rails/version.rb
@@ -2,6 +2,15 @@ module RSpec
   module Rails
     module Version
       STRING = '2.13.0'
+
+      def self.rails_version?(version)
+        current_version = if ::Rails.version.is_a?(Gem::Version)
+                            ::Rails.version
+                          else
+                            Gem::Version.new(::Rails.version.to_s)
+                          end
+        Gem::Requirement.new(version).satisfied_by?(current_version)
+      end
     end
   end
 end

--- a/spec/generators/rspec/install/install_generator_spec.rb
+++ b/spec/generators/rspec/install/install_generator_spec.rb
@@ -16,7 +16,7 @@ describe Rspec::Generators::InstallGenerator do
     File.read( file('spec/spec_helper.rb') ).should =~ /^require 'rspec\/autorun'$/m
   end
 
-  if Gem::Requirement.new('>= 4.0.0.beta1').satisfied_by?(Gem::Version.new(::Rails.version.to_s))
+  if RSpec::Rails::Version.rails_version?('>= 4.0.0.beta1')
     it "generates spec/spec_helper.rb with a check for pending migrations" do
       run_generator
       File.read( file('spec/spec_helper.rb') ).should =~ /ActiveRecord::Migration\.check_pending!/m

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -118,7 +118,7 @@ module RSpec::Rails
           view_spec.stub(:_default_file_to_render) { "widgets/new.en.html.erb" }
           view_spec.render
 
-          if Gem::Requirement.new('>= 3.2').satisfied_by?(Gem::Version.new(::Rails.version.to_s))
+          if RSpec::Rails::Version.rails_version?('>= 3.2')
             view_spec.received.first.should == [{:template => "widgets/new", :locales=>['en'], :formats=>['html'], :handlers=>['erb']}, {}, nil]
           else
             view_spec.received.first.should == [{:template => "widgets/new.en.html.erb"}, {}, nil]

--- a/spec/rspec/rails/matchers/relation_match_array_spec.rb
+++ b/spec/rspec/rails/matchers/relation_match_array_spec.rb
@@ -5,7 +5,7 @@ describe "ActiveSupport::Relation =~ matcher" do
 
   let!(:models) { Array.new(3) { MockableModel.create } }
 
-  if Gem::Requirement.new('>= 4.0.0.beta1').satisfied_by?(Gem::Version.new(Rails.version.to_s))
+  if RSpec::Rails::Version.rails_version?('>= 4.0.0.beta1')
     it "verifies that the scope returns the records on the right hand side, regardless of order" do
       MockableModel.all.should =~ models.reverse
     end


### PR DESCRIPTION
A proposal to centralize and simplify how rails version is checked instead os use directly the long line:
`Gem::Requirement.new('< 3.1').satisfied_by?(Gem::Version.new(::Rails.version.to_s))`

proposal: `RSpec::Rails::Version.rails_version?('< 3.1')`
