### PR TITLE
Ensure a consistent require order of support files

### DIFF
--- a/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
+++ b/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
@@ -10,7 +10,7 @@ require 'rspec/rails'
 # run twice. It is recommended that you do not name files matching this glob to
 # end with _spec.rb. You can configure this pattern with with the --pattern
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 <% if ::Rails::VERSION::STRING >= '4' -%>
 # Checks for pending migrations before tests are run.


### PR DESCRIPTION
Sort the array of support files before requiring them to ensure a consistent require order between operating systems.
