### PR TITLE
Use git dependencies for rspec gems (3.x)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,8 @@ gemspec
   library_path = File.expand_path("../../#{lib}", __FILE__)
   if File.exist?(library_path)
     gem lib, :path => library_path
-  elsif ENV["CI"] || ENV["USE_GIT_REPOS"]
-    gem lib, :git => "git://github.com/rspec/#{lib}.git"
   else
-    gem lib
+    gem lib, :git => "git://github.com/rspec/#{lib}.git"
   end
 end
 


### PR DESCRIPTION
The confusion in #816 is possibly caused by `rspec-rails` not following the other gems convention and using git dependencies as the default fallback when there aren't local copies of Gems. Perhaps it'd be an idea to fallback to git dependencies for 3.x until we're ready to release it?
