### PR TITLE
Fix nokogiri dependency to 1.5.x for ruby 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,10 @@ if RUBY_VERSION < '1.9.3'
   gem 'capybara', '>= 2.0.0', '< 2.1.0'
 end
 
+if RUBY_VERSION < '1.9.2'
+  gem 'nokogiri', '~> 1.5.0'
+end
+
 custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)
 eval File.read(custom_gemfile) if File.exist?(custom_gemfile)
 


### PR DESCRIPTION
Nokogiri 1.6.0+ requires ruby >= `1.9.2` which breaks for the older versions of ruby in the CI build.
