### PR TITLE
Check for ActiveRecord configurations for fixture support

### DIFF
--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -2,7 +2,7 @@ module RSpec
   module Rails
     # @private
     module FixtureSupport
-      if defined?(ActiveRecord::TestFixtures)
+      if defined?(ActiveRecord::TestFixtures) && ActiveRecord::Base.configurations.present?
         extend ActiveSupport::Concern
         include RSpec::Rails::SetupAndTeardownAdapter
         include RSpec::Rails::MinitestLifecycleAdapter if ::ActiveRecord::VERSION::STRING > '4'


### PR DESCRIPTION
Currently ActiveRecord fixtures are included if ActiveRecord is defined,
but not set up. On Rails < 4.1.0 this was not a problem, as it had a
test in ActiveRecord::TestFixtures to see if ActiveRecord was
configured. On Rails 4.1.0 this check was removed, causing rspec-rails
to always try to connect to a Database even if there is not one.
