### PR TITLE
Use Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,97 @@
+inherit_from: .rubocop_todo.yml
+
+AccessModifierIndentation:
+  EnforcedStyle: outdent
+
+# "Use alias_method instead of alias"
+# We're fine with `alias`.
+Alias:
+  Enabled: false
+
+AlignParameters:
+  EnforcedStyle: with_first_parameter
+
+# "Avoid the use of the case equality operator ==="
+# We prefer using `Class#===` over `Object#is_a?` because `Class#===`
+# is less likely to be monkey patched than `is_a?` on a user object.
+CaseEquality:
+  Enabled: false
+
+CollectionMethods:
+  PreferredMethods:
+    reduce: 'inject'
+
+# We use YARD to enforce documentation. It works better than rubocop's
+# enforcement...rubocop complains about the places we re-open
+# `RSpec::Expectations` and `RSpec::Matchers` w/o having doc commments.
+Documentation:
+  Enabled: false
+
+# We still support 1.8.7 which requires trailing dots
+DotPosition:
+  EnforcedStyle: trailing
+
+DoubleNegation:
+  Enabled: false
+
+# each_with_object is unavailable on 1.8.7 so we have to disable this one.
+EachWithObject:
+  Enabled: false
+
+Encoding:
+  EnforcedStyle: when_needed
+
+FormatString:
+  EnforcedStyle: percent
+
+# As long as we support ruby 1.8.7 we have to use hash rockets.
+HashSyntax:
+  EnforcedStyle: hash_rockets
+
+# We can't use the new lambda syntax, since we still support 1.8.7.
+Lambda:
+  Enabled: false
+
+# Who cares what we all the argument for binary operator methods?
+OpMethod:
+  Enabled: false
+
+PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%':  ()      # double-quoted string
+    '%i': '[]'    # array of symbols
+    '%q': ()      # single-quoted string
+    '%Q': ()      # double-quoted string
+    '%r': '{}'    # regular expression pattern
+    '%s': ()      # a symbol
+    '%w': '[]'    # array of single-quoted strings
+    '%W': '[]'    # array of double-quoted strings
+    '%x': ()      # a shell command as a string
+
+# We have too many special cases where we allow generator methods or prefer a
+# prefixed predicate due to it's improved readability.
+PredicateName:
+  Enabled: false
+
+# On 1.8 `proc` is `lambda`, so we use `Proc.new` to ensure we get real procs
+# on all supported versions.
+# http://batsov.com/articles/2014/02/04/the-elements-of-style-in-ruby-number-12-proc-vs-proc-dot-new/
+Proc:
+  Enabled: false
+
+RedundantReturn:
+  AllowMultipleReturnValues: true
+
+# We haven't adopted the `fail` to signal exceptions vs `raise` for re-raises
+# convention.
+SignalException:
+  Enabled: false
+
+# We don't care about single vs double qoutes.
+StringLiterals:
+  Enabled: false
+
+TrivialAccessors:
+  AllowDSLWriters: true
+  AllowPredicates: true
+  ExactNameMatch: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,0 +1,53 @@
+# Warns when the class is excessively long.
+ClassLength:
+  Max: 100
+
+# Over time we'd like to get this down, but this is what we're at now.
+CyclomaticComplexity:
+  Max: 10
+
+# Over time we'd like to get this down, but this is what we're at now.
+LineLength:
+  Max: 186
+
+# Over time we'd like to get this down, but this is what we're at now.
+MethodLength:
+  Max: 50
+
+################################################################################
+# Individual File Exclusions
+################################################################################
+
+AllCops:
+  Exclude:
+    # Templates are really ERB which Rubocop does not parse
+    - 'lib/generators/rspec/*/templates/**/*'
+
+FileName:
+  Exclude:
+    # I'm not sure why yet but we break convention for this one file
+    - lib/rspec-rails.rb
+
+GuardClause:
+  Exclude:
+    # This is getting triggered since the `unless` clause is the last
+    # statement, which doesn't matter since it's the initializer. If it's
+    # possible to break this up cleanly we can remove this exclude
+    - lib/rspec/rails/matchers/have_http_status.rb
+
+HandleExceptions:
+  Exclude:
+    # RSpec is tightly coupled to capybara right now, this should be
+    # re-evaluted in the future. For now we allow the empty rescue
+    - lib/rspec/rails/vendor/capybara.rb
+
+IfUnlessModifier:
+  Exclude:
+    # Allow single line statement as the style matches the remainder of the file
+    - lib/rspec/rails/vendor/capybara.rb
+
+PerlBackrefs:
+  Exclude:
+    # We probably can refactor the backref out, but for now excluding it since
+    # we can't use named matches in 1.8.7
+    - lib/generators/rspec/scaffold/scaffold_generator.rb

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ if RUBY_VERSION <= '1.8.7'
   gem 'rubyzip', '< 1.0'
 end
 
+gem 'rubocop', "~> 0.23.0", :platform => [:ruby_19, :ruby_20, :ruby_21]
+
 custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)
 eval_gemfile custom_gemfile if File.exist?(custom_gemfile)
 

--- a/Rakefile
+++ b/Rakefile
@@ -142,3 +142,10 @@ end
 
 task :build => :verify_private_key_present
 
+if RUBY_VERSION.to_f > 1.8
+  require 'rubocop/rake_task'
+  desc 'Run RuboCop on the lib directory'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.patterns = ['lib/**/*.rb']
+  end
+end

--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -27,10 +27,10 @@ module Rails
     class GeneratedAttribute
       def input_type
         @input_type ||= if type == :text
-          "textarea"
-        else
-          "input"
-        end
+                          "textarea"
+                        else
+                          "input"
+                        end
       end
     end
   end

--- a/lib/generators/rspec/install/install_generator.rb
+++ b/lib/generators/rspec/install/install_generator.rb
@@ -6,7 +6,6 @@ module Rspec
   module Generators
     # @private
     class InstallGenerator < ::Rails::Generators::Base
-
       desc <<DESC
 Description:
     Copy rspec files to your application.

--- a/lib/generators/rspec/model/model_generator.rb
+++ b/lib/generators/rspec/model/model_generator.rb
@@ -4,19 +4,32 @@ module Rspec
   module Generators
     # @private
     class ModelGenerator < Base
-      argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
+      argument :attributes,
+               :type => :array,
+               :default => [],
+               :banner => "field:type field:type"
       class_option :fixture, :type => :boolean
 
       def create_model_spec
-        template 'model_spec.rb', File.join('spec/models', class_path, "#{file_name}_spec.rb")
+        template_file = File.join(
+          'spec/models',
+          class_path,
+          "#{file_name}_spec.rb"
+        )
+        template 'model_spec.rb', template_file
       end
 
       hook_for :fixture_replacement
 
       def create_fixture_file
-        if options[:fixture] && options[:fixture_replacement].nil?
-          template 'fixtures.yml', File.join('spec/fixtures', "#{table_name}.yml")
-        end
+        return unless missing_fixture_replacement?
+        template 'fixtures.yml', File.join('spec/fixtures', "#{table_name}.yml")
+      end
+
+    private
+
+      def missing_fixture_replacement?
+        options[:fixture] && options[:fixture_replacement].nil?
       end
     end
   end

--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -21,8 +21,12 @@ module Rspec
       def generate_controller_spec
         return unless options[:controller_specs]
 
-        template 'controller_spec.rb',
-                 File.join('spec/controllers', controller_class_path, "#{controller_file_name}_controller_spec.rb")
+        template_file = File.join(
+          'spec/controllers',
+          controller_class_path,
+          "#{controller_file_name}_controller_spec.rb"
+        )
+        template 'controller_spec.rb', template_file
       end
 
       def generate_view_specs
@@ -37,123 +41,126 @@ module Rspec
       def generate_routing_spec
         return unless options[:routing_specs]
 
-        template 'routing_spec.rb',
-          File.join('spec/routing', controller_class_path, "#{controller_file_name}_routing_spec.rb")
+        template_file = File.join(
+          'spec/routing',
+          controller_class_path,
+          "#{controller_file_name}_routing_spec.rb"
+        )
+        template 'routing_spec.rb', template_file
       end
 
       hook_for :integration_tool, :as => :integration
 
-      protected
+    protected
 
-        def copy_view(view)
-          template "#{view}_spec.rb",
-                   File.join("spec/views", controller_file_path, "#{view}.html.#{options[:template_engine]}_spec.rb")
+      def copy_view(view)
+        template "#{view}_spec.rb",
+                 File.join("spec/views", controller_file_path, "#{view}.html.#{options[:template_engine]}_spec.rb")
+      end
+
+      def formatted_hash(hash)
+        formatted = hash.inspect
+        formatted.gsub!("{", "{ ")
+        formatted.gsub!("}", " }")
+        formatted.gsub!("=>", " => ")
+        formatted
+      end
+
+      # support for namespaced-resources
+      def ns_file_name
+        ns_parts.empty? ? file_name : "#{ns_parts[0].underscore}_#{ns_parts[1].singularize.underscore}"
+      end
+
+      # support for namespaced-resources
+      def ns_table_name
+        ns_parts.empty? ? table_name : "#{ns_parts[0].underscore}/#{ns_parts[1].tableize}"
+      end
+
+      def ns_parts
+        @ns_parts ||= begin
+                        matches = ARGV[0].to_s.match(/\A(\w+)(?:\/|::)(\w+)/)
+                        matches ? [matches[1], matches[2]] : []
+                      end
+      end
+
+      # Returns the name of the mock. For example, if the file name is user,
+      # it returns mock_user.
+      #
+      # If a hash is given, it uses the hash key as the ORM method and the
+      # value as response. So, for ActiveRecord and file name "User":
+      #
+      #   mock_file_name(:save => true)
+      #   #=> mock_user(:save => true)
+      #
+      # If another ORM is being used and another method instead of save is
+      # called, it will be the one used.
+      #
+      def mock_file_name(hash = nil)
+        if hash
+          method, and_return = hash.to_a.first
+          method = orm_instance.send(method).split('.').last.gsub(/\(.*?\)/, '')
+          "mock_#{ns_file_name}(:#{method} => #{and_return})"
+        else
+          "mock_#{ns_file_name}"
         end
+      end
 
-        def formatted_hash(hash)
-          formatted = hash.inspect
-          formatted.gsub!("{", "{ ")
-          formatted.gsub!("}", " }")
-          formatted.gsub!("=>", " => ")
-          formatted
+      # Receives the ORM chain and convert to expects. For ActiveRecord:
+      #
+      #   should! orm_class.find(User, "37")
+      #   #=> User.should_receive(:find).with(37)
+      #
+      # For Datamapper:
+      #
+      #   should! orm_class.find(User, "37")
+      #   #=> User.should_receive(:get).with(37)
+      #
+      def should_receive(chain)
+        stub_or_should_chain(:should_receive, chain)
+      end
+
+      # Receives the ORM chain and convert to stub. For ActiveRecord:
+      #
+      #   stub orm_class.find(User, "37")
+      #   #=> User.stub(:find).with(37)
+      #
+      # For Datamapper:
+      #
+      #   stub orm_class.find(User, "37")
+      #   #=> User.stub(:get).with(37)
+      #
+      def stub(chain)
+        stub_or_should_chain(:stub, chain)
+      end
+
+      def stub_or_should_chain(mode, chain)
+        receiver, method = chain.split(".")
+        method.gsub!(/\((.*?)\)/, '')
+
+        response = "#{receiver}.#{mode}(:#{method})"
+        response << ".with(#{$1})" unless $1.blank?
+        response
+      end
+
+      def value_for(attribute)
+        raw_value_for(attribute).inspect
+      end
+
+      def raw_value_for(attribute)
+        case attribute.type
+        when :string
+          attribute.name.titleize
+        when :integer
+          @attribute_id_map ||= {}
+          @attribute_id_map[attribute] ||= @attribute_id_map.keys.size.next
+        else
+          attribute.default
         end
