### PR TITLE
Changing helper spec generator to use 'expect' syntax

### DIFF
--- a/lib/generators/rspec/helper/templates/helper_spec.rb
+++ b/lib/generators/rspec/helper/templates/helper_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 # describe <%= class_name %>Helper do
 #   describe "string concat" do
 #     it "concats two strings with spaces" do
-#       helper.concat_strings("this","that").should == "this that"
+#       expect(helper.concat_strings("this","that")).to eq("this that")
 #     end
 #   end
 # end


### PR DESCRIPTION
This is a minor change but for the sake of consistency, I changed the example spec given in all helper files to use 'expect' syntax instead of 'should'.

Thanks for providing such a great resource to the Rails community!
