### PR TITLE
Use backtrace_exclusion_patterns instead of backtrace_clean_patterns

### DIFF
--- a/lib/rspec/rails.rb
+++ b/lib/rspec/rails.rb
@@ -1,8 +1,8 @@
 require 'rspec/core'
 
 RSpec::configure do |c|
-  c.backtrace_clean_patterns << /vendor\//
-  c.backtrace_clean_patterns << /lib\/rspec\/rails/
+  c.backtrace_exclusion_patterns << /vendor\//
+  c.backtrace_exclusion_patterns << /lib\/rspec\/rails/
 end
 
 require 'rspec/rails/rails_version'


### PR DESCRIPTION
`backtrace_clean_patterns` is now deprecated, this uses the new
`backtrace_exclusion_patterns` method instead.