+      end
 
-        # support for namespaced-resources
-        def ns_file_name
-          ns_parts.empty? ? file_name : "#{ns_parts[0].underscore}_#{ns_parts[1].singularize.underscore}"
-        end
-
-        # support for namespaced-resources
-        def ns_table_name
-          ns_parts.empty? ? table_name : "#{ns_parts[0].underscore}/#{ns_parts[1].tableize}"
-        end
-
-        def ns_parts
-          @ns_parts ||= begin
-                          matches = ARGV[0].to_s.match(/\A(\w+)(?:\/|::)(\w+)/)
-                          matches ? [matches[1], matches[2]] : []
-                        end
-        end
-
-        # Returns the name of the mock. For example, if the file name is user,
-        # it returns mock_user.
-        #
-        # If a hash is given, it uses the hash key as the ORM method and the
-        # value as response. So, for ActiveRecord and file name "User":
-        #
-        #   mock_file_name(:save => true)
-        #   #=> mock_user(:save => true)
-        #
-        # If another ORM is being used and another method instead of save is
-        # called, it will be the one used.
-        #
-        def mock_file_name(hash=nil)
-          if hash
-            method, and_return = hash.to_a.first
-            method = orm_instance.send(method).split('.').last.gsub(/\(.*?\)/, '')
-            "mock_#{ns_file_name}(:#{method} => #{and_return})"
-          else
-            "mock_#{ns_file_name}"
-          end
-        end
-
-        # Receives the ORM chain and convert to expects. For ActiveRecord:
-        #
-        #   should! orm_class.find(User, "37")
-        #   #=> User.should_receive(:find).with(37)
-        #
-        # For Datamapper:
-        #
-        #   should! orm_class.find(User, "37")
-        #   #=> User.should_receive(:get).with(37)
-        #
-        def should_receive(chain)
-          stub_or_should_chain(:should_receive, chain)
-        end
-
-        # Receives the ORM chain and convert to stub. For ActiveRecord:
-        #
-        #   stub orm_class.find(User, "37")
-        #   #=> User.stub(:find).with(37)
-        #
-        # For Datamapper:
-        #
-        #   stub orm_class.find(User, "37")
-        #   #=> User.stub(:get).with(37)
-        #
-        def stub(chain)
-          stub_or_should_chain(:stub, chain)
-        end
-
-        def stub_or_should_chain(mode, chain)
-          receiver, method = chain.split(".")
-          method.gsub!(/\((.*?)\)/, '')
-
-          response = "#{receiver}.#{mode}(:#{method})"
-          response << ".with(#{$1})" unless $1.blank?
-          response
-        end
-
-        def value_for(attribute)
-          raw_value_for(attribute).inspect
-        end
-
-        def raw_value_for(attribute)
-          case attribute.type
-          when :string
-            attribute.name.titleize
-          when :integer
-            @attribute_id_map ||= {}
-            @attribute_id_map[attribute] ||= @attribute_id_map.keys.size.next
-          else
-            attribute.default
-          end
-        end
-
-        def banner
-          self.class.banner
-        end
-
+      def banner
+        self.class.banner
+      end
     end
   end
 end

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -7,7 +7,7 @@ module RSpec
       # Rails-3.0.1 requires config.app_generators instead of 3.0.0's config.generators
       generators = config.respond_to?(:app_generators) ? config.app_generators : config.generators
       generators.integration_tool :rspec
-      generators.test_framework   :rspec
+      generators.test_framework :rspec
 
       rake_tasks do
         load "rspec/rails/tasks/rspec.rake"

--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -89,12 +89,9 @@ module RSpec
 
     # @private
     module MinitestCounters
+      attr_writer :assertions
       def assertions
         @assertions ||= 0
-      end
-
-      def assertions=(assertions)
-        @assertions = assertions
       end
     end
 
@@ -143,8 +140,12 @@ module RSpec
         # examples without exposing non-assertion methods in Test::Unit or
         # Minitest.
         def assertion_method_names
-          ::RSpec::Rails::Assertions.public_instance_methods.select{|m| m.to_s =~ /^(assert|flunk|refute)/} +
-            [:build_message]
+          methods = ::RSpec::Rails::Assertions.
+            public_instance_methods.
+            select do |m|
+              m.to_s =~ /^(assert|flunk|refute)/
+            end
+          methods + [:build_message]
         end
 
         def define_assertion_delegators

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -1,5 +1,4 @@
 module RSpec
-
   module Rails
     # Fake class to document RSpec Rails configuration options. In practice,
     # these are dynamically added to the normal RSpec configuration object.
@@ -39,7 +38,7 @@ module RSpec
     # @private
     def self.initialize_configuration(config)
       config.backtrace_exclusion_patterns << /vendor\//
-      config.backtrace_exclusion_patterns << /lib\/rspec\/rails/
+      config.backtrace_exclusion_patterns << %r{ lib/rspec/rails }
 
       config.include RSpec::Rails::ControllerExampleGroup, :type => :controller
       config.include RSpec::Rails::HelperExampleGroup,     :type => :helper
@@ -57,7 +56,7 @@ module RSpec
       config.add_setting :infer_base_class_for_anonymous_controllers, :default => true
 
       # fixture support
-      config.include     RSpec::Rails::FixtureSupport
+      config.include RSpec::Rails::FixtureSupport
       config.add_setting :use_transactional_fixtures, :alias_with => :use_transactional_examples
       config.add_setting :use_instantiated_fixtures
       config.add_setting :global_fixtures

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -1,179 +1,187 @@
-module RSpec::Rails
-  # Container module for controller spec functionality.
-  module ControllerExampleGroup
-    extend ActiveSupport::Concern
-    include RSpec::Rails::RailsExampleGroup
-    include ActionController::TestCase::Behavior
-    include RSpec::Rails::ViewRendering
-    include RSpec::Rails::Matchers::RedirectTo
-    include RSpec::Rails::Matchers::RenderTemplate
-    include RSpec::Rails::Matchers::RoutingMatchers
-    include RSpec::Rails::AssertionDelegator.new(ActionDispatch::Assertions::RoutingAssertions)
+module RSpec
+  module Rails
+    # Container module for controller spec functionality.
+    module ControllerExampleGroup
+      extend ActiveSupport::Concern
+      include RSpec::Rails::RailsExampleGroup
+      include ActionController::TestCase::Behavior
+      include RSpec::Rails::ViewRendering
+      include RSpec::Rails::Matchers::RedirectTo
+      include RSpec::Rails::Matchers::RenderTemplate
+      include RSpec::Rails::Matchers::RoutingMatchers
+      include RSpec::Rails::AssertionDelegator.new(ActionDispatch::Assertions::RoutingAssertions)
 
-    # Class-level DSL for controller specs.
-    module ClassMethods
+      # Class-level DSL for controller specs.
+      module ClassMethods
+        # @private
+        def controller_class
+          described_class
+        end
+
+        # Supports a simple DSL for specifying behavior of ApplicationController.
+        # Creates an anonymous subclass of ApplicationController and evals the
+        # `body` in that context. Also sets up implicit routes for this
+        # controller, that are separate from those defined in "config/routes.rb".
+        #
+        # @note Due to Ruby 1.8 scoping rules in anonymous subclasses, constants
+        #   defined in `ApplicationController` must be fully qualified (e.g.
+        #   `ApplicationController::AccessDenied`) in the block passed to the
+        #   `controller` method. Any instance methods, filters, etc, that are
+        #   defined in `ApplicationController`, however, are accessible from
+        #   within the block.
+        #
+        # @example
+        #     describe ApplicationController do
+        #       controller do
+        #         def index
+        #           raise ApplicationController::AccessDenied
+        #         end
+        #       end
+        #
+        #       describe "handling AccessDenied exceptions" do
+        #         it "redirects to the /401.html page" do
+        #           get :index
+        #           response.should redirect_to("/401.html")
+        #         end
+        #       end
+        #     end
+        #
+        # If you would like to spec a subclass of ApplicationController, call
+        # controller like so:
+        #
+        #     controller(ApplicationControllerSubclass) do
+        #       # ....
+        #     end
+        def controller(base_class = nil, &body)
+          if RSpec.configuration.infer_base_class_for_anonymous_controllers?
+            base_class ||= controller_class
+          end
+          base_class ||= defined?(ApplicationController) ? ApplicationController : ActionController::Base
+
+          new_controller_class = Class.new(base_class) do
+            def self.name
+              root_controller = defined?(ApplicationController) ? ApplicationController : ActionController::Base
+              if superclass == root_controller || superclass.abstract?
+                "AnonymousController"
+              else
+                superclass.to_s
+              end
+            end
+          end
+          new_controller_class.class_exec(&body)
+          (class << self; self; end).__send__(:define_method, :controller_class) { new_controller_class }
+
+          before do
+            @orig_routes = routes
+            resource_name = if @controller.respond_to?(:controller_name)
+                              @controller.controller_name.to_sym
+                            else
+                              :anonymous
+                            end
+            resource_path = if @controller.respond_to?(:controller_path)
+                              @controller.controller_path
+                            else
+                              resource_name.to_s
+                            end
+            resource_module = resource_path.rpartition('/').first.presence
+            resource_as = 'anonymous_' + resource_path.tr('/', '_')
+            self.routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
+              r.draw do
+                resources resource_name,
+                          :as => resource_as,
+                          :module => resource_module,
+                          :path => resource_path
+              end
+            end
+          end
+
+          after do
+            self.routes  = @orig_routes
+            @orig_routes = nil
+          end
+        end
+
+        # Specifies the routeset that will be used for the example group. This
+        # is most useful when testing Rails engines.
+        #
+        # @example
+        #     describe MyEngine::PostsController do
+        #       routes { MyEngine::Engine.routes }
+        #
+        #       # ...
+        #     end
+        def routes(&blk)
+          before do
+            self.routes = blk.call
+          end
+        end
+      end
+
+      attr_reader :controller, :routes
+
       # @private
-      def controller_class
-        described_class
+      #
+      # RSpec Rails uses this to make Rails routes easily available to specs.
+      def routes=(routes)
+        @routes = routes
+        assertion_instance.instance_variable_set(:@routes, routes)
       end
 
-      # Supports a simple DSL for specifying behavior of ApplicationController.
-      # Creates an anonymous subclass of ApplicationController and evals the
-      # `body` in that context. Also sets up implicit routes for this
-      # controller, that are separate from those defined in "config/routes.rb".
-      #
-      # @note Due to Ruby 1.8 scoping rules in anonymous subclasses, constants
-      #   defined in `ApplicationController` must be fully qualified (e.g.
-      #   `ApplicationController::AccessDenied`) in the block passed to the
-      #   `controller` method. Any instance methods, filters, etc, that are
-      #   defined in `ApplicationController`, however, are accessible from
-      #   within the block.
+      # @private
+      module BypassRescue
+        def rescue_with_handler(exception)
+          raise exception
+        end
+      end
+
+      # Extends the controller with a module that overrides
+      # `rescue_with_handler` to raise the exception passed to it. Use this to
+      # specify that an action _should_ raise an exception given appropriate
+      # conditions.
       #
       # @example
-      #     describe ApplicationController do
-      #       controller do
-      #         def index
-      #           raise ApplicationController::AccessDenied
-      #         end
-      #       end
+      #     describe ProfilesController do
+      #       it "raises a 403 when a non-admin user tries to view another user's profile" do
+      #         profile = create_profile
+      #         login_as profile.user
       #
-      #       describe "handling AccessDenied exceptions" do
-      #         it "redirects to the /401.html page" do
-      #           get :index
-      #           response.should redirect_to("/401.html")
-      #         end
+      #         expect do
+      #           bypass_rescue
+      #           get :show, :id => profile.id + 1
+      #         end.to raise_error(/403 Forbidden/)
       #       end
       #     end
