### PR TITLE
Change some version checks to use ActiveRecord.

### DIFF
--- a/features/model_specs/errors_on.feature
+++ b/features/model_specs/errors_on.feature
@@ -10,7 +10,7 @@ Feature: errors_on
         validates_presence_of :name
 
         # In Rails 4, mass assignment protection is implemented on controllers
-        attr_accessible :name if ::Rails::VERSION::STRING < '4'
+        attr_accessible :name if ::ActiveRecord::VERSION::STRING < '4'
 
         validates_length_of :name, :minimum => 10, :on => :publication
       end

--- a/lib/rspec/rails/extensions/active_record/base.rb
+++ b/lib/rspec/rails/extensions/active_record/base.rb
@@ -10,7 +10,7 @@ module RSpec
           #     ModelClass.should have(:no).records
           #     ModelClass.should have(1).record
           #     ModelClass.should have(n).records
-          if ::Rails::VERSION::STRING >= '4'
+          if ::ActiveRecord::VERSION::STRING >= '4'
             def records
               all.to_a
             end

--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -4,7 +4,7 @@ module RSpec
       module FixtureSupport
         extend ActiveSupport::Concern
         include RSpec::Rails::SetupAndTeardownAdapter
-        include RSpec::Rails::MiniTestLifecycleAdapter if ::Rails::VERSION::STRING > '4'
+        include RSpec::Rails::MiniTestLifecycleAdapter if ::ActiveRecord::VERSION::STRING > '4'
         include RSpec::Rails::TestUnitAssertionAdapter
         include ActiveRecord::TestFixtures
 


### PR DESCRIPTION
This allow using ActiveRecord fixtures without pulling in all of Rails.

(#804 rebased on top of current master so the tests have an opportunity to run green)
