### PR TITLE
Fix scaffold view generator templates for reference attributes

### DIFF
--- a/lib/generators/rspec/scaffold/templates/edit_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/edit_spec.rb
@@ -15,7 +15,8 @@ describe "<%= ns_table_name %>/edit" do
 
     assert_select "form[action=?][method=?]", <%= ns_file_name %>_path(@<%= ns_file_name %>), "post" do
 <% for attribute in output_attributes -%>
-      assert_select "<%= attribute.input_type -%>#<%= ns_file_name %>_<%= attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>[name=?]", "<%= ns_file_name %>[<%= attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>]"
+      <%- name = attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>
+      assert_select "<%= attribute.input_type -%>#<%= ns_file_name %>_<%= name %>[name=?]", "<%= ns_file_name %>[<%= name %>]"
 <% end -%>
     end
   end

--- a/lib/generators/rspec/scaffold/templates/new_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/new_spec.rb
@@ -14,7 +14,8 @@ describe "<%= ns_table_name %>/new" do
 
     assert_select "form[action=?][method=?]", <%= index_helper %>_path, "post" do
 <% for attribute in output_attributes -%>
-      assert_select "<%= attribute.input_type -%>#<%= ns_file_name %>_<%= attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>[name=?]", "<%= ns_file_name %>[<%= attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>]"
+      <%- name = attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>
+      assert_select "<%= attribute.input_type -%>#<%= ns_file_name %>_<%= name %>[name=?]", "<%= ns_file_name %>[<%= name %>]"
 <% end -%>
     end
   end

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'rubygems'
 
 require 'generators/rspec/scaffold/scaffold_generator'
 
@@ -73,7 +72,7 @@ describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
       end
     end
 
-    if ENV['RAILS_VERSION'] && Gem::Version.new(ENV['RAILS_VERSION']) >= Gem::Version.new('4.0.0')
+    if Rails.version.to_f >= 4.0
       describe 'with reference attribute' do
         before { run_generator %w(posts title:string author:references) }
         describe 'edit' do


### PR DESCRIPTION
Rails generates field with an `_id` suffix for reference attributes, see
https://github.com/rails/rails/blob/master/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb#L24-L30

This commit should fix this case by using `attribute.column_name` instead of
`attribute.name` as used by the Rails generator template.