-      #
-      # If you would like to spec a subclass of ApplicationController, call
-      # controller like so:
-      #
-      #     controller(ApplicationControllerSubclass) do
-      #       # ....
-      #     end
-      def controller(base_class = nil, &body)
-        if RSpec.configuration.infer_base_class_for_anonymous_controllers?
-          base_class ||= controller_class
-        end
-        base_class ||= defined?(ApplicationController) ? ApplicationController : ActionController::Base
+      def bypass_rescue
+        controller.extend(BypassRescue)
+      end
 
-        new_controller_class = Class.new(base_class) do
-          def self.name
-            root_controller = defined?(ApplicationController) ? ApplicationController : ActionController::Base
-            if superclass == root_controller || superclass.abstract?
-              "AnonymousController"
-            else
-              superclass.to_s
-            end
-          end
+      # If method is a named_route, delegates to the RouteSet associated with
+      # this controller.
+      def method_missing(method, *args, &block)
+        if defined?(@routes) && @routes.named_routes.helpers.include?(method)
+          controller.send(method, *args, &block)
+        elsif defined?(@orig_routes) && @orig_routes && @orig_routes.named_routes.helpers.include?(method)
+          controller.send(method, *args, &block)
+        else
+          super
         end
-        new_controller_class.class_exec(&body)
-        (class << self; self; end).__send__(:define_method, :controller_class) { new_controller_class }
+      end
+
+      included do
+        subject { controller }
 
         before do
-          @orig_routes = self.routes
-          resource_name = @controller.respond_to?(:controller_name) ?
-            @controller.controller_name.to_sym : :anonymous
-          resource_path = @controller.respond_to?(:controller_path) ?
-            @controller.controller_path : resource_name.to_s
-          resource_module = resource_path.rpartition('/').first.presence
-          resource_as = 'anonymous_' + resource_path.tr('/', '_')
-          self.routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
-            r.draw do
-              resources resource_name,
-                :as => resource_as,
-                :module => resource_module,
-                :path => resource_path
-            end
+          self.routes = ::Rails.application.routes
+        end
+
+        around do |ex|
+          previous_allow_forgery_protection_value = ActionController::Base.allow_forgery_protection
+          begin
+            ActionController::Base.allow_forgery_protection = false
+            ex.call
+          ensure
+            ActionController::Base.allow_forgery_protection = previous_allow_forgery_protection_value
           end
-        end
-
-        after do
-          self.routes  = @orig_routes
-          @orig_routes = nil
-        end
-      end
-
-      # Specifies the routeset that will be used for the example group. This
-      # is most useful when testing Rails engines.
-      #
-      # @example
-      #     describe MyEngine::PostsController do
-      #       routes { MyEngine::Engine.routes }
-      #
-      #       # ...
-      #     end
-      def routes(&blk)
-        before do
-          self.routes = blk.call
-        end
-      end
-    end
-
-    attr_reader :controller, :routes
-
-    # @private
-    #
-    # RSpec Rails uses this to make Rails routes easily available to specs.
-    def routes=(routes)
-      @routes = routes
-      assertion_instance.instance_variable_set(:@routes, routes)
-    end
-
-    # @private
-    module BypassRescue
-      def rescue_with_handler(exception)
-        raise exception
-      end
-    end
-
-    # Extends the controller with a module that overrides
-    # `rescue_with_handler` to raise the exception passed to it. Use this to
-    # specify that an action _should_ raise an exception given appropriate
-    # conditions.
-    #
-    # @example
-    #     describe ProfilesController do
-    #       it "raises a 403 when a non-admin user tries to view another user's profile" do
-    #         profile = create_profile
-    #         login_as profile.user
-    #
-    #         expect do
-    #           bypass_rescue
-    #           get :show, :id => profile.id + 1
-    #         end.to raise_error(/403 Forbidden/)
-    #       end
-    #     end
-    def bypass_rescue
-      controller.extend(BypassRescue)
-    end
-
-    # If method is a named_route, delegates to the RouteSet associated with
-    # this controller.
-    def method_missing(method, *args, &block)
-      if defined?(@routes) && @routes.named_routes.helpers.include?(method)
-        controller.send(method, *args, &block)
-      elsif defined?(@orig_routes) && @orig_routes && @orig_routes.named_routes.helpers.include?(method)
-        controller.send(method, *args, &block)
-      else
-        super
-      end
-    end
-
-    included do
-      subject { controller }
-
-      before do
-        self.routes = ::Rails.application.routes
-      end
-
-      around do |ex|
-        previous_allow_forgery_protection_value = ActionController::Base.allow_forgery_protection
-        begin
-          ActionController::Base.allow_forgery_protection = false
-          ex.call
-        ensure
-          ActionController::Base.allow_forgery_protection = previous_allow_forgery_protection_value
         end
       end
     end

--- a/lib/rspec/rails/example/feature_example_group.rb
+++ b/lib/rspec/rails/example/feature_example_group.rb
@@ -1,32 +1,34 @@
-module RSpec::Rails
-  # Container module for routing spec functionality.
-  module FeatureExampleGroup
-    extend ActiveSupport::Concern
-    include RSpec::Rails::RailsExampleGroup
+module RSpec
+  module Rails
+    # Container module for routing spec functionality.
+    module FeatureExampleGroup
+      extend ActiveSupport::Concern
+      include RSpec::Rails::RailsExampleGroup
 
-    # Default host to be used in Rails route helpers if none is specified.
-    DEFAULT_HOST = "www.example.com"
+      # Default host to be used in Rails route helpers if none is specified.
+      DEFAULT_HOST = "www.example.com"
 
-    included do
-      app = ::Rails.application
-      if app.respond_to?(:routes)
-        include app.routes.url_helpers     if app.routes.respond_to?(:url_helpers)
-        include app.routes.mounted_helpers if app.routes.respond_to?(:mounted_helpers)
+      included do
+        app = ::Rails.application
+        if app.respond_to?(:routes)
+          include app.routes.url_helpers     if app.routes.respond_to?(:url_helpers)
+          include app.routes.mounted_helpers if app.routes.respond_to?(:mounted_helpers)
 
-        if respond_to?(:default_url_options)
-          default_url_options[:host] ||= ::RSpec::Rails::FeatureExampleGroup::DEFAULT_HOST
+          if respond_to?(:default_url_options)
+            default_url_options[:host] ||= ::RSpec::Rails::FeatureExampleGroup::DEFAULT_HOST
+          end
         end
       end
-    end
 
-    # Shim to check for presence of Capybara. Will delegate if present, raise
-    # if not. We assume here that in most cases `visit` will be the first
-    # Capybara method called in a spec.
-    def visit(*)
-      if defined?(super)
-        super
-      else
-        raise "Capybara not loaded, please add it to your Gemfile:\n\ngem \"capybara\""
+      # Shim to check for presence of Capybara. Will delegate if present, raise
+      # if not. We assume here that in most cases `visit` will be the first
+      # Capybara method called in a spec.
+      def visit(*)
+        if defined?(super)
+          super
+        else
+          raise "Capybara not loaded, please add it to your Gemfile:\n\ngem \"capybara\""
+        end
       end
     end
   end

--- a/lib/rspec/rails/example/helper_example_group.rb
+++ b/lib/rspec/rails/example/helper_example_group.rb
@@ -1,38 +1,40 @@
 require 'rspec/rails/view_assigns'
 
-module RSpec::Rails
-  # Container module for helper specs.
-  module HelperExampleGroup
-    extend ActiveSupport::Concern
-    include RSpec::Rails::RailsExampleGroup
-    include ActionView::TestCase::Behavior
-    include RSpec::Rails::ViewAssigns
+module RSpec
+  module Rails
+    # Container module for helper specs.
+    module HelperExampleGroup
+      extend ActiveSupport::Concern
+      include RSpec::Rails::RailsExampleGroup
+      include ActionView::TestCase::Behavior
+      include RSpec::Rails::ViewAssigns
 
-    # @private
-    module ClassMethods
-      def determine_default_helper_class(ignore)
-        described_class
+      # @private
+      module ClassMethods
+        def determine_default_helper_class(_ignore)
+          described_class
+        end
       end
-    end
 
-    # Returns an instance of ActionView::Base with the helper being specified
-    # mixed in, along with any of the built-in rails helpers.
-    def helper
-      _view.tap do |v|
-        v.extend(ApplicationHelper) if defined?(ApplicationHelper)
-        v.assign(view_assigns)
+      # Returns an instance of ActionView::Base with the helper being specified
+      # mixed in, along with any of the built-in rails helpers.
+      def helper
+        _view.tap do |v|
+          v.extend(ApplicationHelper) if defined?(ApplicationHelper)
+          v.assign(view_assigns)
+        end
       end
-    end
 
     private
 
-    def _controller_path(example)
-      example.example_group.described_class.to_s.sub(/Helper/,'').underscore
-    end
+      def _controller_path(example)
+        example.example_group.described_class.to_s.sub(/Helper/, '').underscore
+      end
 
-    included do
-      before do |example|
-        controller.controller_path = _controller_path(example)
+      included do
+        before do |example|
+          controller.controller_path = _controller_path(example)
+        end
       end
     end
   end

--- a/lib/rspec/rails/example/mailer_example_group.rb
+++ b/lib/rspec/rails/example/mailer_example_group.rb
@@ -1,31 +1,35 @@
-module RSpec::Rails
-  # Container module for mailer spec functionality. It is only available if
-  # ActionMailer has been loaded before it.
-  module MailerExampleGroup
-    # This blank module is only necessary for YARD processing. It doesn't
-    # handle the conditional `defined?` check below very well.
+module RSpec
+  module Rails
+    # Container module for mailer spec functionality. It is only available if
+    # ActionMailer has been loaded before it.
+    module MailerExampleGroup
+      # This blank module is only necessary for YARD processing. It doesn't
+      # handle the conditional `defined?` check below very well.
+    end
   end
 end
 
 if defined?(ActionMailer)
-  module RSpec::Rails
-    # Container module for mailer spec functionality.
-    module MailerExampleGroup
-      extend ActiveSupport::Concern
-      include RSpec::Rails::RailsExampleGroup
-      include ActionMailer::TestCase::Behavior
+  module RSpec
+    module Rails
+      # Container module for mailer spec functionality.
+      module MailerExampleGroup
+        extend ActiveSupport::Concern
+        include RSpec::Rails::RailsExampleGroup
+        include ActionMailer::TestCase::Behavior
 
-      included do
-        include ::Rails.application.routes.url_helpers
-        options = ::Rails.configuration.action_mailer.default_url_options
-        options.each { |key, value| default_url_options[key] = value } if options
-      end
+        included do
+          include ::Rails.application.routes.url_helpers
+          options = ::Rails.configuration.action_mailer.default_url_options
+          options.each { |key, value| default_url_options[key] = value } if options
+        end
 
-      # Class-level DSL for mailer specs.
-      module ClassMethods
-        # Alias for `described_class`.
-        def mailer_class
-          described_class
+        # Class-level DSL for mailer specs.
+        module ClassMethods
+          # Alias for `described_class`.
+          def mailer_class
+            described_class
+          end
         end
       end
     end

--- a/lib/rspec/rails/example/model_example_group.rb
+++ b/lib/rspec/rails/example/model_example_group.rb
@@ -1,8 +1,10 @@
-module RSpec::Rails
-  # Container class for model spec functionality. Does not provide anything
-  # special over the common RailsExampleGroup currently.
-  module ModelExampleGroup
-    extend ActiveSupport::Concern
-    include RSpec::Rails::RailsExampleGroup
+module RSpec
+  module Rails
+    # Container class for model spec functionality. Does not provide anything
+    # special over the common RailsExampleGroup currently.
+    module ModelExampleGroup
+      extend ActiveSupport::Concern
+      include RSpec::Rails::RailsExampleGroup
+    end
   end
 end

