### PR TITLE
Fix spacing in install generator template

### DIFF
--- a/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
+++ b/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
@@ -6,7 +6,7 @@ require 'rspec/autorun'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 <% if Gem::Requirement.new('>= 4.0.0.beta1').satisfied_by?(Gem::Version.new(::Rails.version.to_s)) -%>
 # Checks for pending migrations before tests are run.


### PR DESCRIPTION
When I generated `spec_helper.rb` using this gem, I noticed really little things about spacing. It is really little thing and everyone might not care about it.

Thank you for great gem.
