### PR TITLE
Use '~> 3.1.0' instead of '~> 3.0.0'...

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add `rspec-rails` to **both** the `:development` and `:test` groups in the
 
 ```ruby
 group :development, :test do
-  gem 'rspec-rails', '~> 3.1.0'
+  gem 'rspec-rails', '~> 3.0'
 end
 ```
 


### PR DESCRIPTION
...in install instructions for 3.1 maintenance branch