--- a/lib/rspec/rails/example/request_example_group.rb
+++ b/lib/rspec/rails/example/request_example_group.rb
@@ -1,22 +1,24 @@
-module RSpec::Rails
-  # Container class for request spec functionality.
-  module RequestExampleGroup
-    extend ActiveSupport::Concern
-    include RSpec::Rails::RailsExampleGroup
-    include ActionDispatch::Integration::Runner
-    include ActionDispatch::Assertions
-    include RSpec::Rails::Matchers::RedirectTo
-    include RSpec::Rails::Matchers::RenderTemplate
-    include ActionController::TemplateAssertions
+module RSpec
+  module Rails
+    # Container class for request spec functionality.
+    module RequestExampleGroup
+      extend ActiveSupport::Concern
+      include RSpec::Rails::RailsExampleGroup
+      include ActionDispatch::Integration::Runner
+      include ActionDispatch::Assertions
+      include RSpec::Rails::Matchers::RedirectTo
+      include RSpec::Rails::Matchers::RenderTemplate
+      include ActionController::TemplateAssertions
 
-    # Delegates to `Rails.application`.
-    def app
-      ::Rails.application
-    end
+      # Delegates to `Rails.application`.
+      def app
+        ::Rails.application
+      end
 
-    included do
-      before do
-        @routes = ::Rails.application.routes
+      included do
+        before do
+          @routes = ::Rails.application.routes
+        end
       end
     end
   end

--- a/lib/rspec/rails/example/routing_example_group.rb
+++ b/lib/rspec/rails/example/routing_example_group.rb
@@ -1,53 +1,55 @@
 require "action_dispatch/testing/assertions/routing"
 
-module RSpec::Rails
-  # Container module for routing spec functionality.
-  module RoutingExampleGroup
-    extend ActiveSupport::Concern
-    include RSpec::Rails::RailsExampleGroup
-    include RSpec::Rails::Matchers::RoutingMatchers
-    include RSpec::Rails::Matchers::RoutingMatchers::RouteHelpers
-    include RSpec::Rails::AssertionDelegator.new(ActionDispatch::Assertions::RoutingAssertions)
+module RSpec
+  module Rails
+    # Container module for routing spec functionality.
+    module RoutingExampleGroup
+      extend ActiveSupport::Concern
+      include RSpec::Rails::RailsExampleGroup
+      include RSpec::Rails::Matchers::RoutingMatchers
+      include RSpec::Rails::Matchers::RoutingMatchers::RouteHelpers
+      include RSpec::Rails::AssertionDelegator.new(ActionDispatch::Assertions::RoutingAssertions)
 
-    # Class-level DSL for route specs.
-    module ClassMethods
-      # Specifies the routeset that will be used for the example group. This
-      # is most useful when testing Rails engines.
-      #
-      # @example
-      #     describe MyEngine::PostsController do
-      #       routes { MyEngine::Engine.routes }
-      #
-      #       it "routes posts#index" do
-      #         expect(:get => "/posts").to
-      #           route_to(:controller => "my_engine/posts", :action => "index")
-      #       end
-      #     end
-      def routes(&blk)
-        before do
-          self.routes = blk.call
+      # Class-level DSL for route specs.
+      module ClassMethods
+        # Specifies the routeset that will be used for the example group. This
+        # is most useful when testing Rails engines.
+        #
+        # @example
+        #     describe MyEngine::PostsController do
+        #       routes { MyEngine::Engine.routes }
+        #
+        #       it "routes posts#index" do
+        #         expect(:get => "/posts").to
+        #           route_to(:controller => "my_engine/posts", :action => "index")
+        #       end
+        #     end
+        def routes(&blk)
+          before do
+            self.routes = blk.call
+          end
         end
       end
-    end
 
-    included do
-      before do
-        self.routes = ::Rails.application.routes
+      included do
+        before do
+          self.routes = ::Rails.application.routes
+        end
       end
-    end
 
-    attr_reader :routes
+      attr_reader :routes
 
-    # @private
-    def routes=(routes)
-      @routes = routes
-      assertion_instance.instance_variable_set(:@routes, routes)
-    end
+      # @private
+      def routes=(routes)
+        @routes = routes
+        assertion_instance.instance_variable_set(:@routes, routes)
+      end
 
     private
 
-    def method_missing(m, *args, &block)
-      routes.url_helpers.respond_to?(m) ? routes.url_helpers.send(m, *args) : super
+      def method_missing(m, *args, &block)
+        routes.url_helpers.respond_to?(m) ? routes.url_helpers.send(m, *args) : super
+      end
     end
   end
 end

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -1,169 +1,172 @@
 require 'rspec/rails/view_assigns'
 
-module RSpec::Rails
-  # Container class for view spec functionality.
-  module ViewExampleGroup
-    extend ActiveSupport::Concern
-    include RSpec::Rails::RailsExampleGroup
-    include ActionView::TestCase::Behavior
-    include RSpec::Rails::ViewAssigns
-    include RSpec::Rails::Matchers::RenderTemplate
+module RSpec
+  module Rails
+    # Container class for view spec functionality.
+    module ViewExampleGroup
+      extend ActiveSupport::Concern
+      include RSpec::Rails::RailsExampleGroup
+      include ActionView::TestCase::Behavior
+      include RSpec::Rails::ViewAssigns
+      include RSpec::Rails::Matchers::RenderTemplate
 
-    # @private
-    module ClassMethods
-      def _default_helper
-        base = metadata[:description].split('/')[0..-2].join('/')
-        (base.camelize + 'Helper').constantize if base
-      rescue NameError
-        nil
-      end
-
-      def _default_helpers
-        helpers = [_default_helper].compact
-        helpers << ApplicationHelper if Object.const_defined?('ApplicationHelper')
-        helpers
-      end
-    end
-
-    # DSL exposed to view specs.
-    module ExampleMethods
-      # @overload render
-      # @overload render({:partial => path_to_file})
-      # @overload render({:partial => path_to_file}, {... locals ...})
-      # @overload render({:partial => path_to_file}, {... locals ...}) do ... end
-      #
-      # Delegates to ActionView::Base#render, so see documentation on that
-      # for more info.
-      #
-      # The only addition is that you can call render with no arguments, and RSpec
-      # will pass the top level description to render:
-      #
-      #     describe "widgets/new.html.erb" do
-      #       it "shows all the widgets" do
-      #         render # => view.render(:file => "widgets/new.html.erb")
-      #         # ...
-      #       end
-      #     end
-      def render(options={}, local_assigns={}, &block)
-        options = _default_render_options if Hash === options and options.empty?
-        super(options, local_assigns, &block)
-      end
-
-      # The instance of `ActionView::Base` that is used to render the template.
-      # Use this to stub methods _before_ calling `render`.
-      #
-      #     describe "widgets/new.html.erb" do
-      #       it "shows all the widgets" do
-      #         view.stub(:foo) { "foo" }
-      #         render
-      #         # ...
-      #       end
-      #     end
-      def view
-        _view
-      end
-
-      # Simulates the presence of a template on the file system by adding a
-      # Rails' FixtureResolver to the front of the view_paths list. Designed to
-      # help isolate view examples from partials rendered by the view template
-      # that is the subject of the example.
-      #
-      #     stub_template("widgets/_widget.html.erb" => "This content.")
-      def stub_template(hash)
-        view.view_paths.unshift(ActionView::FixtureResolver.new(hash))
-      end
-
-      # Provides access to the params hash that will be available within the
-      # view.
-      #
-      #     params[:foo] = 'bar'
-      def params
-        controller.params
-      end
-
-      # @deprecated Use `view` instead.
-      def template
-        RSpec.deprecate("template", :replacement => "view")
-        view
-      end
-
-      # @deprecated Use `rendered` instead.
-      def response
-        # `assert_template` expects `response` to implement a #body method
-        # like an `ActionDispatch::Response` does to force the view to render.
-        # For backwards compatibility, we use #response as an alias for
-        # #rendered, but it needs to implement #body to avoid `assert_template`
-        # raising a `NoMethodError`.
-        unless rendered.respond_to?(:body)
-          def rendered.body; self; end;
+      # @private
+      module ClassMethods
+        def _default_helper
+          base = metadata[:description].split('/')[0..-2].join('/')
+          (base.camelize + 'Helper').constantize if base
+        rescue NameError
+          nil
         end
 
-        rendered
-      end
-
-    private
-
-      def _default_render_options
-        if ::Rails::VERSION::STRING >= '3.2'
-          # pluck the handler, format, and locale out of, eg, posts/index.de.html.haml
-          template, *components   = _default_file_to_render.split('.')
-          handler, format, locale = *components.reverse
-
-          render_options = {:template => template}
-          render_options[:handlers] = [handler] if handler
-          render_options[:formats] = [format] if format
-          render_options[:locales] = [locale] if locale
-
-          render_options
-        else
-          {:template => _default_file_to_render}
+        def _default_helpers
+          helpers = [_default_helper].compact
+          helpers << ApplicationHelper if Object.const_defined?('ApplicationHelper')
+          helpers
         end
       end
 
-      def _path_parts
-        _default_file_to_render.split("/")
-      end
-
-      def _controller_path
-        _path_parts[0..-2].join("/")
-      end
-
-      def _inferred_action
-        _path_parts.last.split(".").first
-      end
-
-      def _include_controller_helpers
-        helpers = controller._helpers
-        view.singleton_class.class_exec do
-          include helpers unless included_modules.include?(helpers)
-        end
-      end
-    end
-
-    included do
-      include ExampleMethods
-
-      helper(*_default_helpers)
-
-      before do
-        _include_controller_helpers
-        if view.lookup_context.respond_to?(:prefixes)
-          # rails 3.1
-          view.lookup_context.prefixes << _controller_path
+      # DSL exposed to view specs.
+      module ExampleMethods
+        # @overload render
+        # @overload render({:partial => path_to_file})
+        # @overload render({:partial => path_to_file}, {... locals ...})
+        # @overload render({:partial => path_to_file}, {... locals ...}) do ... end
+        #
+        # Delegates to ActionView::Base#render, so see documentation on that
+        # for more info.
+        #
+        # The only addition is that you can call render with no arguments, and
+        # RSpec will pass the top level description to render:
+        #
+        #     describe "widgets/new.html.erb" do
+        #       it "shows all the widgets" do
+        #         render # => view.render(:file => "widgets/new.html.erb")
+        #         # ...
+        #       end
+        #     end
+        def render(options = {}, local_assigns = {}, &block)
+          options = _default_render_options if Hash === options && options.empty?
+          super(options, local_assigns, &block)
         end
 
-        # fixes bug with differing formats
-        view.lookup_context.view_paths.each(&:clear_cache)
+        # The instance of `ActionView::Base` that is used to render the template.
+        # Use this to stub methods _before_ calling `render`.
+        #
+        #     describe "widgets/new.html.erb" do
+        #       it "shows all the widgets" do
+        #         view.stub(:foo) { "foo" }
+        #         render
+        #         # ...
+        #       end
+        #     end
+        def view
+          _view
+        end
 
