### PR TITLE
Respond to controller name

### DIFF
--- a/features/controller_specs/anonymous_controller.feature
+++ b/features/controller_specs/anonymous_controller.feature
@@ -122,37 +122,34 @@ Feature: anonymous controller
 
   Scenario: get name and controller_name from the described class
     Given a file named "spec/controllers/get_name_and_controller_name_from_described_class_spec.rb" with:
-      """ruby
-      require "spec_helper"
+    """ruby
+    require "spec_helper"
 
-      class ApplicationController < ActionController::Base; end
-      class FoosController < ApplicationController; end
+    class ApplicationController < ActionController::Base; end
+    class FoosController < ApplicationController; end
 
-      describe "FoosController controller_name" do
-        controller FoosController do        
-          def index
-            @name = self.class.name
-            @controller_name = controller_name
-            render :text => "Hello World"
-          end
+    describe "FoosController controller_name" do
+      controller FoosController do        
+        def index
+          @name = self.class.name
+          @controller_name = controller_name
+          render :text => "Hello World"
         end
-
-        before do
-          get :index
-        end
-
-        it "get the class name as described" do
-          expect(assigns[:name]).to eq('FoosController')
-        end
-
-        it "get the controller_name as described" do
-          expect(assigns[:controller_name]).to eq('foos')
-        end
-        
       end
 
-      """
+      before do
+        get :index
+      end
 
+      it "gets the class name as described" do
+        expect(assigns[:name]).to eq('FoosController')
+      end
+
+      it "gets the controller_name as described" do
+        expect(assigns[:controller_name]).to eq('foos')
+      end
+    end
+    """
     When I run `rspec spec`
     Then the examples should all pass
 

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -70,9 +70,10 @@ module RSpec::Rails
         orig_routes = nil
         before do
           orig_routes = self.routes
-          resource_name = self.instance_variable_get("@controller").controller_name
+          resource_name = @controller.respond_to?(:controller_name) ?
+            @controller.controller_name.to_sym : :anonymous
           self.routes  = ActionDispatch::Routing::RouteSet.new.tap { |r|
-            r.draw { resources :"#{resource_name}" }
+            r.draw { resources resource_name }
           }
         end
 

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -95,26 +95,26 @@ module RSpec::Rails
         controller_class = group.metadata[:example_group][:described_class]
         expect(controller_class.superclass).to eq(ApplicationController)
       end
-
     end
 
     describe "controller name" do
+      let(:controller_class) { group.metadata[:example_group][:described_class]}
 
       it "sets the name as AnonymousController if it's anonymous" do
         group.controller { }
-        controller_class = group.metadata[:example_group][:described_class]
         expect(controller_class.name).to eq "AnonymousController"
       end
 
       it "sets the name according to defined controller if it is not anonymous" do
-        class ::FoosController < ::ApplicationController; end;
-        group.controller(::FoosController){ }
-        controller_class = group.metadata[:example_group][:described_class]
+        stub_const "FoosController", Class.new(::ApplicationController)
+        group.controller(FoosController){ }
         expect(controller_class.name).to eq "FoosController"
-        Object.send(:remove_const, :FoosController)
       end
 
+      it "sets name as AnonymousController if defined as ApplicationController" do
+        group.controller(ApplicationController){ }
+        expect(controller_class.name).to eq "AnonymousController"
+      end
     end
-
   end
 end


### PR DESCRIPTION
When using named controller like `controller FoosController do`,  `#controller_name` method and routes drawn will refer to this name instead of anonymous one.

About #884.
