### PR TITLE
clear cached templates between specs

### DIFF
--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -152,6 +152,9 @@ module RSpec::Rails
           view.lookup_context.prefixes << _controller_path
         end
 
+        # fixes bug with differing formats
+        view.lookup_context.view_paths.each(&:clear_cache)
+
         controller.controller_path = _controller_path
         controller.request.path_parameters[:controller] = _controller_path
         controller.request.path_parameters[:action]     = _inferred_action unless _inferred_action =~ /^_/


### PR DESCRIPTION
One of our cukes was failing because Rails caches templates and the differing
format seems not to be enough to invalidate it automatically, I'm going to
open a Rails patch for this but in the mean time this fixes that cuke.
