### PR TITLE
fix 'uninitialized instance variable' warning

### DIFF
--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -120,6 +120,10 @@ module RSpec
         end
       end
 
+      def initialize
+        @example = nil
+      end
+
       def method_name
         @example
       end


### PR DESCRIPTION
Running specs in my Rails 4.1.2.rc1 app with warnings turned on prints this warning, and just this warning. So I fixed it. :)