-        controller.controller_path = _controller_path
-        controller.request.path_parameters[:controller] = _controller_path
-        controller.request.path_parameters[:action]     = _inferred_action unless _inferred_action =~ /^_/
+        # Simulates the presence of a template on the file system by adding a
+        # Rails' FixtureResolver to the front of the view_paths list. Designed to
+        # help isolate view examples from partials rendered by the view template
+        # that is the subject of the example.
+        #
+        #     stub_template("widgets/_widget.html.erb" => "This content.")
+        def stub_template(hash)
+          view.view_paths.unshift(ActionView::FixtureResolver.new(hash))
+        end
+
+        # Provides access to the params hash that will be available within the
+        # view.
+        #
+        #     params[:foo] = 'bar'
+        def params
+          controller.params
+        end
+
+        # @deprecated Use `view` instead.
+        def template
+          RSpec.deprecate("template", :replacement => "view")
+          view
+        end
+
+        # @deprecated Use `rendered` instead.
+        def response
+          # `assert_template` expects `response` to implement a #body method
+          # like an `ActionDispatch::Response` does to force the view to
+          # render. For backwards compatibility, we use #response as an alias
+          # for #rendered, but it needs to implement #body to avoid
+          # `assert_template` raising a `NoMethodError`.
+          unless rendered.respond_to?(:body)
+            def rendered.body
+              self
+            end
+          end
+
+          rendered
+        end
+
+      private
+
+        def _default_render_options
+          if ::Rails::VERSION::STRING >= '3.2'
+            # pluck the handler, format, and locale out of, eg, posts/index.de.html.haml
+            template, *components   = _default_file_to_render.split('.')
+            handler, format, locale = *components.reverse
+
+            render_options = { :template => template }
+            render_options[:handlers] = [handler] if handler
+            render_options[:formats] = [format] if format
+            render_options[:locales] = [locale] if locale
+
+            render_options
+          else
+            { :template => _default_file_to_render }
+          end
+        end
+
+        def _path_parts
+          _default_file_to_render.split("/")
+        end
+
+        def _controller_path
+          _path_parts[0..-2].join("/")
+        end
+
+        def _inferred_action
+          _path_parts.last.split(".").first
+        end
+
+        def _include_controller_helpers
+          helpers = controller._helpers
+          view.singleton_class.class_exec do
+            include helpers unless included_modules.include?(helpers)
+          end
+        end
       end
 
-      let(:_default_file_to_render) do |example|
-        example.example_group.top_level_description
+      included do
+        include ExampleMethods
+
+        helper(*_default_helpers)
+
+        before do
+          _include_controller_helpers
+          if view.lookup_context.respond_to?(:prefixes)
+            # rails 3.1
+            view.lookup_context.prefixes << _controller_path
+          end
+
+          # fixes bug with differing formats
+          view.lookup_context.view_paths.each(&:clear_cache)
+
+          controller.controller_path = _controller_path
+          controller.request.path_parameters[:controller] = _controller_path
+          controller.request.path_parameters[:action]     = _inferred_action unless _inferred_action =~ /^_/
+        end
+
+        let(:_default_file_to_render) do |example|
+          example.example_group.top_level_description
+        end
       end
     end
   end
 end
-

--- a/lib/rspec/rails/extensions/active_record/proxy.rb
+++ b/lib/rspec/rails/extensions/active_record/proxy.rb
@@ -14,4 +14,3 @@ RSpec.configure do |rspec|
     end
   end
 end
-

--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -10,7 +10,7 @@ module RSpec
         include ActiveRecord::TestFixtures
 
         included do
-          # TODO (DC 2011-06-25) this is necessary because fixture_file_upload
+          # TODO: (DC 2011-06-25) this is necessary because fixture_file_upload
           # accesses fixture_path directly on ActiveSupport::TestCase. This is
           # fixed in rails by https://github.com/rails/rails/pull/1861, which
           # should be part of the 3.1 release, at which point we can include

--- a/lib/rspec/rails/matchers.rb
+++ b/lib/rspec/rails/matchers.rb
@@ -1,8 +1,11 @@
 require 'rspec/core/warnings'
 require 'rspec/expectations'
 
-module RSpec::Rails
-  module Matchers
+module RSpec
+  module Rails
+    # Container module for Rails specific matchers.
+    module Matchers
+    end
   end
 end
 

--- a/lib/rspec/rails/matchers/be_a_new.rb
+++ b/lib/rspec/rails/matchers/be_a_new.rb
@@ -1,77 +1,81 @@
-module RSpec::Rails::Matchers
-  # @api private
-  #
-  # Matcher class for `be_a_new`. Should not be instantiated directly.
-  #
-  # @see RSpec::Rails::Matchers#be_a_new
-  class BeANew < RSpec::Matchers::BuiltIn::BaseMatcher
-    # @private
-    def initialize(expected)
-      @expected = expected
-    end
-
-    # @private
-    def matches?(actual)
-      @actual = actual
-      actual.is_a?(expected) && actual.new_record? && attributes_match?(actual)
-    end
-
-    # @api public
-    # @see RSpec::Rails::Matchers#be_a_new
-    def with(expected_attributes)
-      attributes.merge!(expected_attributes)
-      self
-    end
-
-    # @private
-    def failure_message
-      [].tap do |message|
-        unless actual.is_a?(expected) && actual.new_record?
-          message << "expected #{actual.inspect} to be a new #{expected.inspect}"
+module RSpec
+  module Rails
+    module Matchers
+      # @api private
+      #
+      # Matcher class for `be_a_new`. Should not be instantiated directly.
+      #
+      # @see RSpec::Rails::Matchers#be_a_new
+      class BeANew < RSpec::Matchers::BuiltIn::BaseMatcher
+        # @private
+        def initialize(expected)
+          @expected = expected
         end
-        unless attributes_match?(actual)
-          if unmatched_attributes.size > 1
-            message << "attributes #{unmatched_attributes.inspect} were not set on #{actual.inspect}"
-          else
-            message << "attribute #{unmatched_attributes.inspect} was not set on #{actual.inspect}"
+
+        # @private
+        def matches?(actual)
+          @actual = actual
+          actual.is_a?(expected) && actual.new_record? && attributes_match?(actual)
+        end
+
+        # @api public
+        # @see RSpec::Rails::Matchers#be_a_new
+        def with(expected_attributes)
+          attributes.merge!(expected_attributes)
+          self
+        end
+
+        # @private
+        def failure_message
+          [].tap do |message|
+            unless actual.is_a?(expected) && actual.new_record?
+              message << "expected #{actual.inspect} to be a new #{expected.inspect}"
+            end
+            unless attributes_match?(actual)
+              if unmatched_attributes.size > 1
+                message << "attributes #{unmatched_attributes.inspect} were not set on #{actual.inspect}"
+              else
+                message << "attribute #{unmatched_attributes.inspect} was not set on #{actual.inspect}"
+              end
+            end
+          end.join(' and ')
+        end
+
+      private
+
+        def attributes
+          @attributes ||= {}
+        end
+
+        def attributes_match?(actual)
+          attributes.stringify_keys.all? do |key, value|
+            actual.attributes[key].eql?(value)
           end
         end
-      end.join(' and ')
-    end
 
-    private
+        def unmatched_attributes
+          attributes.stringify_keys.reject do |key, value|
+            actual.attributes[key].eql?(value)
+          end
+        end
+      end
 
-    def attributes
-      @attributes ||= {}
-    end
-
-    def attributes_match?(actual)
-      attributes.stringify_keys.all? do |key, value|
-        actual.attributes[key].eql?(value)
+      # Passes if actual is an instance of `model_class` and returns `false` for
+      # `persisted?`. Typically used to specify instance variables assigned to
+      # views by controller actions
+      #
+      # Use the `with` method to specify the specific attributes to match on the
+      # new record.
+      #
+      # @example
+      #     get :new
+      #     assigns(:thing).should be_a_new(Thing)
+      #
+      #     post :create, :thing => { :name => "Illegal Value" }
+      #     assigns(:thing).should be_a_new(Thing).with(:name => nil)
+      def be_a_new(model_class)
+        BeANew.new(model_class)
       end
     end
-
-    def unmatched_attributes
-      attributes.stringify_keys.reject do |key, value|
-        actual.attributes[key].eql?(value)
-      end
-    end
-  end
-
-  # Passes if actual is an instance of `model_class` and returns `false` for
-  # `persisted?`. Typically used to specify instance variables assigned to
-  # views by controller actions
-  #
-  # Use the `with` method to specify the specific attributes to match on the
-  # new record.
-  #
-  # @example
-  #     get :new
-  #     assigns(:thing).should be_a_new(Thing)
-  #
-  #     post :create, :thing => { :name => "Illegal Value" }
-  #     assigns(:thing).should be_a_new(Thing).with(:name => nil)
-  def be_a_new(model_class)
-    BeANew.new(model_class)
   end
 end

--- a/lib/rspec/rails/matchers/be_new_record.rb
+++ b/lib/rspec/rails/matchers/be_new_record.rb
@@ -1,25 +1,29 @@
-module RSpec::Rails::Matchers
-  # @private
-  class BeANewRecord < RSpec::Matchers::BuiltIn::BaseMatcher
-    def matches?(actual)
-      !actual.persisted?
-    end
+module RSpec
+  module Rails
+    module Matchers
+      # @private
+      class BeANewRecord < RSpec::Matchers::BuiltIn::BaseMatcher
+        def matches?(actual)
+          !actual.persisted?
+        end
 
-    def failure_message
-      "expected #{actual.inspect} to be a new record, but was persisted"
-    end
+        def failure_message
+          "expected #{actual.inspect} to be a new record, but was persisted"
+        end
 
-    def failure_message_when_negated
-      "expected #{actual.inspect} to be persisted, but was a new record"
-    end
-  end
+        def failure_message_when_negated
+          "expected #{actual.inspect} to be persisted, but was a new record"
+        end
+      end
 
-  # Passes if actual returns `false` for `persisted?`.
-  #
-  # @example
-  #     get :new
-  #     expect(assigns(:thing)).to be_new_record
-  def be_new_record
-    BeANewRecord.new
+      # Passes if actual returns `false` for `persisted?`.
+      #
+      # @example
+      #     get :new
+      #     expect(assigns(:thing)).to be_new_record
+      def be_new_record
+        BeANewRecord.new
+      end
+    end
   end
 end

--- a/lib/rspec/rails/matchers/be_valid.rb
+++ b/lib/rspec/rails/matchers/be_valid.rb
@@ -1,44 +1,48 @@
-module RSpec::Rails::Matchers
-  # @private
-  class BeValid < RSpec::Matchers::BuiltIn::Be
-    def initialize(*args)
-      @args = args
-    end
-
-    def matches?(actual)
-      @actual = actual
-      actual.valid?(*@args)
-    end
-
-    def failure_message
-      message = "expected #{actual.inspect} to be valid"
-
-      if actual.respond_to?(:errors)
-        errors = if actual.errors.respond_to?(:full_messages)
-          actual.errors.full_messages
-        else
-          actual.errors
+module RSpec
+  module Rails
+    module Matchers
+      # @private
+      class BeValid < RSpec::Matchers::BuiltIn::Be
+        def initialize(*args)
+          @args = args
         end
 
-        message << ", but got errors: #{errors.map(&:to_s).join(', ')}"
+        def matches?(actual)
+          @actual = actual
+          actual.valid?(*@args)
+        end
+
+        def failure_message
+          message = "expected #{actual.inspect} to be valid"
+
+          if actual.respond_to?(:errors)
+            errors = if actual.errors.respond_to?(:full_messages)
+                       actual.errors.full_messages
+                     else
+                       actual.errors
+                     end
+
+            message << ", but got errors: #{errors.map(&:to_s).join(', ')}"
+          end
+
+          message
+        end
+
+        def failure_message_when_negated
+          "expected #{actual.inspect} not to be valid"
+        end
       end
 
-      message
+      # Passes if the given model instance's `valid?` method is true, meaning
+      # all of the `ActiveModel::Validations` passed and no errors exist. If a
+      # message is not given, a default message is shown listing each error.
+      #
+      # @example
+      #     thing = Thing.new
+      #     expect(thing).to be_valid
+      def be_valid(*args)
+        BeValid.new(*args)
+      end
     end
-
-    def failure_message_when_negated
-      "expected #{actual.inspect} not to be valid"
-    end
-  end
-
-  # Passes if the given model instance's `valid?` method is true, meaning all
-  # of the `ActiveModel::Validations` passed and no errors exist. If a message
-  # is not given, a default message is shown listing each error.
-  #
-  # @example
-  #     thing = Thing.new
-  #     expect(thing).to be_valid
-  def be_valid(*args)
-    BeValid.new(*args)
   end
 end

--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -4,352 +4,356 @@
 #
 # Thank you to all the Rails devs who did the heavy lifting on this!
 
