### PR TITLE
Require `rspec/collection_matchers` by default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Bug fixes
 * Loads ActiveSupport properly to support changes in Rails 4.1. (Andy Lindeman)
 * Anonymous controllers inherit from `ActionController::Base` if `ApplicationController`
   is not present. (Jon Rowe)
+* Require `rspec/collection_matchers` when `rspec/rails` is required. (Yuji Nakayama)
 
 Enhancements
 

--- a/lib/rspec/rails.rb
+++ b/lib/rspec/rails.rb
@@ -1,4 +1,5 @@
 require 'rspec/core'
+require 'rspec/collection_matchers'
 
 RSpec::configure do |c|
   c.backtrace_exclusion_patterns << /vendor\//

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'rspec/collection_matchers'
 require 'rails/all'
 
 module RSpecRails


### PR DESCRIPTION
Currently `rspec-collection_matchers` gem is specified as a runtime dependency but it's not loaded, so `have(...).error_on(...)` fails as the following:

```
     Failure/Error: it { should have(1).error_on(:name) }
     NoMethodError:
       undefined method `have' for #<RSpec::ExampleGroups::User_2::Name::WhenNameIsNotPresent:0x007fc3d72a3648>
```

I think `2-99-maintenance` branch also needs to require it to suppress the deprecation warning.
