### PR TITLE
Deprecate `mock_model` and `stub_model`

### DIFF
--- a/lib/rspec/rails.rb
+++ b/lib/rspec/rails.rb
@@ -11,6 +11,9 @@ require 'rspec/rails/view_rendering'
 require 'rspec/rails/adapters'
 require 'rspec/rails/matchers'
 require 'rspec/rails/fixture_support'
+
+# Load rspec-activemodel-mocks if available; otherwise fall back
+# to the deprecated mock methods
 require 'rspec/rails/mocks'
 require 'rspec/rails/module_inclusion'
 require 'rspec/rails/example'

--- a/lib/rspec/rails/mocks.rb
+++ b/lib/rspec/rails/mocks.rb
@@ -1,4 +1,5 @@
 require 'active_support'
+require 'active_support/deprecation'
 require 'active_support/core_ext'
 require 'active_model'
 
@@ -86,12 +87,13 @@ module RSpec
       #   * A String representing a Class that extends ActiveModel::Naming
       #   * A Class that extends ActiveModel::Naming
       def mock_model(string_or_model_class, stubs = {})
+        RSpec.deprecate("`mock_model`", :replacement => "the `rspec-activemodel-mocks` gem")
         if String === string_or_model_class
           if Object.const_defined?(string_or_model_class)
             model_class = Object.const_get(string_or_model_class)
           else
             model_class = Object.const_set(string_or_model_class, Class.new do
-              extend ActiveModel::Naming
+              extend ::ActiveModel::Naming
               def self.primary_key; :id; end
             end)
           end
@@ -99,7 +101,7 @@ module RSpec
           model_class = string_or_model_class
         end
 
-        unless model_class.kind_of? ActiveModel::Naming
+        unless model_class.kind_of? ::ActiveModel::Naming
           raise ArgumentError.new <<-EOM
 The mock_model method can only accept as its first argument:
   * A String representing a Class that does not exist
@@ -121,8 +123,8 @@ EOM
           m.singleton_class.class_eval do
             include ActiveModelInstanceMethods
             include ActiveRecordInstanceMethods if defined?(ActiveRecord)
-            include ActiveModel::Conversion
-            include ActiveModel::Validations
+            include ::ActiveModel::Conversion
+            include ::ActiveModel::Validations
           end
           if defined?(ActiveRecord)
             [:save, :update_attributes, :update].each do |key|
@@ -229,6 +231,7 @@ EOM
       #     stub_model(Person, :to_param => 37)
       #     stub_model(Person) {|person| person.first_name = "David"}
       def stub_model(model_class, stubs={})
+        RSpec.deprecate("`stub_model`", :replacement => "the `rspec-activemodel-mocks` gem")
         model_class.new.tap do |m|
           m.extend ActiveModelStubExtensions
           if defined?(ActiveRecord) && model_class < ActiveRecord::Base
@@ -266,4 +269,12 @@ EOM
   end
 end
 
-RSpec.configuration.include RSpec::Rails::Mocks
+# We need to check if rspec-activemodel-mocks is in use on this side due
+# to Rails defaults. Because rspec-activemodel-mocks does not depend on
+# rspec-rails, bundler is likely to require rspec-activemodel-mocks before
+# rspec-rails when Bundler.require is performed. This will result in the
+# user still getting a deprecation message even when they are doing
+# everything right.
+unless defined?(RSpec::ActiveModel::Mocks::Mocks)
+  RSpec.configuration.include RSpec::Rails::Mocks
+end

--- a/spec/rspec/rails/deprecations_spec.rb
+++ b/spec/rspec/rails/deprecations_spec.rb
@@ -10,8 +10,26 @@ describe "rspec-rails-2 deprecations" do
       end
 
       it "is deprecated" do
-        expect(RSpec).to receive(:deprecate)
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)
         group.integrate_views
+      end
+    end
+  end
+
+  context "activemodel mocking" do
+    describe "mock_model" do
+      let(:model_class) { NonActiveRecordModel }
+      it "is deprecated" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)
+        mock_model(model_class)
+      end
+    end
+
+    describe "stub_model" do
+     let(:model_class) { MockableModel }
+     it "is deprecated" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)
+        stub_model(model_class)
       end
     end
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -30,5 +30,11 @@ module Helpers
     RSpec.configuration = original_config
   end
 
+  def expect_deprecation_with_call_site(file, line)
+    expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
+      expect(options[:call_site]).to include([file, line].join(':'))
+    end
+  end
+
   RSpec.configure {|c| c.include self}
 end


### PR DESCRIPTION
For rspec/rspec-rails#894
