### PR TITLE
Adding method check_pending to module RSpec

### DIFF
--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -11,4 +11,13 @@ module RSpec
       end
     end
   end
+
+  def self.check_pending
+    begin
+      ActiveRecord::Migration.check_pending!
+    rescue ActiveRecord::PendingMigrationError => error
+      puts "\e[31m#{error}\e[0m"
+      exit
+    end
+  end
 end


### PR DESCRIPTION
This is method is to replace the statement:

``` ruby
# Checks for pending migrations before tests are run.
# If you are not using ActiveRecord, you can remove this line.
ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
```

that goes into **spec_helper.rb**.

It should change to:

``` ruby
# Checks for pending migrations before tests are run.
# If you are not using ActiveRecord, you can remove this line.
RSpec::check_pending if defined?(ActiveRecord::Migration)
```

It shows a prettier message than rising a exception.
