### PR TITLE
Fix controller spec fails on edge Rails

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ Enhancements:
 
 Bug Fixes:
 
+* Fix controller route lookup for Rails 4.2. (Tomohiro Hashidate, #1142)
+
 ### 3.0.2 / 2014-07-21
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.0.1...v3.0.2)
 

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -8,6 +8,8 @@ when /master/
   gem "rails-observers", :git => "git://github.com/rails/rails-observers"
   gem 'sass-rails', :git => "git://github.com/rails/sass-rails.git"
   gem 'coffee-rails', :git => "git://github.com/rails/coffee-rails.git"
+  gem 'rack', :git => 'git://github.com/rack/rack.git'
+  gem 'i18n', :git => 'git://github.com/svenfuchs/i18n.git', :branch => 'master'
 when /stable$/
   gem "rails", :git => "git://github.com/rails/rails.git", :branch => version
 when nil, false, ""

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -158,9 +158,7 @@ module RSpec
       # If method is a named_route, delegates to the RouteSet associated with
       # this controller.
       def method_missing(method, *args, &block)
-        if defined?(@routes) && @routes.named_routes.helpers.include?(method)
-          controller.send(method, *args, &block)
-        elsif defined?(@orig_routes) && @orig_routes && @orig_routes.named_routes.helpers.include?(method)
+        if route_available?(method)
           controller.send(method, *args, &block)
         else
           super
@@ -182,6 +180,23 @@ module RSpec
           ensure
             ActionController::Base.allow_forgery_protection = previous_allow_forgery_protection_value
           end
+        end
+      end
+
+    private
+
+      def route_available?(method)
+        (defined?(@routes) && route_defined?(routes, method)) ||
+          (defined?(@orig_routes) && route_defined?(@orig_routes, method))
+      end
+
+      def route_defined?(routes, method)
+        return false if routes.nil?
+
+        if routes.named_routes.respond_to?(:route_defined?)
+          routes.named_routes.route_defined?(method)
+        else
+          routes.named_routes.helpers.include?(method)
         end
       end
     end


### PR DESCRIPTION
Current edge Rails split named_routes.helpers to path_helpers and url_helpers.
And add `route_defined?` method to NamedRouteCollection.
Because of it, Controller Spec is failed on edge Rails.
This patch fixes it.

refs.
- https://github.com/rails/rails/commit/f889831ed65bea14b6b687bdaa4012d73d81b2a6
- https://github.com/rails/rails/commit/210b338db20b1cdd0684f40bd78b52ed16148b99
