### PR TITLE
Switch have support to use the extracted gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-%w[rspec rspec-core rspec-expectations rspec-mocks].each do |lib|
+%w[rspec rspec-core rspec-expectations rspec-mocks rspec-collection_matchers].each do |lib|
   library_path = File.expand_path("../../#{lib}", __FILE__)
   if File.exist?(library_path)
     gem lib, :path => library_path

--- a/lib/rspec/rails/matchers/have_extension.rb
+++ b/lib/rspec/rails/matchers/have_extension.rb
@@ -1,5 +1,5 @@
 require 'active_support/core_ext/module/aliasing'
-require 'rspec/matchers/built_in/have'
+require 'rspec/collection_matchers'
 
 module RSpec::Rails::Matchers
   module HaveExtensions
@@ -30,6 +30,6 @@ module RSpec::Rails::Matchers
   end
 end
 
-RSpec::Matchers::BuiltIn::Have.class_eval do
+RSpec::CollectionMatchers::Have.class_eval do
   include RSpec::Rails::Matchers::HaveExtensions
 end

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -21,10 +21,11 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.require_path     = "lib"
 
-  s.add_runtime_dependency(%q<activesupport>, [">= 3.0"])
-  s.add_runtime_dependency(%q<activemodel>, [">= 3.0"])
-  s.add_runtime_dependency(%q<actionpack>, [">= 3.0"])
-  s.add_runtime_dependency(%q<railties>, [">= 3.0"])
+  s.add_runtime_dependency "activesupport", ">= 3.0"
+  s.add_runtime_dependency "activemodel",   ">= 3.0"
+  s.add_runtime_dependency "actionpack",    ">= 3.0"
+  s.add_runtime_dependency "railties",      ">= 3.0"
+
   %w[core expectations mocks].each do |name|
     if RSpec::Rails::Version::STRING =~ /[a-zA-Z]+/ # prerelease builds
       s.add_runtime_dependency "rspec-#{name}", "= #{RSpec::Rails::Version::STRING}"
@@ -32,6 +33,7 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency "rspec-#{name}", "~> #{RSpec::Rails::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
     end
   end
+  s.add_runtime_dependency "rspec-collection_matchers"
 
   s.add_development_dependency 'rake',     '~> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.3.5'


### PR DESCRIPTION
We extracted the `have(n)` etc matchers to a seperate gem, use that in `rspec-rails` 3.x
