### PR TITLE
Explicitly create pathnames in sanity_check_spec.rb

### DIFF
--- a/spec/sanity_check_spec.rb
+++ b/spec/sanity_check_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
+require 'pathname'
 
 RSpec.describe "Verify required rspec dependencies" do
 
-  tmp_root = RSpec::Core::RubyProject.root.join("tmp")
+  tmp_root = Pathname.new(RSpec::Core::RubyProject.root).join("tmp")
 
   before{ FileUtils.mkdir_p tmp_root }
 


### PR DESCRIPTION
This is so that we can return strings _or_ pathnames from
RSpec::Core::RubyProject.root
