### PR TITLE
Routing specs: Switched Rack::Utils::parse_query to Rack::Utils::parse_nested_query

### DIFF
--- a/lib/rspec/rails/matchers/routing_matchers.rb
+++ b/lib/rspec/rails/matchers/routing_matchers.rb
@@ -25,7 +25,7 @@ module RSpec::Rails::Matchers
           @scope.assert_recognizes(
             @expected,
             {:method => verb_to_path_map.keys.first, :path => path},
-            Rack::Utils::parse_query(query)
+            Rack::Utils::parse_nested_query(query)
           )
         end
       end

--- a/spec/rspec/rails/matchers/route_to_spec.rb
+++ b/spec/rspec/rails/matchers/route_to_spec.rb
@@ -27,7 +27,7 @@ describe "route_to" do
 
     it "routes without extra options" do
       expect(self).to receive(:assert_recognizes).with(
-        {:controller => "controller", :action => "action"}, 
+        {:controller => "controller", :action => "action"},
         {:method=> :get, :path=>"path" },
         {}
       )
@@ -50,6 +50,15 @@ describe "route_to" do
         {'queryitem' => 'queryvalue', 'qi2' => 'qv2'}
       )
       expect(get("path?queryitem=queryvalue&qi2=qv2")).to route_to("controller#action", :queryitem => 'queryvalue', :qi2 => 'qv2')
+    end
+
+    it "routes with nested query parameters" do
+      expect(self).to receive(:assert_recognizes).with(
+        {:controller => "controller", :action => "action", 'queryitem' => {'qi2' => 'qv2'}},
+        {:method=> :get, :path=>"path"},
+        {'queryitem' => {'qi2' => 'qv2'} }
+      )
+      expect(get("path?queryitem[qi2]=qv2")).to route_to("controller#action", 'queryitem' => { 'qi2' => 'qv2' })
     end
 
   end


### PR DESCRIPTION
When testing a route relying on nested params Rack::Utils::parse_nested_query is required instead of the current Rack::Utils::parse_query
