### PR TITLE
Make filetype infer opt-in

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,10 @@ Breaking Changes for 3.0.0:
 
 * Extracts the `mock_model` and `stub_model` methods to the
   `rspec-activemodel-mocks` gem. (Thomas Holmes)
+* Spec types are no longer inferred by location, they instead need to be
+  explicitly tagged. The old behaviour is enabled by
+  `config.infer_spec_type_from_file_location!`, which is still supplied
+  in the default generated `spec_helper.rb`. (Xavier Shay)
 
 ### 3.0.0.beta2 / 2014-02-17
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.0.0.beta1...v3.0.0.beta2)

--- a/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
+++ b/lib/generators/rspec/install/templates/spec/spec_helper.rb.tt
@@ -45,4 +45,19 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = "random"
+
+  # RSpec Rails can automatically mix in different behaviours to your tests
+  # based on their file location, for example enabling you to call `get` and
+  # `post` in specs under `spec/controllers`.
+  #
+  # You can disable this behaviour by removing the line below, and instead
+  # explictly tag your specs with their type, e.g.:
+  #
+  #     describe UsersController, :type => :controller do
+  #       # ...
+  #     end
+  #
+  # The different available types are documented in the features, such as in
+  # https://relishapp.com/rspec/rspec-rails/v/3-0/docs
+  config.infer_spec_type_from_file_location!
 end

--- a/lib/rspec/rails/example.rb
+++ b/lib/rspec/rails/example.rb
@@ -7,3 +7,5 @@ require 'rspec/rails/example/mailer_example_group'
 require 'rspec/rails/example/routing_example_group'
 require 'rspec/rails/example/model_example_group'
 require 'rspec/rails/example/feature_example_group'
+
+require 'rspec/rails/infer_type_configuration'

--- a/lib/rspec/rails/infer_type_configuration.rb
+++ b/lib/rspec/rails/infer_type_configuration.rb
@@ -1,0 +1,65 @@
+RSpec.configure do |config|
+  def config.infer_spec_type_from_file_location!
+    def self.escaped_path(*parts)
+      Regexp.compile(parts.join('[\\\/]') + '[\\\/]')
+    end
+
+    controller_path_regex = self.escaped_path(%w[spec controllers])
+    self.include RSpec::Rails::ControllerExampleGroup,
+      :type          => :controller,
+      :file_path     => lambda { |file_path, metadata|
+        metadata[:type].nil? && controller_path_regex =~ file_path
+      }
+
+    helper_path_regex = self.escaped_path(%w[spec helpers])
+    self.include RSpec::Rails::HelperExampleGroup,
+      :type          => :helper,
+      :file_path     => lambda { |file_path, metadata|
+        metadata[:type].nil? && helper_path_regex =~ file_path
+      }
+
+    mailer_path_regex = self.escaped_path(%w[spec mailers])
+    if defined?(RSpec::Rails::MailerExampleGroup)
+      self.include RSpec::Rails::MailerExampleGroup,
+        :type          => :mailer,
+        :file_path     => lambda { |file_path, metadata|
+          metadata[:type].nil? && mailer_path_regex =~ file_path
+        }
+    end
+
+    model_path_regex = self.escaped_path(%w[spec models])
+    self.include RSpec::Rails::ModelExampleGroup,
+      :type          => :model,
+      :file_path     => lambda { |file_path, metadata|
+        metadata[:type].nil? && model_path_regex =~ file_path
+      }
+
+    request_path_regex = self.escaped_path(%w[spec (requests|integration|api)])
+    self.include RSpec::Rails::RequestExampleGroup,
+      :type          => :request,
+      :file_path     => lambda { |file_path, metadata|
+        metadata[:type].nil? && request_path_regex =~ file_path
+      }
+
+    routing_path_regex = self.escaped_path(%w[spec routing])
+    self.include RSpec::Rails::RoutingExampleGroup,
+      :type          => :routing,
+      :file_path     => lambda { |file_path, metadata|
+        metadata[:type].nil? && routing_path_regex =~ file_path
+      }
+
+    view_path_regex = self.escaped_path(%w[spec views])
+    self.include RSpec::Rails::ViewExampleGroup,
+      :type          => :view,
+      :file_path     => lambda { |file_path, metadata|
+        metadata[:type].nil? && view_path_regex =~ file_path
+      }
+
+    feature_example_regex = self.escaped_path(%w[spec features])
+    self.include RSpec::Rails::FeatureExampleGroup,
+      :type          => :feature,
+      :file_path     => lambda { |file_path, metadata|
+        metadata[:type].nil? && feature_example_regex =~ file_path
+      }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,4 +36,6 @@ RSpec.configure do |config|
   config.after(:each) do
     RSpec.instance_variable_set(:@world, real_world)
   end
+
+  config.infer_spec_type_from_file_location!
 end


### PR DESCRIPTION
(Re-issue of https://github.com/rspec/rspec-rails/pull/967 against master)

Begins to address #662 
- Configuration is a bang method rather than a setting, because we don't have a public API for "un-including" modules.
- As a result there is no way to make this "opt-out" without requiring a breaking change to config.
- Newly generated `spec_helper.rb` will opt-in, with an explanatory comment.

**DO NOT MERGE:** Needs a 2.99 deprecation.

@alindeman @myronmarston 