-module RSpec::Rails::Matchers
-  # Namespace for various implementations of `have_http_status`.
-  #
-  # @api private
-  module HaveHttpStatus
-    # Instantiates an instance of the proper matcher based on the provided
-    # `target`.
-    #
-    # @param target [Object] expected http status or code
-    # @return response matcher instance
-    def self.matcher_for_status(target)
-      if GenericStatus.valid_statuses.include?(target)
-        GenericStatus.new(target)
-      elsif Symbol === target
-        SymbolicStatus.new(target)
-      else
-        NumericCode.new(target)
-      end
-    end
-
-    # @api private
-    # Conversion function to coerce the provided object into an
-    # `ActionDispatch::TestResponse`.
-    #
-    # @param obj [Object] object to convert to a response
-    # @return [ActionDispatch::TestResponse]
-    def as_test_response(obj)
-      if ::ActionDispatch::Response === obj
-        ::ActionDispatch::TestResponse.from_response(obj)
-      elsif ::ActionDispatch::TestResponse === obj
-        obj
-      elsif obj.respond_to?(:status_code) && obj.respond_to?(:response_headers)
-        # Acts As Capybara Session
-        # Hack to support `Capybara::Session` without having to load Capybara or
-        # catch `NameError`s for the undefined constants
-        ::ActionDispatch::TestResponse.new.tap{ |resp|
-          resp.status  = obj.status_code
-          resp.headers = obj.response_headers
-          resp.body    = obj.body
-        }
-      else
-        raise TypeError, "Invalid response type: #{obj}"
-      end
-    end
-    module_function :as_test_response
-
-    # @return [String, nil] a formatted failure message if `@invalid_response`
-    #   is present, `nil` otherwise
-    def invalid_response_type_message
-      if @invalid_response
-        "expected a response object, but an instance of " +
-        "#{@invalid_response.class} was received"
-      end
-    end
-
-    # @api private
-    # Provides an implementation for `have_http_status` matching against
-    # numeric http status codes.
-    #
-    # Not intended to be instantiated directly.
-    #
-    # @example
-    #   expect(response).to have_http_status(404)
-    #
-    # @see RSpec::Rails::Matchers.have_http_status
-    class NumericCode < RSpec::Matchers::BuiltIn::BaseMatcher
-      include HaveHttpStatus
-
-      def initialize(code)
-        @expected = code.to_i
-        @actual = nil
-        @invalid_response = nil
-      end
-
-      # @param [Object] response object providing an http code to match
-      # @return [Boolean] `true` if the numeric code matched the `response` code
-      def matches?(response)
-        test_response = as_test_response(response)
-        @actual = test_response.response_code
-        expected == @actual
-      rescue TypeError => _ignored
-        @invalid_response = response
-        false
-      end
-
-      # @return [String]
-      def description
-        "respond with numeric status code #{expected}"
-      end
-
-      # @return [String] explaining why the match failed
-      def failure_message
-        invalid_response_type_message ||
-        "expected the response to have status code #{expected.inspect}" +
-          " but it was #{actual.inspect}"
-      end
-
-      # @return [String] explaining why the match failed
-      def failure_message_when_negated
-        invalid_response_type_message ||
-        "expected the response not to have status code #{expected.inspect}" +
-          " but it did"
-      end
-    end
-
-    # @api private
-    # Provides an implementation for `have_http_status` matching against
-    # Rack symbol http status codes.
-    #
-    # Not intended to be instantiated directly.
-    #
-    # @example
-    #   expect(response).to have_http_status(:created)
-    #
-    # @see RSpec::Rails::Matchers.have_http_status
-    # @see https://github.com/rack/rack/blob/master/lib/rack/utils.rb `Rack::Utils::SYMBOL_TO_STATUS_CODE`
-    class SymbolicStatus < RSpec::Matchers::BuiltIn::BaseMatcher
-      include HaveHttpStatus
-
-      def initialize(status)
-        @expected_status = status
-        @actual = nil
-        @invalid_response = nil
-        unless set_expected_code!
-          raise ArgumentError, "Invalid HTTP status: #{status.inspect}"
-        end
-      end
-
-      # @param [Object] response object providing an http code to match
-      # @return [Boolean] `true` if Rack's associated numeric HTTP code matched
-      #   the `response` code
-      def matches?(response)
-        test_response = as_test_response(response)
-        @actual = test_response.response_code
-        expected == @actual
-      rescue TypeError => _ignored
-        @invalid_response = response
-        false
-      end
-
-      # @return [String]
-      def description
-        "respond with status code #{pp_expected}"
-      end
-
-      # @return [String] explaining why the match failed
-      def failure_message
-        invalid_response_type_message ||
-        "expected the response to have status code #{pp_expected} but it" +
-          " was #{pp_actual}"
-      end
-
-      # @return [String] explaining why the match failed
-      def failure_message_when_negated
-        invalid_response_type_message ||
-        "expected the response not to have status code #{pp_expected} " +
-          "but it did"
-      end
-
-      # The initialized expected status symbol
-      attr_reader :expected_status
-      private :expected_status
-
-    private
-
-      # @return [Symbol] representing the actual http numeric code
-      def actual_status
-        if actual
-          @actual_status ||= compute_status_from(actual)
-        end
-      end
-
-      # Reverse lookup of the Rack status code symbol based on the numeric http
-      # code
+module RSpec
+  module Rails
+    module Matchers
+      # Namespace for various implementations of `have_http_status`.
       #
-      # @param code [Fixnum] http status code to look up
-      # @return [Symbol] representing the http numeric code
-      def compute_status_from(code)
-        status, _ = Rack::Utils::SYMBOL_TO_STATUS_CODE.find{ |_, c| c == code }
-        status
-      end
+      # @api private
+      module HaveHttpStatus
+        # Instantiates an instance of the proper matcher based on the provided
+        # `target`.
+        #
+        # @param target [Object] expected http status or code
+        # @return response matcher instance
+        def self.matcher_for_status(target)
+          if GenericStatus.valid_statuses.include?(target)
+            GenericStatus.new(target)
+          elsif Symbol === target
+            SymbolicStatus.new(target)
+          else
+            NumericCode.new(target)
+          end
+        end
 
-      # @return [String] pretty format the actual response status
-      def pp_actual
-        pp_status(actual_status, actual)
-      end
+        # @api private
+        # Conversion function to coerce the provided object into an
+        # `ActionDispatch::TestResponse`.
+        #
+        # @param obj [Object] object to convert to a response
+        # @return [ActionDispatch::TestResponse]
+        def as_test_response(obj)
+          if ::ActionDispatch::Response === obj
+            ::ActionDispatch::TestResponse.from_response(obj)
+          elsif ::ActionDispatch::TestResponse === obj
+            obj
+          elsif obj.respond_to?(:status_code) && obj.respond_to?(:response_headers)
+            # Acts As Capybara Session
+            # Hack to support `Capybara::Session` without having to load
+            # Capybara or catch `NameError`s for the undefined constants
+            ::ActionDispatch::TestResponse.new.tap do |resp|
+              resp.status  = obj.status_code
+              resp.headers = obj.response_headers
+              resp.body    = obj.body
+            end
+          else
+            raise TypeError, "Invalid response type: #{obj}"
+          end
+        end
+        module_function :as_test_response
 
-      # @return [String] pretty format the expected status and associated code
-      def pp_expected
-        pp_status(expected_status, expected)
-      end
+        # @return [String, nil] a formatted failure message if
+        #   `@invalid_response` is present, `nil` otherwise
+        def invalid_response_type_message
+          return unless @invalid_response
+          "expected a response object, but an instance of " \
+          "#{@invalid_response.class} was received"
+        end
 
-      # @return [String] pretty format the actual response status
-      def pp_status(status, code)
-        if status
-          "#{status.inspect} (#{code})"
-        else
-          code.to_s
+        # @api private
+        # Provides an implementation for `have_http_status` matching against
+        # numeric http status codes.
+        #
+        # Not intended to be instantiated directly.
+        #
+        # @example
+        #   expect(response).to have_http_status(404)
+        #
+        # @see RSpec::Rails::Matchers.have_http_status
+        class NumericCode < RSpec::Matchers::BuiltIn::BaseMatcher
+          include HaveHttpStatus
+
+          def initialize(code)
+            @expected = code.to_i
+            @actual = nil
+            @invalid_response = nil
+          end
+
+          # @param [Object] response object providing an http code to match
+          # @return [Boolean] `true` if the numeric code matched the `response` code
+          def matches?(response)
+            test_response = as_test_response(response)
+            @actual = test_response.response_code
+            expected == @actual
+          rescue TypeError => _ignored
+            @invalid_response = response
+            false
+          end
+
+          # @return [String]
+          def description
+            "respond with numeric status code #{expected}"
+          end
+
+          # @return [String] explaining why the match failed
+          def failure_message
+            invalid_response_type_message ||
+            "expected the response to have status code #{expected.inspect}" \
+              " but it was #{actual.inspect}"
+          end
+
+          # @return [String] explaining why the match failed
+          def failure_message_when_negated
+            invalid_response_type_message ||
+            "expected the response not to have status code " \
+            "#{expected.inspect} but it did"
+          end
+        end
+
+        # @api private
+        # Provides an implementation for `have_http_status` matching against
+        # Rack symbol http status codes.
+        #
+        # Not intended to be instantiated directly.
+        #
+        # @example
+        #   expect(response).to have_http_status(:created)
+        #
+        # @see RSpec::Rails::Matchers.have_http_status
+        # @see https://github.com/rack/rack/blob/master/lib/rack/utils.rb `Rack::Utils::SYMBOL_TO_STATUS_CODE`
+        class SymbolicStatus < RSpec::Matchers::BuiltIn::BaseMatcher
+          include HaveHttpStatus
+
+          def initialize(status)
+            @expected_status = status
+            @actual = nil
+            @invalid_response = nil
+            unless set_expected_code!
+              raise ArgumentError, "Invalid HTTP status: #{status.inspect}"
+            end
+          end
+
+          # @param [Object] response object providing an http code to match
+          # @return [Boolean] `true` if Rack's associated numeric HTTP code matched
+          #   the `response` code
+          def matches?(response)
+            test_response = as_test_response(response)
+            @actual = test_response.response_code
+            expected == @actual
+          rescue TypeError => _ignored
+            @invalid_response = response
+            false
+          end
+
+          # @return [String]
+          def description
+            "respond with status code #{pp_expected}"
+          end
+
+          # @return [String] explaining why the match failed
+          def failure_message
+            invalid_response_type_message ||
+            "expected the response to have status code #{pp_expected} but it" \
+              " was #{pp_actual}"
+          end
+
+          # @return [String] explaining why the match failed
+          def failure_message_when_negated
+            invalid_response_type_message ||
+            "expected the response not to have status code #{pp_expected} " \
+              "but it did"
+          end
+
+          # The initialized expected status symbol
+          attr_reader :expected_status
+          private :expected_status
+
+        private
+
+          # @return [Symbol] representing the actual http numeric code
+          def actual_status
+            return unless actual
+            @actual_status ||= compute_status_from(actual)
+          end
+
+          # Reverse lookup of the Rack status code symbol based on the numeric
+          # http code
+          #
+          # @param code [Fixnum] http status code to look up
+          # @return [Symbol] representing the http numeric code
+          def compute_status_from(code)
+            status, _ = Rack::Utils::SYMBOL_TO_STATUS_CODE.find do |_, c|
+              c == code
+            end
+            status
+          end
+
+          # @return [String] pretty format the actual response status
+          def pp_actual
+            pp_status(actual_status, actual)
+          end
+
+          # @return [String] pretty format the expected status and associated code
+          def pp_expected
+            pp_status(expected_status, expected)
+          end
+
+          # @return [String] pretty format the actual response status
+          def pp_status(status, code)
+            if status
+              "#{status.inspect} (#{code})"
+            else
+              code.to_s
+            end
+          end
+
+          # Sets `expected` to the numeric http code based on the Rack
+          # `expected_status` status
+          #
+          # @see Rack::Utils::SYMBOL_TO_STATUS_CODE
+          # @return [nil] if an associated code could not be found
+          def set_expected_code!
+            @expected ||= Rack::Utils::SYMBOL_TO_STATUS_CODE[expected_status]
+          end
+        end
+
+        # @api private
+        # Provides an implementation for `have_http_status` matching against
+        # `ActionDispatch::TestResponse` http status category queries.
+        #
+        # Not intended to be instantiated directly.
+        #
+        # @example
+        #   expect(response).to have_http_status(:success)
+        #   expect(response).to have_http_status(:error)
+        #   expect(response).to have_http_status(:missing)
+        #   expect(response).to have_http_status(:redirect)
+        #
+        # @see RSpec::Rails::Matchers.have_http_status
+        # @see ActionDispatch::TestResponse
+        class GenericStatus < RSpec::Matchers::BuiltIn::BaseMatcher
+          include HaveHttpStatus
+
+          # @return [Array<Symbol>] of status codes which represent a HTTP status
+          #   code "group"
+          # @see https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
+          def self.valid_statuses
+            [:error, :success, :missing, :redirect]
+          end
+
+          def initialize(type)
+            unless self.class.valid_statuses.include?(type)
+              raise ArgumentError, "Invalid generic HTTP status: #{type.inspect}"
+            end
+            @expected = type
+            @actual = nil
+            @invalid_response = nil
+          end
+
+          # @return [Boolean] `true` if Rack's associated numeric HTTP code matched
+          #   the `response` code
+          def matches?(response)
+            test_response = as_test_response(response)
+            @actual = test_response.response_code
+            test_response.send("#{expected}?")
+          rescue TypeError => _ignored
+            @invalid_response = response
+            false
+          end
+
+          # @return [String]
+          def description
+            "respond with #{type_message}"
+          end
+
+          # @return [String] explaining why the match failed
+          def failure_message
+            invalid_response_type_message ||
+            "expected the response to have #{type_message} but it was #{actual}"
+          end
+
+          # @return [String] explaining why the match failed
+          def failure_message_when_negated
+            invalid_response_type_message ||
+            "expected the response not to have #{type_message} but it was #{actual}"
+          end
+
+        private
+
+          # @return [String] formating the expected status and associated code(s)
+          def type_message
+            @type_message ||= (expected == :error ? "an error" : "a #{expected}") +
+              " status code (#{type_codes})"
+          end
+
+          # @return [String] formatting the associated code(s) for the various
+          #   status code "groups"
+          # @see https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
+          # @see https://github.com/rack/rack/blob/master/lib/rack/response.rb `Rack::Response`
+          def type_codes
+            # At the time of this commit the most recent version of
+            # `ActionDispatch::TestResponse` defines the following aliases:
+            #
+            #     alias_method :success?,  :successful?
+            #     alias_method :missing?,  :not_found?
+            #     alias_method :redirect?, :redirection?
+            #     alias_method :error?,    :server_error?
+            #
+            # It's parent `ActionDispatch::Response` includes
+            # `Rack::Response::Helpers` which defines the aliased methods as:
+            #
+            #     def successful?;   status >= 200 && status < 300; end
+            #     def redirection?;  status >= 300 && status < 400; end
+            #     def server_error?; status >= 500 && status < 600; end
+            #     def not_found?;    status == 404;                 end
+            #
+            # @see https://github.com/rails/rails/blob/ca200378/actionpack/lib/action_dispatch/testing/test_response.rb#L17-L27
+            # @see https://github.com/rails/rails/blob/ca200378/actionpack/lib/action_dispatch/http/response.rb#L74
+            # @see https://github.com/rack/rack/blob/ce4a3959/lib/rack/response.rb#L119-L122
+            @type_codes ||= case expected
+                            when :error
+                              "5xx"
+                            when :success
+                              "2xx"
+                            when :missing
+                              "404"
+                            when :redirect
+                              "3xx"
+                            end
+          end
         end
       end
 
