### PR TITLE
Rails test framework is not fully set up before running group-specific before blocks

### DIFF
--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -101,7 +101,7 @@ module RSpec
         # hooks.
         def setup(*methods)
           methods.each do |method|
-            if method.to_s =~ /^setup_(fixtures|controller_request_and_response)$/
+            if method.to_s =~ /^setup_(with_controller|fixtures|controller_request_and_response)$/
               prepend_before { send method }
             else
               before         { send method }


### PR DESCRIPTION
Before blocks specific to view specs (and possibly controller specs) appear to run before the necessary Rails test framework setup methods.  For example:

``` ruby
RSpec.configure do |config|
  config.before(:each, type: :view) do
    view.lookup_context.prefixes << 'wibble'
  end
```

This will fail, because the @controller instance variable has not been set up by the test framework; this is done by the #setup_with_controller method, which has not yet been called.

It's not entirely clear to me why this changed between 2.10.x and 2.14.x, or the plan to manage this going forward.  I'm also not entirely clear how to write specs for this, since I don't know enough about Rspec internals to simulate running a before block from an example block.  However, this small change fixes the problem, and all existing specs pass.
