### PR TITLE
Allow rspec-rails to load without Rubygems loaded

### DIFF
--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -5,7 +5,11 @@ require 'active_support/concern'
 module RSpec
   module Rails
     if ::Rails::VERSION::STRING >= '4.1.0'
-      gem 'minitest'
+      if defined?(Kernel.gem)
+        gem 'minitest'
+      else
+        require 'minitest'
+      end
       require 'minitest/assertions'
       # Constant aliased to either Minitest or TestUnit, depending on what is
       # loaded.


### PR DESCRIPTION
Rspec-rails is a great gem citizen, and doesn't explicitly require Rubygems anywhere. However, while working on a Rails app that doesn't require Rubygems before loading Rails, we've noticed that rspec-rails expects Rubygems to be loaded even though it doesn't require it.

This pull request simply checks for Rubygems before calling Rubygems methods, so that rspec-rails works without Rubygems already being loaded.
