### PR TITLE
Fix test:prepare launch to depend on the ActiveRecord 'defined?'

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -3,7 +3,7 @@ if default = Rake.application.instance_variable_get('@tasks')['default']
   default.prerequisites.delete('test')
 end
 
-spec_prereq = Rails.configuration.generators.options[:rails][:orm] == :active_record ?  "test:prepare" : :noop
+spec_prereq = defined?(ActiveRecord) ?  "test:prepare" : :noop
 task :noop do; end
 task :default => :spec
 


### PR DESCRIPTION
Fixes issue #794 in the same manner as in this old commit:

https://github.com/rspec/rspec-rails/commit/a5949a566862fa0ac2ec4148f52ea05cc64352a9
