### PR TITLE
Fix formatting for feature description.

### DIFF
--- a/features/controller_specs/anonymous_controller.feature
+++ b/features/controller_specs/anonymous_controller.feature
@@ -16,17 +16,19 @@ Feature: anonymous controller
   default:
 
   ```ruby
-  Rspec.configure do |c|
+  RSpec.configure do |c|
     c.infer_base_class_for_anonymous_controllers = false
   end
 
   describe BaseController do
-    controller { ... }
-    =begin
-      ^^ would normally create an anonymous subclass of `BaseController`,
-      but since `infer_base_class_for_anonymous_controllers` is disabled,
-      it creates a subclass of `ApplicationController` instead
-    =end
+    controller do
+      def index; end
+
+      ​# this normally creates an anonymous `BaseController` subclass, but
+      ​# since `infer_base_class_for_anonymous_controllers` is disabled,
+      ​# it creates a subclass of `ApplicationController` instead
+    end
+  end
   ```
 
   Scenario: Specify error handling in `ApplicationController`


### PR DESCRIPTION
RelishApp and Cucumber are very picky about syntax. **ANY** line which
starts with an octothorpe is treated as a comment. This makes the lexer
very unhappy.

In order to trick it I had to add a unicode space (specifically the zero
width space <200b>). This alone didn't fix things. For some reason,
using a semi-colon fixed things. I tried several additional variations,
all of which worked; but they each still required the semi-colon:
- `controller { ; }`
- `controller do; end`

I settled on this various as I felt it read a bit better with the
comment being in the `controller` definition.

Fixes #1032 
