### PR TITLE
use ammeter 1.0.0 gem as it is now compatible with rspec 3 & 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,6 @@ if RUBY_VERSION <= '1.8.7'
   gem 'rubyzip', '< 1.0'
 end
 
-# For now, only ammeter master is compatible with RSpec 3. This line can be
-# removed once an RSpec 3-compatible version is pushed to rubygems.
-gem 'ammeter', :github => 'alexrothenberg/ammeter', :ref => 'f81c99070f6badf3d5835d3a17c821159230a2d9'
-
 custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)
 eval File.read(custom_gemfile) if File.exist?(custom_gemfile)
 

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'cucumber', '~> 1.3.5'
   s.add_development_dependency 'aruba',    '~> 0.4.11'
   s.add_development_dependency 'ZenTest',  '~> 4.9.5'
-  s.add_development_dependency 'ammeter',  '0.2.9'
+  s.add_development_dependency 'ammeter',  '1.0.0'
 end


### PR DESCRIPTION
Related to issue #961. The ammeter gem was tied to github to resolve that until a new version of the gem was released. Since it is now released use the published gem.
