### PR TITLE
Add documentation for how spec files are required/run.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,10 @@ Bug fixes
 * Code that checks Rails version numbers is more robust in cases where Rails is
   not fully loaded. (Andy Lindeman)
 
+Enhancements
+
+* Document how the spec/support directory works. (Sam Phippen)
+
 ### 2.13.1 / 2013-04-27
 [full changelog](http://github.com/rspec/rspec-rails/compare/v2.13.0...v2.13.1)
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,8 @@ Initialize the `spec/` directory (where specs will reside) with:
 rails generate rspec:install
 ```
 
-This adds the spec directory and some skeleton files, including the "rake spec"
-task. Any ruby file in `spec/support` will be included with `require`. All
-files in spec/ and subdirectories that end with `_spec.rb` will be run as
-specs.
+This adds `spec/spec_helper.rb` and `.rspec` files that are used for
+configuration. See those files for more information.
 
 To run your specs, use the `rspec` command:
 

--- a/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
+++ b/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
@@ -4,12 +4,13 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
 
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb`
-# are run as spec files by default. This means that files in spec/support that
-# end in _spec.rb will both be required and run as specs, causing the specs
-# to be run twice. It is recommended that you do not name files matching
-# this glob to end with _spec.rb.
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 <% if ::Rails::VERSION::STRING >= '4' -%>


### PR DESCRIPTION
This closes #623. @dchelimsky commented this was a documentation issue, so I've tried to document how spec/support works and how specs are run.
