### PR TITLE
Update constructor to handle parent changes.

### DIFF
--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -121,7 +121,8 @@ module RSpec
         end
       end
 
-      def initialize
+      def initialize(*args)
+        super
         @example = nil
       end
 


### PR DESCRIPTION
Previously there was no constructor for the `ExampleGroup`. This changed
with rspec/rspec-core#1687. Instead of exactly matching the contructor,
use the standard Ruby argument catch-all to simply delegate up the
chain.
