### PR TITLE
Change some version checks to use ActiveRecord.

### DIFF
--- a/features/model_specs/errors_on.feature
+++ b/features/model_specs/errors_on.feature
@@ -10,7 +10,7 @@ Feature: errors_on
         validates_presence_of :name
 
         # In Rails 4, mass assignment protection is implemented on controllers
-        attr_accessible :name if ::Rails::VERSION::STRING < '4'
+        attr_accessible :name if ::ActiveRecord::VERSION::STRING < '4'
 
         validates_length_of :name, :minimum => 10, :on => :publication
       end

--- a/lib/rspec/rails/extensions/active_record/base.rb
+++ b/lib/rspec/rails/extensions/active_record/base.rb
@@ -10,7 +10,7 @@ module RSpec
           #     ModelClass.should have(:no).records
           #     ModelClass.should have(1).record
           #     ModelClass.should have(n).records
-          if ::Rails::VERSION::STRING >= '4'
+          if ::ActiveRecord::VERSION::STRING >= '4'
             def records
               all.to_a
             end

--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -4,7 +4,7 @@ module RSpec
       module FixtureSupport
         extend ActiveSupport::Concern
         include RSpec::Rails::SetupAndTeardownAdapter
-        include RSpec::Rails::MiniTestLifecycleAdapter if ::Rails::VERSION::STRING > '4'
+        include RSpec::Rails::MiniTestLifecycleAdapter if ::ActiveRecord::VERSION::STRING > '4'
         include RSpec::Rails::TestUnitAssertionAdapter
         include ActiveRecord::TestFixtures
 


### PR DESCRIPTION
Trying to use ActiveRecord fixtures in my tests for a gem that uses ActiveRecord, but doesn't depend on all of Rails. Currently rspec-rails makes some checks based on `::Rails::VERSION`.

This change uses `::ActiveRecord::VERSION` for those checks related to ActiveRecord fixtures, allowing fixtures to be used without including Rails.
