### PR TITLE
Fix failing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ before_install:
   - gem install bundler -v=1.5.3
   - alias bundle="bundle _1.5.3_"
 rvm:
+  # Use fuzzy matching to work around https://github.com/travis-ci/travis-ci/issues/2220
   - 2.1
   - 2.0.0
   - 1.9.3
   - 1.9.2
+  # Specifically call out MRI to work around https://github.com/travis-ci/travis-ci/issues/2217
   - ruby-1.8.7
 env:
   - RAILS_VERSION=master


### PR DESCRIPTION
This is a work in progress to debug and fix all of the failing travis builds.
- [x] try removing 2nd `before_install` working around a rubygem issue: cff02284
- [x] rspec-dev#67

Open to other ideas too.
