### PR TITLE
Support for rails travel methods

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+### 3.0.2 development
+
+Enhancements:
+
+* Add support for Rails 4.1 time helper methods `travel`, `travel_to`
+  and `travel_back`. (Wojciech Wnętrzak)
+
 ### 3.0.0 / 2014-06-01
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.0.0.rc1...v3.0.0)
 

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -53,6 +53,11 @@ module RSpec
         config.include RSpec::Rails::MailerExampleGroup, :type => :mailer
       end
 
+      # Adds `travel`, `travel_to` and `travel_back` methods
+      if defined?(ActiveSupport::Testing::TimeHelpers)
+        config.include ActiveSupport::Testing::TimeHelpers
+      end
+
       # controller settings
       config.add_setting :infer_base_class_for_anonymous_controllers, :default => true
 


### PR DESCRIPTION
There are new helpers since rails 4.1: `travel`, `travel_to` and `travel_back`.
https://github.com/rails/rails/commit/225cd915cf5ab3b6662d3eecf3fe0715bf73e4de

I think they should be available out of the box in rspec, but I'm not sure what would be the best way to include them.

For me, simple line in spec_helper works fine:

``` ruby
RSpec.configure do |config|
  config.include ActiveSupport::Testing::TimeHelpers
end
```

It could be included in pregenerated spec_helper (this way user can always disable it) or placed in https://github.com/rspec/rspec-rails/blob/v3.0.0.rc1/lib/rspec/rails/configuration.rb

What do you think?
