### PR TITLE
Default infer_base_class_for_anonymous_controllers to true

### DIFF
--- a/features/controller_specs/anonymous_controller.feature
+++ b/features/controller_specs/anonymous_controller.feature
@@ -1,23 +1,23 @@
 Feature: anonymous controller
 
-  Use the `controller` method to define an anonymous controller derived from
-  `ApplicationController`. This is useful for specifying behavior like global
-  error handling.
+  Use the `controller` method to define an anonymous controller
+  that will inherit from the described class. This is useful for
+  specifying behavior like global error handling.
 
-  To specify a different base class, you can pass the class explicitly to the
-  controller method:
+  To specify a different base class you can pass the class explicitly
+  to the controller method:
 
       controller(BaseController)
 
-  You can also configure RSpec to use the described class:
+  You can disable base type inference:
 
-      RSpec.configure do |c|
-        c.infer_base_class_for_anonymous_controllers = true
+      Rspec.configure do |c|
+        c.infer_base_class_for_anonymous_controllers = false
       end
 
       describe BaseController do
         controller { ... }
-        # ^^ creates an anonymous subclass of `BaseController`
+        # ^^ creates an anonymous subclass of `ApplicationController`
 
   Scenario: specify error handling in ApplicationController
     Given a file named "spec/controllers/application_controller_spec.rb" with:
@@ -96,10 +96,6 @@ Feature: anonymous controller
     Given a file named "spec/controllers/base_class_can_be_inferred_spec.rb" with:
       """ruby
       require "spec_helper"
-
-      RSpec.configure do |c|
-        c.infer_base_class_for_anonymous_controllers = true
-      end
 
       class ApplicationController < ActionController::Base; end
 

--- a/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
+++ b/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
@@ -35,10 +35,9 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  # If true, the base class of anonymous controllers will be inferred
-  # automatically. This will be the default behavior in future versions of
-  # rspec-rails.
-  config.infer_base_class_for_anonymous_controllers = false
+  # If false, the base class of anonymous controllers will not be inferred
+  # automatically.
+  # config.infer_base_class_for_anonymous_controllers = true
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
-  config.add_setting :infer_base_class_for_anonymous_controllers, :default => false
+  config.add_setting :infer_base_class_for_anonymous_controllers, :default => true
 end
 
 module RSpec::Rails

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -80,6 +80,10 @@ module RSpec::Rails
         allow(group).to receive(:controller_class).and_return(Class.new)
       end
 
+      it "defaults to inferring anonymous controller class" do
+        expect(RSpec.configuration.infer_base_class_for_anonymous_controllers).to be_truthy
+      end
+
       it "infers the anonymous controller class when infer_base_class_for_anonymous_controllers is true" do
         allow(RSpec.configuration).to receive(:infer_base_class_for_anonymous_controllers?).and_return(true)
         group.controller { }


### PR DESCRIPTION
For RSpec 3 this option should now default to true. Updated
the config value setting and the spec_helper generator template
to instead indicate the default value with the line to set it
commented out.

Fixes #869
