### PR TITLE
Two small README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ spec](#feature-specs).
 
 ## <a id="request-spec"></a>Request Specs
 
-Request specs live in spec/requests, spec/api and spec/integration, and mix in behavior
+Request specs live in spec/requests, spec/features, spec/api and spec/integration, and mix in behavior
 [ActionDispatch::Integration::Runner](http://api.rubyonrails.org/classes/ActionDispatch/Integration/Runner.html),
 which is the basis for [Rails' integration
 tests](http://guides.rubyonrails.org/testing.html#integration-testing).  The
@@ -145,7 +145,9 @@ which can be encoded into the underlying factory definition without requiring
 changes to this example.
 
 Among other benefits, Capybara binds the form post to the generated HTML, which
-means we don't need to specify them separately.
+means we don't need to specify them separately.  Note that Capybara's DSL as
+shown is, by default, only available in specs in the spec/features directory.
+For more information, see the [Capybara integration docs](http://rubydoc.info/gems/rspec-rails/file/Capybara.md).
 
 There are several other Ruby libs that implement the factory pattern or provide
 a DSL for request specs (a.k.a. acceptance or integration specs), but


### PR DESCRIPTION
The first change fixes a small omission in the Controller spec example – response.code is a string, not a number, so it fails when you use eq(200).

The second change adds a link to the Capybara doc in the Request spec section, instead of only "hiding" in the rake customisation section.  I also added the explanation that the DSL is only available in spec/features by default, which is another thing I didn't find explained in the README; I was expecting the DSL to be available in the three directories outlined at the beginning of the section.  It may need a bit of work, but I tried to make it as clear as possible.
