### PR TITLE
POST with invalid params should stub :update instead of :save

### DIFF
--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -134,7 +134,11 @@ describe <%= controller_class_name %>Controller do
       it "assigns the <%= ns_file_name %> as @<%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         # Trigger the behavior that occurs when invalid params are submitted
-        allow_any_instance_of(<%= class_name %>).to receive(:save).and_return(false)
+        <%- if ::Rails::VERSION::STRING >= '4' -%>
+        allow_any_instance_of(<%= class_name %>).to receive(:update).and_return(false)
+        <%- else -%>
+        allow_any_instance_of(<%= class_name %>).to receive(:update_attributes).and_return(false)
+        <%- end -%>
         put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => <%= formatted_hash(example_invalid_attributes) %>}, valid_session
         expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
       end
@@ -142,7 +146,11 @@ describe <%= controller_class_name %>Controller do
       it "re-renders the 'edit' template" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         # Trigger the behavior that occurs when invalid params are submitted
-        allow_any_instance_of(<%= class_name %>).to receive(:save).and_return(false)
+        <%- if ::Rails::VERSION::STRING >= '4' -%>
+        allow_any_instance_of(<%= class_name %>).to receive(:update).and_return(false)
+        <%- else -%>
+        allow_any_instance_of(<%= class_name %>).to receive(:update_attributes).and_return(false)
+        <%- end -%>
         put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => <%= formatted_hash(example_invalid_attributes) %>}, valid_session
         expect(response).to render_template("edit")
       end


### PR DESCRIPTION
I noticed an inconsistency in the generated controller scaffold.

The spec for valid params expects a call to `update`, but the spec for invalid params expects a call to `save`. Only `update` is used with the controller action.

I assume this only worked because the Rails implementation of `update` calls `save` within the implementation at some point?
