### PR TITLE
Warn on context fixture helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,24 @@ language: ruby
 rvm:
   - 1.8.7
   - 2.1.4
-  - 2.1.3
-  - 2.1.2
-  - 2.1.1
-  - 2.1.0
-  - 2.0.0
-  - 1.9.3
-  - 1.9.2
+#  - 2.1.3
+#  - 2.1.2
+#  - 2.1.1
+#  - 2.1.0
+#  - 2.0.0
+#  - 1.9.3
+#  - 1.9.2
 
 env:
   - RAILS_VERSION='~> 4.2.0.beta2'
-  - RAILS_VERSION=master
+#  - RAILS_VERSION=master
   - RAILS_VERSION='~> 4.1.0'
-  - RAILS_VERSION=4-1-stable
-  - RAILS_VERSION='~> 4.0.4'
-  - RAILS_VERSION=4-0-stable
-  - RAILS_VERSION='~> 3.2.17'
-  - RAILS_VERSION=3-2-stable
-  - RAILS_VERSION='~> 3.1.12'
+#  - RAILS_VERSION=4-1-stable
+#  - RAILS_VERSION='~> 4.0.4'
+#  - RAILS_VERSION=4-0-stable
+#  - RAILS_VERSION='~> 3.2.17'
+#  - RAILS_VERSION=3-2-stable
+#  - RAILS_VERSION='~> 3.1.12'
   - RAILS_VERSION='~> 3.0.20'
 
 sudo: false

--- a/lib/rspec/rails/fixture_context_helpers.rb
+++ b/lib/rspec/rails/fixture_context_helpers.rb
@@ -1,0 +1,72 @@
+module RSpec
+  module Rails
+    # @private
+    module FixtureContextHelpers
+      # @private
+      module TrackableFixtures
+        def known_fixtures
+          @_known_fixtures ||= []
+        end
+
+        def to_s
+          "#{super}(#{known_fixtures.sort.join(', ')})"
+        end
+        alias_method :inspect, :to_s
+      end
+
+    private
+
+      def convert_to_accessors(names)
+        names.map { |n| n.to_s.tr('/', '_').to_sym }
+      end
+
+      def ensure_prevent_fixture_helpers
+        if const_defined?(:PreventFixtures, false)
+          const_get(:PreventFixtures, false)
+        else
+          set_prevent_fixture_helpers
+        end
+      end
+
+      def prevent_fixture_helpers
+        const_get(:PreventFixtures) if const_defined?(:PreventFixtures)
+      end
+
+      def prevent_fixtures_in_context(accessor_names)
+        return if accessor_names.empty?
+        ensure_prevent_fixture_helpers.module_exec do
+          (accessor_names - known_fixtures).each do |accessor_name|
+            known_fixtures << accessor_name
+            define_method(accessor_name) do |*_fixture_names|
+              raise <<-EOS
+Fixture accessor `#{accessor_name}` invoked in a `before` or `after` context hook at:
+  #{CallerFilter.first_non_rspec_line}
+
+Calling fixture accessors from a context hook is not supported.
+
+Active Record fixtures are automatically loaded into the database before each
+example. To ensure consistent data, the environment deletes the fixtures before
+running the load each time.
+
+Fixture accessor helpers are not intended to be called in a context hook, as
+they exist to load database state that is reset between each example, while
+`before(:context)` exists to define state that is shared across examples in an
+example group and `after(:context)` exists to cleanup state that is shared
+across examples in an example group.
+EOS
+            end
+          end
+        end
+      end
+
+      def set_prevent_fixture_helpers
+        existing_helpers = prevent_fixture_helpers
+        mod = Module.new do
+          extend TrackableFixtures
+          include existing_helpers if existing_helpers
+        end
+        const_set(:PreventFixtures, mod)
+      end
+    end
+  end
+end

--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -1,3 +1,4 @@
+require_relative 'fixture_context_helpers'
 module RSpec
   module Rails
     # @private
@@ -25,6 +26,34 @@ module RSpec
           self.use_transactional_fixtures = RSpec.configuration.use_transactional_fixtures
           self.use_instantiated_fixtures  = RSpec.configuration.use_instantiated_fixtures
           fixtures RSpec.configuration.global_fixtures if RSpec.configuration.global_fixtures
+        end
+
+        # @private
+        module ClassMethods
+          include RSpec::Rails::FixtureContextHelpers
+
+          def run_before_context_hooks(example_group_instance)
+            if (_helpers = prevent_fixture_helpers)
+              example_group_instance.extend _helpers
+            end
+            super
+          end
+          private :run_before_context_hooks
+
+          def run_after_context_hooks(example_group_instance)
+            if (_helpers = prevent_fixture_helpers)
+              example_group_instance.extend _helpers
+            end
+            super
+          end
+          private :run_before_context_hooks
+
+          def setup_fixture_accessors(table_names = nil)
+            fixture_set_names = Array(fixture_set_names || fixture_table_names)
+            prevent_fixtures_in_context(convert_to_accessors(fixture_set_names))
+            super
+          end
+          private :setup_fixture_accessors
         end
       end
     end


### PR DESCRIPTION
Fixtures are controlled by the underlying `ActiveRecord::TestFixtures` code. Which sets up fixtures before **each** example. While the database _may_ have fixture data in it before this point, that data will be reset once the test fixture code runs.
    
When the `fixtures` message is sent in an example group, or global fixtures are defined, the Active Record test fixtures register the accessors in an anonymous module. That module is included in the example group's ancestors.
    
Which means the accessor helpers are available in any example group instance; thus they are available in `before(:context)` and `after(:context)`. However, the internal fixture setup and cache has not been performed yet. Attempting to call a fixture helper prior to the fixtures being setup, raises an undefined method on `NilClass` error.
    
This update shims a module into the fixture registration process. The module creates mirrored accessor helpers which raise a helpful error when called. In order to ensure these are only available in context hooks, the private RSpec APIs (:grimacing:), are redeclared in order to extend the provided example group instance with the accessor preventing module.

Resolve #1201

**TODO:**

- [ ] Find a way to test this properly
- [ ] Update the cuke documentation about fixtures (there are several pages that need updating)
- [ ] Add Changelog entry
- [ ] Remove reduced travis matrix