### PR TITLE
Only run `test:prepare` task if available.

### DIFF
--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -22,7 +22,7 @@ namespace :spec do
   task :prepare do
     ENV['RACK_ENV'] = ENV['RAILS_ENV'] = 'test'
     if Rails.configuration.generators.options[:rails][:orm] == :active_record
-      if ::Rails::VERSION::STRING.to_f < 4.1
+      if Rake::Task.task_defined?("test:prepare")
         Rake::Task["test:prepare"].invoke
       end
     end


### PR DESCRIPTION
Per comment on #949, check if the task is defined instead of switching only on the Rails version.
