### PR TITLE
Update README.md

### DIFF
--- a/features/controller_specs/README.md
+++ b/features/controller_specs/README.md
@@ -27,10 +27,10 @@ To specify outcomes, you can use:
     ```ruby
     expect(response).to redirect_to(location)   # wraps assert_redirected_to
     ```
-  - [`have_status`](matchers/have-status-matcher)
+  - [`have_http_status`](matchers/have-http-status-matcher)
 
     ```ruby
-    expect(response).to have_status(:created)
+    expect(response).to have_http_status(:created)
     ```
   - [`be_a_new`](#)
 


### PR DESCRIPTION
Set the correct name and link for have_http_status matcher, it was still referencing the "old" name have_status.
