### PR TITLE
Make rspec-collection_matchers runtime requirement on 2.99 too

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency "rspec-#{name}", "~> #{RSpec::Rails::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
     end
   end
+  s.add_runtime_dependency "rspec-collection_matchers"
 
   s.add_development_dependency 'rake',     '~> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.3.5'


### PR DESCRIPTION
It's already a requirement on 3.x, leaving it off causes confusion for upgraders... (see #929 #933)
