### PR TITLE
Switch to pessimistic operator for Rails versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+before_script:
+  # Rails 4.x complains with a bundler rails binstub in PROJECT_ROOT/bin/
+  - rm -f bin/rails
+  - bundle exec rails --version
 script: "bin/rake --trace 2>&1"
 bundler_args: "--binstubs --without documentation"
 before_install:


### PR DESCRIPTION
Instead of having to make sure each of the minor Rails releases are correct, use pessimistic matchings on Travis. This will ensure we always test against the most recent minor releases; including PRs.
