### PR TITLE
Remove deprecated  from spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,6 @@ end
 RSpec.configure do |config|
   real_world = nil
 
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
   config.before(:each) do


### PR DESCRIPTION
Removed a line from the `spec/spec_helper.rb` causing a deprecation warning.
