### PR TITLE
make controller_spec templates conform

### DIFF
--- a/lib/generators/rspec/controller/templates/controller_spec.rb
+++ b/lib/generators/rspec/controller/templates/controller_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 RSpec.describe <%= class_name %>Controller, :type => :controller do
 
 <% for action in actions -%>
-  describe "GET '<%= action %>'" do
+  describe "GET <%= action %>" do
     it "returns http success" do
-      get '<%= action %>'
+      get :<%= action %>
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
I noticed that the generated specs are different for `scaffold/templates/controller_spec.rb` and `controller/templates/controller_spec.rb`.

This PR equalizes both to the same style:
- no single quotes around action in describe-message
- `get` invocation using a symbol of the action