-      # Sets `expected` to the numeric http code based on the Rack
-      # `expected_status` status
+      # @api public
+      # Passes if `response` has a matching HTTP status code.
       #
-      # @see Rack::Utils::SYMBOL_TO_STATUS_CODE
-      # @return [nil] if an associated code could not be found
-      def set_expected_code!
-        @expected ||= Rack::Utils::SYMBOL_TO_STATUS_CODE[expected_status]
+      # The following symbolic status codes are allowed:
+      #
+      # - `Rack::Utils::SYMBOL_TO_STATUS_CODE`
+      # - One of the defined `ActionDispatch::TestResponse` aliases:
+      #   - `:error`
+      #   - `:missing`
+      #   - `:redirect`
+      #   - `:success`
+      #
+      # @example Accepts numeric and symbol statuses
+      #   expect(response).to have_http_status(404)
+      #   expect(response).to have_http_status(:created)
+      #   expect(response).to have_http_status(:success)
+      #   expect(response).to have_http_status(:error)
+      #   expect(response).to have_http_status(:missing)
+      #   expect(response).to have_http_status(:redirect)
+      #
+      # @example Works with standard `response` objects and Capybara's `page`
+      #   expect(response).to have_http_status(404)
+      #   expect(page).to     have_http_status(:created)
+      #
+      # @see https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
+      # @see https://github.com/rack/rack/blob/master/lib/rack/utils.rb `Rack::Utils::SYMBOL_TO_STATUS_CODE`
+      def have_http_status(target)
+        raise ArgumentError, "Invalid HTTP status: nil" unless target
+        HaveHttpStatus.matcher_for_status(target)
       end
     end
-
-    # @api private
-    # Provides an implementation for `have_http_status` matching against
-    # `ActionDispatch::TestResponse` http status category queries.
-    #
-    # Not intended to be instantiated directly.
-    #
-    # @example
-    #   expect(response).to have_http_status(:success)
-    #   expect(response).to have_http_status(:error)
-    #   expect(response).to have_http_status(:missing)
-    #   expect(response).to have_http_status(:redirect)
-    #
-    # @see RSpec::Rails::Matchers.have_http_status
-    # @see ActionDispatch::TestResponse
-    class GenericStatus < RSpec::Matchers::BuiltIn::BaseMatcher
-      include HaveHttpStatus
-
-      # @return [Array<Symbol>] of status codes which represent a HTTP status
-      #   code "group"
-      # @see https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
-      def self.valid_statuses
-        [:error, :success, :missing, :redirect]
-      end
-
-      def initialize(type)
-        unless self.class.valid_statuses.include?(type)
-          raise ArgumentError, "Invalid generic HTTP status: #{type.inspect}"
-        end
-        @expected = type
-        @actual = nil
-        @invalid_response = nil
-      end
-
-      # @return [Boolean] `true` if Rack's associated numeric HTTP code matched
-      #   the `response` code
-      def matches?(response)
-        test_response = as_test_response(response)
-        @actual = test_response.response_code
-        test_response.send("#{expected}?")
-      rescue TypeError => _ignored
-        @invalid_response = response
-        false
-      end
-
-      # @return [String]
-      def description
-        "respond with #{type_message}"
-      end
-
-      # @return [String] explaining why the match failed
-      def failure_message
-        invalid_response_type_message ||
-        "expected the response to have #{type_message} but it was #{actual}"
-      end
-
-      # @return [String] explaining why the match failed
-      def failure_message_when_negated
-        invalid_response_type_message ||
-        "expected the response not to have #{type_message} but it was #{actual}"
-      end
-
-    private
-
-      # @return [String] formating the expected status and associated code(s)
-      def type_message
-        @type_message ||= (expected == :error ? "an error" : "a #{expected}") +
-          " status code (#{type_codes})"
-      end
-
-      # @return [String] formatting the associated code(s) for the various
-      #   status code "groups"
-      # @see https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
-      # @see https://github.com/rack/rack/blob/master/lib/rack/response.rb `Rack::Response`
-      def type_codes
-        # At the time of this commit the most recent version of
-        # `ActionDispatch::TestResponse` defines the following aliases:
-        #
-        #     alias_method :success?,  :successful?
-        #     alias_method :missing?,  :not_found?
-        #     alias_method :redirect?, :redirection?
-        #     alias_method :error?,    :server_error?
-        #
-        # It's parent `ActionDispatch::Response` includes
-        # `Rack::Response::Helpers` which defines the aliased methods as:
-        #
-        #     def successful?;   status >= 200 && status < 300; end
-        #     def redirection?;  status >= 300 && status < 400; end
-        #     def server_error?; status >= 500 && status < 600; end
-        #     def not_found?;    status == 404;                 end
-        #
-        # @see https://github.com/rails/rails/blob/ca200378/actionpack/lib/action_dispatch/testing/test_response.rb#L17-L27
-        # @see https://github.com/rails/rails/blob/ca200378/actionpack/lib/action_dispatch/http/response.rb#L74
-        # @see https://github.com/rack/rack/blob/ce4a3959/lib/rack/response.rb#L119-L122
-        @type_codes ||= case expected
-                        when :error
-                          "5xx"
-                        when :success
-                          "2xx"
-                        when :missing
-                          "404"
-                        when :redirect
-                          "3xx"
-                        end
-      end
-    end
-  end
-
-  # @api public
-  # Passes if `response` has a matching HTTP status code.
-  #
-  # The following symbolic status codes are allowed:
-  #
-  # - `Rack::Utils::SYMBOL_TO_STATUS_CODE`
-  # - One of the defined `ActionDispatch::TestResponse` aliases:
-  #   - `:error`
-  #   - `:missing`
-  #   - `:redirect`
-  #   - `:success`
-  #
-  # @example Accepts numeric and symbol statuses
-  #   expect(response).to have_http_status(404)
-  #   expect(response).to have_http_status(:created)
-  #   expect(response).to have_http_status(:success)
-  #   expect(response).to have_http_status(:error)
-  #   expect(response).to have_http_status(:missing)
-  #   expect(response).to have_http_status(:redirect)
-  #
-  # @example Works with standard `response` objects and Capybara's `page`
-  #   expect(response).to have_http_status(404)
-  #   expect(page).to     have_http_status(:created)
-  #
-  # @see https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
-  # @see https://github.com/rack/rack/blob/master/lib/rack/utils.rb `Rack::Utils::SYMBOL_TO_STATUS_CODE`
-  def have_http_status(target)
-    raise ArgumentError, "Invalid HTTP status: nil" unless target
-    HaveHttpStatus.matcher_for_status(target)
   end
 end

--- a/lib/rspec/rails/matchers/have_rendered.rb
+++ b/lib/rspec/rails/matchers/have_rendered.rb
@@ -1,41 +1,44 @@
-module RSpec::Rails::Matchers
-  # Matcher for template rendering.
-  module RenderTemplate
-    # @private
-    class RenderTemplateMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
+module RSpec
+  module Rails
+    module Matchers
+      # Matcher for template rendering.
+      module RenderTemplate
+        # @private
+        class RenderTemplateMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
+          def initialize(scope, expected, message = nil)
+            @expected = Symbol === expected ? expected.to_s : expected
+            @message = message
+            @scope = scope
+          end
 
-      def initialize(scope, expected, message=nil)
-        @expected = Symbol === expected ? expected.to_s : expected
-        @message = message
-        @scope = scope
-      end
+          # @api private
+          def matches?(*)
+            match_unless_raises ActiveSupport::TestCase::Assertion do
+              @scope.assert_template expected, @message
+            end
+          end
 
-      # @api private
-      def matches?(*)
-        match_unless_raises ActiveSupport::TestCase::Assertion do
-          @scope.assert_template expected, @message
+          # @api private
+          def failure_message
+            rescued_exception.message
+          end
+
+          # @api private
+          def failure_message_when_negated
+            "expected not to render #{expected.inspect}, but did"
+          end
         end
-      end
 
-      # @api private
-      def failure_message
-        rescued_exception.message
-      end
+        # Delegates to `assert_template`.
+        #
+        # @example
+        #     expect(response).to have_rendered("new")
+        def have_rendered(options, message = nil)
+          RenderTemplateMatcher.new(self, options, message)
+        end
 
