### PR TITLE
Declare an activemodel dependency

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.require_path     = "lib"
 
   s.add_runtime_dependency(%q<activesupport>, [">= 3.0"])
+  s.add_runtime_dependency(%q<activemodel>, [">= 3.0"])
   s.add_runtime_dependency(%q<actionpack>, [">= 3.0"])
   s.add_runtime_dependency(%q<railties>, [">= 3.0"])
   %w[core expectations mocks].each do |name|


### PR DESCRIPTION
mocks.rb requires active_model, therefore it should be listed in the gemspec.
