### PR TITLE
Replace mocking in generated controller specs with integration tests.

### DIFF
--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -50,36 +50,6 @@ module Rspec
                    File.join("spec/views", controller_file_path, "#{view}.html.#{options[:template_engine]}_spec.rb")
         end
 
-        def example_valid_attributes
-          # Only take the first attribute so this hash does not become unweildy and large in the
-          # generated controller spec. It is the responsibility of the user to keep the the valid
-          # attributes method up-to-date as they add validations.
-          @example_valid_attributes ||=
-            if attributes.any?
-              { attributes.first.name => attributes.first.default.to_s }
-            else
-              { }
-            end
-        end
-
-        def example_invalid_attributes
-          @example_invalid_attributes ||=
-            if attributes.any?
-              { attributes.first.name => "invalid value" }
-            else
-              { }
-            end
-        end
-
-        def example_params_for_update
-          @example_params_for_update ||=
-            if example_valid_attributes.any?
-              example_valid_attributes
-            else
-              { "these" => "params" }
-            end
-        end
-
         def formatted_hash(hash)
           formatted = hash.inspect
           formatted.gsub!("{", "{ ")

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -24,7 +24,13 @@ describe <%= controller_class_name %>Controller, :type => :controller do
   # This should return the minimal set of attributes required to create a valid
   # <%= class_name %>. As you add validations to <%= class_name %>, be sure to
   # adjust the attributes here as well.
-  let(:valid_attributes) { <%= formatted_hash(example_valid_attributes) %> }
+  let(:valid_attributes) {
+    skip("Add a hash of attributes valid for your model")
+  }
+
+  let(:invalid_attributes) {
+    skip("Add a hash of attributes invalid for your model")
+  }
 
   # This should return the minimal set of values that should be in the session
   # in order to pass any filters (e.g. authentication) defined in
@@ -86,16 +92,12 @@ describe <%= controller_class_name %>Controller, :type => :controller do
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved <%= ns_file_name %> as @<%= ns_file_name %>" do
-        # Trigger the behavior that occurs when invalid params are submitted
-        allow_any_instance_of(<%= class_name %>).to receive(:save).and_return(false)
-        post :create, {:<%= ns_file_name %> => <%= formatted_hash(example_invalid_attributes) %>}, valid_session
+        post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
         expect(assigns(:<%= ns_file_name %>)).to be_a_new(<%= class_name %>)
       end
 
       it "re-renders the 'new' template" do
-        # Trigger the behavior that occurs when invalid params are submitted
-        allow_any_instance_of(<%= class_name %>).to receive(:save).and_return(false)
-        post :create, {:<%= ns_file_name %> => <%= formatted_hash(example_invalid_attributes) %>}, valid_session
+        post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
         expect(response).to render_template("new")
       end
     end
@@ -103,18 +105,15 @@ describe <%= controller_class_name %>Controller, :type => :controller do
 
   describe "PUT update" do
     describe "with valid params" do
+      let(:new_attributes) {
+        skip("Add a hash of attributes valid for your model")
+      }
+
       it "updates the requested <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        # Assuming there are no other <%= table_name %> in the database, this
-        # specifies that the <%= class_name %> created on the previous line
-        # receives the :update_attributes message with whatever params are
-        # submitted in the request.
-        <%- if ::Rails::VERSION::STRING >= '4' -%>
-        expect_any_instance_of(<%= class_name %>).to receive(:update).with(<%= formatted_hash(example_params_for_update) %>)
-        <%- else -%>
-        expect_any_instance_of(<%= class_name %>).to receive(:update_attributes).with(<%= formatted_hash(example_params_for_update) %>)
-        <%- end -%>
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => <%= formatted_hash(example_params_for_update) %>}, valid_session
+        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => new_attributes}, valid_session
+        <%= file_name %>.reload
+        skip("Add assertions for updated state")
       end
 
       it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
@@ -133,25 +132,13 @@ describe <%= controller_class_name %>Controller, :type => :controller do
     describe "with invalid params" do
       it "assigns the <%= ns_file_name %> as @<%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        # Trigger the behavior that occurs when invalid params are submitted
-        <%- if ::Rails::VERSION::STRING >= '4' -%>
-        allow_any_instance_of(<%= class_name %>).to receive(:update).and_return(false)
-        <%- else -%>
-        allow_any_instance_of(<%= class_name %>).to receive(:update_attributes).and_return(false)
-        <%- end -%>
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => <%= formatted_hash(example_invalid_attributes) %>}, valid_session
+        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, valid_session
         expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
       end
 
       it "re-renders the 'edit' template" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        # Trigger the behavior that occurs when invalid params are submitted
-        <%- if ::Rails::VERSION::STRING >= '4' -%>
-        allow_any_instance_of(<%= class_name %>).to receive(:update).and_return(false)
-        <%- else -%>
-        allow_any_instance_of(<%= class_name %>).to receive(:update_attributes).and_return(false)
-        <%- end -%>
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => <%= formatted_hash(example_invalid_attributes) %>}, valid_session
+        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, valid_session
         expect(response).to render_template("edit")
       end
     end

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -14,20 +14,12 @@ describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
       before { run_generator %w(posts) }
       it { is_expected.to contain(/require 'spec_helper'/) }
       it { is_expected.to contain(/describe PostsController, :type => :controller/) }
-      it { is_expected.to contain(%({ "these" => "params" })) }
     end
 
     describe 'with --no-controller_specs' do
       before { run_generator %w(posts --no-controller_specs) }
       it { is_expected.not_to exist }
     end
-  end
-
-  describe 'controller spec with attributes specified' do
-    subject { file('spec/controllers/posts_controller_spec.rb') }
-    before { run_generator %w(posts title:string) }
-
-    it { is_expected.to contain(%({ "title" => "MyString" })) }
   end
 
   describe 'namespaced controller spec' do


### PR DESCRIPTION
This was a terrible example and should never have been here. This
replacement isn't great, but at least is not obviously bad.

Unfortunately we cannot provide default implementations of these because
we don't have sufficient information about the data model. Specs that
require this are marked pending.

I gave up on the default approach: it doesn't work at all for models
with no attributes, and is a crapshoot if they do.

@cupakromer @JonRowe @myronmarston 

Fixes #1008 
