### PR TITLE
don't try to run rake db:test:prepare if it isn't defined

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -3,7 +3,13 @@ if default = Rake.application.instance_variable_get('@tasks')['default']
   default.prerequisites.delete('test')
 end
 
-spec_prereq = Rails.configuration.generators.options[:rails][:orm] == :active_record ?  "test:prepare" : :noop
+if Rails.configuration.generators.options[:rails][:orm] == :active_record &&
+  Rake::Task.task_defined?("test:prepare")
+  spec_prereq = "test:prepare"
+else
+  spec_prereq = :noop
+end
+
 task :noop do; end
 task :default => :spec
 


### PR DESCRIPTION
Possibly fixes #936

This at least gets rake spec to run for me.  I don't know enough about the internals of rspec-rails to have confidence that it will work for everyone.
