### PR TITLE
Fix: Ensure rake task correctly identifies directories with specs in them

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -14,7 +14,10 @@ RSpec::Core::RakeTask.new(:spec => spec_prereq)
 
 namespace :spec do
   def types
-    dirs = Dir['./spec/**/*_spec.rb'].map { |f| f.sub(/^\.\/(spec\/\w+)\/.*/, '\\1') }.uniq
+    dirs = Dir['./spec/**/*_spec.rb'].
+      map { |f| f.sub(/^\.\/(spec\/\w+)\/.*/, '\\1') }.
+      uniq.
+      select { |f| Dir.exists?(f) }
     Hash[dirs.map { |d| [d.split('/').last, d] }]
   end
 


### PR DESCRIPTION
see https://github.com/metricfu/metric_fu/issues/57

It was returning files in the spec/ folder since it never checked if the `dirs` were directories

I don't see any tests for the rake task.  Where should I make one?

This was crashing the `rake stats` task in rails since when there is an e.g. `spec/paperclip_spec.rb` it would add the folders, e.g. `["spec/controllers", "spec/lib", "spec/models", "./spec/paperclip_spec.rb", "spec/validators"]` which obviously aren't all folders

Error message and stack trace for the googles

```
rake aborted!
Not a directory - ./spec/paperclip_spec.rb
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/railties-3.2.13/lib/rails/code_statistics.rb:32:in `open'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/railties-3.2.13/lib/rails/code_statistics.rb:32:in `foreach'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/railties-3.2.13/lib/rails/code_statistics.rb:32:in `calculate_directory_statistics'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/railties-3.2.13/lib/rails/code_statistics.rb:26:in `block in calculate_statistics'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/railties-3.2.13/lib/rails/code_statistics.rb:26:in `map'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/railties-3.2.13/lib/rails/code_statistics.rb:26:in `calculate_statistics'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/railties-3.2.13/lib/rails/code_statistics.rb:7:in `initialize'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/railties-3.2.13/lib/rails/tasks/statistics.rake:15:in `new'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/railties-3.2.13/lib/rails/tasks/statistics.rake:15:in `block in <top (required)>'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/rake-10.0.4/lib/rake/task.rb:246:in `call'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/rake-10.0.4/lib/rake/task.rb:246:in `block in execute'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/rake-10.0.4/lib/rake/task.rb:241:in `each'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/rake-10.0.4/lib/rake/task.rb:241:in `execute'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/rake-10.0.4/lib/rake/task.rb:184:in `block in invoke_with_call_chain'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/rake-10.0.4/lib/rake/task.rb:177:in `invoke_with_call_chain'
~/.rvm/gems/ruby-1.9.3-p385@mygemset/gems/rake-10.0.4/lib/rake/task.rb:170:in `invoke'
```
