### PR TITLE
Fix issue when ActiveRecord isn't present.

### DIFF
--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -1,7 +1,7 @@
 module RSpec
   module Rails
-    if defined?(ActiveRecord::TestFixtures)
-      module FixtureSupport
+    module FixtureSupport
+      if defined?(ActiveRecord::TestFixtures)
         extend ActiveSupport::Concern
         include RSpec::Rails::SetupAndTeardownAdapter
         include RSpec::Rails::MinitestLifecycleAdapter if ::ActiveRecord::VERSION::STRING > '4'


### PR DESCRIPTION
Moves the conditional check inside the fixture support module definition to make including a no-op when there's no `ActiveRecord` fixes #1027.
