### PR TITLE
Add feature generator and include in list of available generators

### DIFF
--- a/features/Generators.md
+++ b/features/Generators.md
@@ -22,3 +22,4 @@ The same generator pattern is available for all specs:
 * mailer
 * observer
 * integration
+* feature

--- a/lib/generators/rspec/feature/feature_generator.rb
+++ b/lib/generators/rspec/feature/feature_generator.rb
@@ -1,0 +1,16 @@
+require 'generators/rspec'
+
+module Rspec
+  module Generators
+    class FeatureGenerator < Base
+      class_option :feature_specs, :type => :boolean, :default => true, :desc => "Generate feature specs"
+
+      def generate_feature_spec
+        return unless options[:feature_specs]
+
+        template 'feature_spec.rb', File.join('spec/features', class_path, "#{table_name}_spec.rb")
+      end
+    end
+  end
+end
+

--- a/lib/generators/rspec/feature/templates/feature_spec.rb
+++ b/lib/generators/rspec/feature/templates/feature_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+feature "<%= class_name.pluralize %>" do
+  pending "add some scenarios (or delete) #{__FILE__}"
+end
+

--- a/spec/generators/rspec/feature/feature_generator_spec.rb
+++ b/spec/generators/rspec/feature/feature_generator_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+# Generators are not automatically loaded by rails
+require 'generators/rspec/feature/feature_generator'
+
+describe Rspec::Generators::FeatureGenerator do
+  # Tell the generator where to put its output (what it thinks of as Rails.root)
+  destination File.expand_path("../../../../../temp", __FILE__)
+
+  before { prepare_destination } 
+
+  describe 'feature specs' do
+    describe 'are generated independently from the command line' do
+      before do
+        run_generator %w(posts)
+      end
+      describe 'the spec' do
+        subject { file('spec/features/posts_spec.rb') }
+        it { should exist }
+        it { should contain(/require 'spec_helper'/) }
+        it { should contain(/feature "Posts"/) }
+      end
+    end
+
+    describe "are not generated" do
+      before do
+        run_generator %w(posts --no-feature-specs)
+      end
+      describe "the spec" do
+        subject { file('spec/features/posts_spec.rb') }
+        it { should_not exist }
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
I used to generate integration/request specs all the time from the command line. However, with the changes to Capybara, the DSL is only available in feature specs. So I have switched to using feature specs. After submitting a PR on the generator documentation, I realized feature specs could not be generated like integration/request specs. I wrote a feature generator that can be invoked from the command line and want to contribute so anyone else can use the generator if they like. 
