### PR TITLE
Stop defining a method called `task` in rake task

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -13,13 +13,13 @@ desc "Run all specs in spec directory (excluding plugin specs)"
 RSpec::Core::RakeTask.new(:spec => spec_prereq)
 
 namespace :spec do
-  def types
-    dirs = Dir['./spec/**/*_spec.rb'].
-      map { |f| f.sub(/^\.\/(spec\/\w+)\/.*/, '\\1') }.
-      uniq.
-      select { |f| File.directory?(f) }
-    Hash[dirs.map { |d| [d.split('/').last, d] }]
-  end
+  types = begin
+            dirs = Dir['./spec/**/*_spec.rb'].
+              map { |f| f.sub(/^\.\/(spec\/\w+)\/.*/, '\\1') }.
+              uniq.
+              select { |f| File.directory?(f) }
+            Hash[dirs.map { |d| [d.split('/').last, d] }]
+          end
 
   types.each do |type, dir|
     desc "Run the code examples in #{dir}"


### PR DESCRIPTION
If rspec.rake is loaded, a library which uses `#method_missing` to catch the invocation of a method named `#types` won't work because `#types` is already defined in the task.

Let's say we have an app with a model which has a column called 'types'. It's factory will look like this:

``` ruby
FactoryGirl.define do
  factory :user do
    name "MyString"
    types "MyString"
  end
end
```

The invocation of `#types` method in the factory block expects to be caught by `#method_missing` in FactoryGirl, but when rspec.rake was loaded, `#types` in there will be invoked. 

This can be reproducible in this repo: https://github.com/fujimura/rspec_rails_with_factory_girl

And this is trace of a failed task.

```
$ bundle exec rake db:migrate --trace
** Invoke db:migrate (first_time)
** Invoke environment (first_time)
** Execute environment
rake aborted!
wrong number of arguments (1 for 0)
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rspec-rails-2.13.2/lib/rspec/rails/tasks/rspec.rake:16:in `types'
/Users/fujimura/sandbox/rspec_rails_with_factory_girl/spec/factories/users.rb:6:in `block (2 levels) in <top (required)>'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl-4.2.0/lib/factory_girl/syntax/default.rb:18:in `instance_eval'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl-4.2.0/lib/factory_girl/syntax/default.rb:18:in `factory'
/Users/fujimura/sandbox/rspec_rails_with_factory_girl/spec/factories/users.rb:4:in `block in <top (required)>'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl-4.2.0/lib/factory_girl/syntax/default.rb:49:in `instance_eval'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl-4.2.0/lib/factory_girl/syntax/default.rb:49:in `run'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl-4.2.0/lib/factory_girl/syntax/default.rb:7:in `define'
/Users/fujimura/sandbox/rspec_rails_with_factory_girl/spec/factories/users.rb:3:in `<top (required)>'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:245:in `load'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:245:in `block in load'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:236:in `load_dependency'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:245:in `load'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl-4.2.0/lib/factory_girl/find_definitions.rb:20:in `block (2 levels) in find_definitions'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl-4.2.0/lib/factory_girl/find_definitions.rb:19:in `each'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl-4.2.0/lib/factory_girl/find_definitions.rb:19:in `block in find_definitions'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl-4.2.0/lib/factory_girl/find_definitions.rb:15:in `each'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl-4.2.0/lib/factory_girl/find_definitions.rb:15:in `find_definitions'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/factory_girl_rails-4.2.1/lib/factory_girl_rails/railtie.rb:33:in `block in <class:Railtie>'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activesupport-3.2.13/lib/active_support/lazy_load_hooks.rb:34:in `call'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activesupport-3.2.13/lib/active_support/lazy_load_hooks.rb:34:in `execute_hook'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activesupport-3.2.13/lib/active_support/lazy_load_hooks.rb:43:in `block in run_load_hooks'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activesupport-3.2.13/lib/active_support/lazy_load_hooks.rb:42:in `each'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/activesupport-3.2.13/lib/active_support/lazy_load_hooks.rb:42:in `run_load_hooks'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/application/finisher.rb:59:in `block in <module:Finisher>'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/initializable.rb:30:in `instance_exec'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/initializable.rb:30:in `run'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/initializable.rb:55:in `block in run_initializers'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/initializable.rb:54:in `each'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/initializable.rb:54:in `run_initializers'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/application.rb:136:in `initialize!'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/railtie/configurable.rb:30:in `method_missing'
/Users/fujimura/sandbox/rspec_rails_with_factory_girl/config/environment.rb:5:in `<top (required)>'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/application.rb:103:in `require'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/application.rb:103:in `require_environment!'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/railties-3.2.13/lib/rails/application.rb:297:in `block (2 levels) in initialize_tasks'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:246:in `call'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:246:in `block in execute'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:241:in `each'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:241:in `execute'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:184:in `block in invoke_with_call_chain'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:177:in `invoke_with_call_chain'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:205:in `block in invoke_prerequisites'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:203:in `each'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:203:in `invoke_prerequisites'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:183:in `block in invoke_with_call_chain'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:177:in `invoke_with_call_chain'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/task.rb:170:in `invoke'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/application.rb:143:in `invoke_task'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/application.rb:101:in `block (2 levels) in top_level'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/application.rb:101:in `each'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/application.rb:101:in `block in top_level'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/application.rb:110:in `run_with_threads'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/application.rb:95:in `top_level'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/application.rb:73:in `block in run'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/application.rb:160:in `standard_exception_handling'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/lib/rake/application.rb:70:in `run'
/Users/fujimura/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/rake-10.0.4/bin/rake:33:in `<top (required)>'
/Users/fujimura/.rbenv/versions/2.0.0-p195/bin/rake:23:in `load'
/Users/fujimura/.rbenv/versions/2.0.0-p195/bin/rake:23:in `<main>'
Tasks: TOP => db:migrate => environment
```
