### PR TITLE
Fix fixtures documentation link on YAML template.

### DIFF
--- a/lib/generators/rspec/model/templates/fixtures.yml
+++ b/lib/generators/rspec/model/templates/fixtures.yml
@@ -1,4 +1,4 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 <% unless attributes.empty? -%>
 one:

--- a/spec/generators/rspec/model/model_generator_spec.rb
+++ b/spec/generators/rspec/model/model_generator_spec.rb
@@ -33,7 +33,7 @@ describe Rspec::Generators::ModelGenerator do
       describe 'the fixtures' do
         subject { file('spec/fixtures/posts.yml') }
 
-        it { is_expected.to contain(Regexp.new('# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html')) }
+        it { is_expected.to contain(Regexp.new('# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html')) }
       end
     end
 


### PR DESCRIPTION
`ActiveRecord::Fixtures` was deprecated and the documentation now lives
in a different URL.