-      # @api private
-      def failure_message_when_negated
-        "expected not to render #{expected.inspect}, but did"
+        alias_method :render_template, :have_rendered
       end
     end
-
-    # Delegates to `assert_template`.
-    #
-    # @example
-    #     expect(response).to have_rendered("new")
-    def have_rendered(options, message=nil)
-      RenderTemplateMatcher.new(self, options, message)
-    end
-
-    alias_method :render_template, :have_rendered
   end
 end

--- a/lib/rspec/rails/matchers/redirect_to.rb
+++ b/lib/rspec/rails/matchers/redirect_to.rb
@@ -1,35 +1,38 @@
-module RSpec::Rails::Matchers
-  # Matcher for redirects.
-  module RedirectTo
-    # @private
-    class RedirectTo < RSpec::Matchers::BuiltIn::BaseMatcher
+module RSpec
+  module Rails
+    module Matchers
+      # Matcher for redirects.
+      module RedirectTo
+        # @private
+        class RedirectTo < RSpec::Matchers::BuiltIn::BaseMatcher
+          def initialize(scope, expected)
+            @expected = expected
+            @scope = scope
+          end
 
-      def initialize(scope, expected)
-        @expected = expected
-        @scope = scope
-      end
+          def matches?(_)
+            match_unless_raises ActiveSupport::TestCase::Assertion do
+              @scope.assert_redirected_to(@expected)
+            end
+          end
 
-      def matches?(_)
-        match_unless_raises ActiveSupport::TestCase::Assertion do
-          @scope.assert_redirected_to(@expected)
+          def failure_message
+            rescued_exception.message
+          end
+
+          def failure_message_when_negated
+            "expected not to redirect to #{@expected.inspect}, but did"
+          end
+        end
+
+        # Delegates to `assert_redirected_to`.
+        #
+        # @example
+        #     expect(response).to redirect_to(:action => "new")
+        def redirect_to(target)
+          RedirectTo.new(self, target)
         end
       end
-
-      def failure_message
-        rescued_exception.message
-      end
-
-      def failure_message_when_negated
-        "expected not to redirect to #{@expected.inspect}, but did"
-      end
-    end
-
-    # Delegates to `assert_redirected_to`.
-    #
-    # @example
-    #     expect(response).to redirect_to(:action => "new")
-    def redirect_to(target)
-      RedirectTo.new(self, target)
     end
   end
 end

--- a/lib/rspec/rails/matchers/routing_matchers.rb
+++ b/lib/rspec/rails/matchers/routing_matchers.rb
@@ -1,117 +1,119 @@
-module RSpec::Rails::Matchers
-  # Matchers to help with specs for routing code.
-  module RoutingMatchers
-    extend RSpec::Matchers::DSL
+module RSpec
+  module Rails
+    module Matchers
+      # Matchers to help with specs for routing code.
+      module RoutingMatchers
+        extend RSpec::Matchers::DSL
 
-    # @private
-    class RouteToMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
+        # @private
+        class RouteToMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
+          def initialize(scope, *expected)
+            @scope = scope
+            @expected = expected[1] || {}
+            if Hash === expected[0]
+              @expected.merge!(expected[0])
+            else
+              controller, action = expected[0].split('#')
+              @expected.merge!(:controller => controller, :action => action)
+            end
+          end
 
-      def initialize(scope, *expected)
-        @scope = scope
-        @expected = expected[1] || {}
-        if Hash === expected[0]
-          @expected.merge!(expected[0])
-        else
-          controller, action = expected[0].split('#')
-          @expected.merge!(:controller => controller, :action => action)
+          def matches?(verb_to_path_map)
+            @actual = @verb_to_path_map = verb_to_path_map
+            # assert_recognizes does not consider ActionController::RoutingError an
+            # assertion failure, so we have to capture that and Assertion here.
+            match_unless_raises ActiveSupport::TestCase::Assertion, ActionController::RoutingError do
+              path, query = *verb_to_path_map.values.first.split('?')
+              @scope.assert_recognizes(
+                @expected,
+                { :method => verb_to_path_map.keys.first, :path => path },
+                Rack::Utils.parse_nested_query(query)
+              )
+            end
+          end
+
+          def failure_message
+            rescued_exception.message
+          end
+
+          def failure_message_when_negated
+            "expected #{@actual.inspect} not to route to #{@expected.inspect}"
+          end
+
+          def description
+            "route #{@actual.inspect} to #{@expected.inspect}"
+          end
         end
-      end
 
-      def matches?(verb_to_path_map)
-        @actual = @verb_to_path_map = verb_to_path_map
-        # assert_recognizes does not consider ActionController::RoutingError an
-        # assertion failure, so we have to capture that and Assertion here.
-        match_unless_raises ActiveSupport::TestCase::Assertion, ActionController::RoutingError do
-          path, query = *verb_to_path_map.values.first.split('?')
-          @scope.assert_recognizes(
-            @expected,
-            {:method => verb_to_path_map.keys.first, :path => path},
-            Rack::Utils::parse_nested_query(query)
-          )
+        # Delegates to `assert_recognizes`. Supports short-hand controller/action
+        # declarations (e.g. `"controller#action"`).
+        #
+        # @example
+        #
+        #     expect(:get => "/things/special").to route_to(
+        #       :controller => "things",
+        #       :action     => "special"
+        #     )
+        #
+        #     expect(:get => "/things/special").to route_to("things#special")
+        #
+        # @see http://api.rubyonrails.org/classes/ActionDispatch/Assertions/RoutingAssertions.html#method-i-assert_recognizes
+        def route_to(*expected)
+          RouteToMatcher.new(self, *expected)
         end
-      end
 
-      def failure_message
-        rescued_exception.message
-      end
+        # @private
+        class BeRoutableMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
+          def initialize(scope)
+            @scope = scope
+          end
 
-      def failure_message_when_negated
-        "expected #{@actual.inspect} not to route to #{@expected.inspect}"
-      end
+          def matches?(path)
+            @actual = path
+            match_unless_raises ActionController::RoutingError do
+              @routing_options = @scope.routes.recognize_path(
+                path.values.first, :method => path.keys.first
+              )
+            end
+          end
 
-      def description
-        "route #{@actual.inspect} to #{@expected.inspect}"
-      end
-    end
+          def failure_message
+            "expected #{@actual.inspect} to be routable"
+          end
 
-    # Delegates to `assert_recognizes`. Supports short-hand controller/action
-    # declarations (e.g. `"controller#action"`).
-    #
-    # @example
-    #
-    #     expect(:get => "/things/special").to route_to(
-    #       :controller => "things",
-    #       :action     => "special"
-    #     )
-    #
-    #     expect(:get => "/things/special").to route_to("things#special")
-    #
-    # @see http://api.rubyonrails.org/classes/ActionDispatch/Assertions/RoutingAssertions.html#method-i-assert_recognizes
-    def route_to(*expected)
-      RouteToMatcher.new(self, *expected)
-    end
-
-    # @private
-    class BeRoutableMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
-
-      def initialize(scope)
-        @scope = scope
-      end
-
-      def matches?(path)
-        @actual = path
-        match_unless_raises ActionController::RoutingError do
-          @routing_options = @scope.routes.recognize_path(
-            path.values.first, :method => path.keys.first
-          )
+          def failure_message_when_negated
+            "expected #{@actual.inspect} not to be routable, but it routes to #{@routing_options.inspect}"
+          end
         end
-      end
 
-      def failure_message
-        "expected #{@actual.inspect} to be routable"
-      end
+        # Passes if the route expression is recognized by the Rails router based on
+        # the declarations in `config/routes.rb`. Delegates to
+        # `RouteSet#recognize_path`.
+        #
+        # @example You can use route helpers provided by rspec-rails.
+        #     expect(:get  => "/a/path").to be_routable
+        #     expect(:post => "/another/path").to be_routable
+        #     expect(:put  => "/yet/another/path").to be_routable
+        def be_routable
+          BeRoutableMatcher.new(self)
+        end
 
-      def failure_message_when_negated
-        "expected #{@actual.inspect} not to be routable, but it routes to #{@routing_options.inspect}"
-      end
-    end
-
-    # Passes if the route expression is recognized by the Rails router based on
-    # the declarations in `config/routes.rb`. Delegates to
-    # `RouteSet#recognize_path`.
-    #
-    # @example You can use route helpers provided by rspec-rails.
-    #     expect(:get  => "/a/path").to be_routable
-    #     expect(:post => "/another/path").to be_routable
-    #     expect(:put  => "/yet/another/path").to be_routable
-    def be_routable
-      BeRoutableMatcher.new(self)
-    end
-
-    # Helpers for matching different route types.
-    module RouteHelpers
-      # @!method get
-      # @!method post
-      # @!method put
-      # @!method patch
-      # @!method delete
-      # @!method options
-      # @!method head
-      #
-      # Shorthand method for matching this type of route.
-      %w(get post put patch delete options head).each do |method|
-        define_method method do |path|
-          { method.to_sym => path }
+        # Helpers for matching different route types.
+        module RouteHelpers
+          # @!method get
+          # @!method post
+          # @!method put
+          # @!method patch
+          # @!method delete
+          # @!method options
+          # @!method head
+          #
+          # Shorthand method for matching this type of route.
+          %w[get post put patch delete options head].each do |method|
+            define_method method do |path|
+              { method.to_sym => path }
+            end
+          end
         end
       end
     end

--- a/lib/rspec/rails/view_assigns.rb
+++ b/lib/rspec/rails/view_assigns.rb
@@ -35,12 +35,11 @@ module RSpec
         super.merge(_encapsulated_assigns)
       end
 
-      private
+    private
 
       def _encapsulated_assigns
         @_encapsulated_assigns ||= {}
       end
-
     end
   end
 end

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -11,7 +11,7 @@ module RSpec
       # DSL methods
       module ClassMethods
         # @see RSpec::Rails::ControllerExampleGroup
-        def render_views(true_or_false=true)
+        def render_views(true_or_false = true)
           @render_views = true_or_false
         end
 
@@ -44,15 +44,13 @@ module RSpec
         end
 
         def find_all(*args)
-          original_path_set.find_all(*args).collect do |template|
+          original_path_set.find_all(*args).map do |template|
             ::ActionView::Template.new(
               "",
               template.identifier,
               EmptyTemplateHandler,
-              {
-                :virtual_path => template.virtual_path,
-                :format => template.formats
-              }
+              :virtual_path => template.virtual_path,
+              :format => template.formats
             )
           end
         end
@@ -60,7 +58,7 @@ module RSpec
 
       # @private
       class EmptyTemplateHandler
-        def self.call(template)
+        def self.call(_template)
           %("")
         end
       end
@@ -77,7 +75,7 @@ module RSpec
           lookup_context.view_paths.push(*_path_decorator(new_path))
         end
 
-        private
+      private
 
         def _path_decorator(path)
           EmptyTemplatePathSetDecorator.new(ActionView::PathSet.new(Array.wrap(path)))

--- a/script/run_build
+++ b/script/run_build
@@ -24,8 +24,24 @@ function documentation_enforced {
   fi
 }
 
+function style_and_lint_enforced {
+ if [ -x ./bin/rubocop ]; then
+   return 0
+ else
+   return 1
+ fi
+}
+
+function check_style_and_lint {
+  bin/rubocop lib
+}
+
 bin/rake --trace
 
 if documentation_enforced; then
   check_documentation_coverage
+fi
+
+if style_and_lint_enforced; then
+  check_style_and_lint
 fi


### PR DESCRIPTION
The initial rubocop config checks were pulled from rspec/rspec-expectations#544. I've added an exclude section with comments for which checks are being disabled for specific files and why.

Additionally, I'm only checking the `lib/` directory right now. It may be good to check a few other directories in the future (i.e. `features/`, `templates/`), but I'm not sure just yet.

Resolve #1072 
