### PR TITLE
Add more local ignore files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ bin
 *.rbc
 .yardoc
 .bundle
-.rails-version
+.rails-version*
 .DS_Store
 Gemfile-custom
 .rbenv-version
@@ -19,3 +19,4 @@ Gemfile-custom
 /.ruby-version
 bundle
 .bundle
+specs.out


### PR DESCRIPTION
Allows for multiple `.rails-versionX` files to exist so developers can easily symlink the root `.rails-version` instead of modifying its contents.

Ignores the `specs.out` generated when running the full build script.

[ci skip]
