### PR TITLE
be_a_new matcher matches based on new_record?, not persisted?

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ expect(object).to be_a_new(Widget)
 ```
 
 
-Passes if the object is a `Widget` and returns true for `new_record?`
+Passes if the object is a `Widget` and returns false for `persisted?`
 
 ## `render_template`
 * Delegates to Rails' assert_template.

--- a/lib/rspec/rails/matchers/be_a_new.rb
+++ b/lib/rspec/rails/matchers/be_a_new.rb
@@ -8,7 +8,7 @@ module RSpec::Rails::Matchers
     # @api private
     def matches?(actual)
       @actual = actual
-      actual.is_a?(expected) && actual.new_record? && attributes_match?(actual)
+      actual.is_a?(expected) && !actual.persisted? && attributes_match?(actual)
     end
 
     # Use this to specify the specific attributes to match on the new record.
@@ -27,7 +27,7 @@ module RSpec::Rails::Matchers
     # @api private
     def failure_message
       [].tap do |message|
-        unless actual.is_a?(expected) && actual.new_record?
+        unless actual.is_a?(expected) && !actual.persisted?
           message << "expected #{actual.inspect} to be a new #{expected.inspect}"
         end
         unless attributes_match?(actual)

--- a/spec/rspec/rails/matchers/be_a_new_spec.rb
+++ b/spec/rspec/rails/matchers/be_a_new_spec.rb
@@ -6,7 +6,7 @@ describe "be_a_new matcher" do
   context "new record" do
     let(:record) do
       Class.new do
-        def new_record?; true; end
+        def persisted?; false; end
       end.new
     end
     context "right class" do
@@ -24,7 +24,7 @@ describe "be_a_new matcher" do
   context "existing record" do
     let(:record) do
       Class.new do
-        def new_record?; false; end
+        def persisted?; true; end
       end.new
     end
     context "right class" do
@@ -51,7 +51,7 @@ describe "be_a_new matcher" do
             @attributes.stringify_keys
           end
 
-          def new_record?; true; end
+          def persisted?; false; end
         end.new(:foo => 'foo', :bar => 'bar')
       end
 
@@ -101,7 +101,7 @@ describe "be_a_new matcher" do
             @attributes.stringify_keys
           end
 
-          def new_record?; false; end
+          def persisted?; true; end
         end.new(:foo => 'foo', :bar => 'bar')
       end
 


### PR DESCRIPTION
This behavior is inconsistent with the comments, but not with the README. Personally I prefer `persisted?` because it is implemented by both ActiveModel and ActiveRecord, as opposed to `new_record?`, which is only available in ActiveRecord to my knowledge.

If this is by design, it would be good to update the comments to reflect that.
