### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rspec-rails [![Build Status](https://secure.travis-ci.org/rspec/rspec-rails.png?branch=master)](http://travis-ci.org/rspec/rspec-rails) [![Code Climate](https://codeclimate.com/github/rspec/rspec-rails.png)](https://codeclimate.com/github/rspec/rspec-rails)
+# rspec-rails [![Build Status](https://secure.travis-ci.org/rspec/rspec-rails.png?branch=master)](http://travis-ci.org/rspec/rspec-rails) [![Code Climate](https://codeclimate.com/github/rspec/rspec-rails.png)](https://codeclimate.com/github/rspec/rspec-rails) [![Inline docs](http://inch-pages.github.io/github/rspec/rspec-rails.png)](http://inch-pages.github.io/github/rspec/rspec-rails)
 
 **rspec-rails** is a testing framework for Rails 3.x and 4.x.
 


### PR DESCRIPTION
I just added the badge @soulcutter requested to the README: ![Inline docs](http://inch-pages.github.io/github/rspec/rspec-rails.png)

Your status page for this project is http://inch-pages.github.io/github/rspec/rspec-rails

Thanks for giving this a shot!
