### PR TITLE
Make sure the `rspec:feature` generator generates code that works when monkey-patching is disabled

### DIFF
--- a/lib/generators/rspec/feature/templates/feature_spec.rb
+++ b/lib/generators/rspec/feature/templates/feature_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-feature "<%= class_name.pluralize %>", :type => :feature do
+RSpec.feature "<%= class_name.pluralize %>", :type => :feature do
   pending "add some scenarios (or delete) #{__FILE__}"
 end

--- a/spec/generators/rspec/feature/feature_generator_spec.rb
+++ b/spec/generators/rspec/feature/feature_generator_spec.rb
@@ -23,7 +23,7 @@ describe Rspec::Generators::FeatureGenerator, :type => :generator do
           expect(feature_spec).to contain(/require 'rails_helper'/)
         end
         it "contains the feature" do
-          expect(feature_spec).to contain(/feature "Posts", :type => :feature/)
+          expect(feature_spec).to contain(/^RSpec.feature "Posts", :type => :feature/)
         end
       end
     end


### PR DESCRIPTION
All of the other generators generated code starting with `RSpec.describe`, but the feature one was just `feature` instead of `RSpec.feature` (which breaks when `config.disable_monkey_patching!` is used.)
