### PR TITLE
Reduce build matrix from 81 jobs to 36.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,7 @@ language: ruby
 
 rvm:
   - 1.8.7
-  - 2.1.4
-  - 2.1.3
-  - 2.1.2
-  - 2.1.1
-  - 2.1.0
+  - 2.1
   - 2.0.0
   - 1.9.3
   - 1.9.2
@@ -41,15 +37,7 @@ matrix:
     # 3.0.x is not supported on MRI 2.0+
     - rvm: 2.0.0
       env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.1.0
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.1.1
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.1.2
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.1.3
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.1.4
+    - rvm: 2.1
       env: RAILS_VERSION='~> 3.0.20'
     # 4.x is not supported on MRI ruby-1.8.7 or 1.9.2
     - rvm: 1.8.7


### PR DESCRIPTION
The build matrix is getting way too large. Even with the high parallelization of the matrix it still takes 2.5+ hours of real time to complete.

With the release of Ruby 2.1.5 we see the build matrix grow by another nine combinations, increasing from 72 to 81 jobs. While Ruby 2.1 tends to run faster, it still is more time to wait.

Currently, there has not been a Ruby 2.1.x specific bug reported for any of the 2.1 releases. Ruby it attempting to follow close to SemVer for the 2.1+ releases. With this change, I feel it is relatively safe to adopt this lighter build matrix.

If an issue does appear which is specific to a single 2.1.x release, we can easily add it back. If it only occurs with a specific Rails version then we can use the `include` feature to only add back as few jobs as necessary.
