### PR TITLE
Sync up matchers to new method names

### DIFF
--- a/lib/rspec/rails/matchers/be_a_new.rb
+++ b/lib/rspec/rails/matchers/be_a_new.rb
@@ -25,7 +25,7 @@ module RSpec::Rails::Matchers
     end
 
     # @api private
-    def failure_message_for_should
+    def failure_message
       [].tap do |message|
         unless actual.is_a?(expected) && actual.new_record?
           message << "expected #{actual.inspect} to be a new #{expected.inspect}"

--- a/lib/rspec/rails/matchers/be_new_record.rb
+++ b/lib/rspec/rails/matchers/be_new_record.rb
@@ -6,11 +6,11 @@ module RSpec::Rails::Matchers
       !actual.persisted?
     end
 
-    def failure_message_for_should
+    def failure_message
       "expected #{actual.inspect} to be a new record, but was persisted"
     end
 
-    def failure_message_for_should_not
+    def failure_message_when_negated
       "expected #{actual.inspect} to be persisted, but was a new record"
     end
   end

--- a/lib/rspec/rails/matchers/be_valid.rb
+++ b/lib/rspec/rails/matchers/be_valid.rb
@@ -11,7 +11,7 @@ module RSpec::Rails::Matchers
     end
 
     # @api private
-    def failure_message_for_should
+    def failure_message
       message = "expected #{actual.inspect} to be valid"
 
       if actual.respond_to?(:errors)
@@ -28,7 +28,7 @@ module RSpec::Rails::Matchers
     end
 
     # @api private
-    def failure_message_for_should_not
+    def failure_message_when_negated
       "expected #{actual.inspect} not to be valid"
     end
   end

--- a/lib/rspec/rails/matchers/have_rendered.rb
+++ b/lib/rspec/rails/matchers/have_rendered.rb
@@ -16,12 +16,12 @@ module RSpec::Rails::Matchers
       end
 
       # @api private
-      def failure_message_for_should
+      def failure_message
         rescued_exception.message
       end
 
       # @api private
-      def failure_message_for_should_not
+      def failure_message_when_negated
         "expected not to render #{expected.inspect}, but did"
       end
     end

--- a/lib/rspec/rails/matchers/redirect_to.rb
+++ b/lib/rspec/rails/matchers/redirect_to.rb
@@ -15,12 +15,12 @@ module RSpec::Rails::Matchers
       end
 
       # @api private
-      def failure_message_for_should
+      def failure_message
         rescued_exception.message
       end
 
       # @api private
-      def failure_message_for_should_not
+      def failure_message_when_negated
         "expected not to redirect to #{@expected.inspect}, but did"
       end
     end

--- a/lib/rspec/rails/matchers/routing_matchers.rb
+++ b/lib/rspec/rails/matchers/routing_matchers.rb
@@ -31,7 +31,7 @@ module RSpec::Rails::Matchers
       end
 
       # @api private
-      def failure_message_for_should
+      def failure_message
         rescued_exception.message
       end
 
@@ -73,11 +73,11 @@ module RSpec::Rails::Matchers
         end
       end
 
-      def failure_message_for_should
+      def failure_message
         "expected #{@actual.inspect} to be routable"
       end
 
-      def failure_message_for_should_not
+      def failure_message_when_negated
         "expected #{@actual.inspect} not to be routable, but it routes to #{@routing_options.inspect}"
       end
     end


### PR DESCRIPTION
The builds were failing based on the rename of some of the base matcher methods. I believe this fixes that.

Related to: https://github.com/rspec/rspec-expectations/issues/270
