### PR TITLE
Remove dependency on activemodel

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_runtime_dependency(%q<activesupport>, [">= 3.0"])
-  s.add_runtime_dependency(%q<activemodel>, [">= 3.0"])
   s.add_runtime_dependency(%q<actionpack>, [">= 3.0"])
   s.add_runtime_dependency(%q<railties>, [">= 3.0"])
   %w[core expectations mocks support].each do |name|


### PR DESCRIPTION
This dependency has been introduced by John Firebaugh in commit 4549965af169019c7f3d679371e4650057d176b2 because `lib/rspec/rails/mocks.rb` required it.

But this file was removed in commit 29c175832f55d180473f35c22d1b88245a828917.

Currently `rspec-rails` will check for `defined?(::ActiveModel)` before patching/extending it.

The dependency on activemodel will install unnecessary gems for some applications and will also trigger some bugs in Bundler which would prevent pre releases of railties to be installed with `rspec-rails`.
