### PR TITLE
Switch to using the `have_http_status` matcher.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 ### Development
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.0.1...master)
 
+Enhancements:
+
+* Switch to using the `have_http_status` matcher in spec generators. (Aaron Kromer, #1086)
+
 Bug Fixes:
 
 * Suppress warning in `SetupAndTeardownAdapter`. (André Arko, #1085)

--- a/lib/generators/rspec/controller/templates/controller_spec.rb
+++ b/lib/generators/rspec/controller/templates/controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe <%= class_name %>Controller, :type => :controller do
   describe "GET '<%= action %>'" do
     it "returns http success" do
       get '<%= action %>'
-      expect(response).to be_success
+      expect(response).to have_http_status(:success)
     end
   end
 

--- a/lib/generators/rspec/integration/templates/request_spec.rb
+++ b/lib/generators/rspec/integration/templates/request_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "<%= class_name.pluralize %>", :type => :request do
   describe "GET /<%= table_name %>" do
     it "works! (now write some real specs)" do
       get <%= index_helper %>_path
-      expect(response.status).to be(200)
+      expect(response).to have_http_status(200)
     end
   end
 end


### PR DESCRIPTION
The `have_http_status` matchers provides more helpful messaging on
failure. Change the generators to use this matcher to provide enhanced
help out of the box.
- Resolves #1083
