### PR TITLE
Refactored HelperExampleGroup to use view context instances from a controller

### DIFF
--- a/lib/rspec/rails/example/helper_example_group.rb
+++ b/lib/rspec/rails/example/helper_example_group.rb
@@ -31,10 +31,10 @@ module RSpec
         let(:controller) { controller_class.new }
 
         let(:helper) do
-          view_context = controller.view_context
-          view_context.extend(ApplicationHelper) if defined?(ApplicationHelper)
-          view_context.extend(described_class)
-          view_context
+          @controller = controller
+          view.extend(ApplicationHelper) if defined?(ApplicationHelper)
+          view.extend(described_class)
+          view
         end
 
         subject { helper }

--- a/lib/rspec/rails/example/helper_example_group.rb
+++ b/lib/rspec/rails/example/helper_example_group.rb
@@ -19,8 +19,8 @@ module RSpec
       included do
         let(:controller_class) do
           controller_class_name = described_class.name.gsub("Helper", "Controller")
-          if self.class.const_defined?("::#{controller_class_name}")
-            self.class.const_get(controller_class_name.to_sym)
+          if Object.const_defined?(controller_class_name)
+            Object.const_get(controller_class_name.to_sym)
           elsif defined?(ApplicationController)
             ApplicationController
           else

--- a/lib/rspec/rails/example/helper_example_group.rb
+++ b/lib/rspec/rails/example/helper_example_group.rb
@@ -6,35 +6,32 @@ module RSpec
     module HelperExampleGroup
       extend ActiveSupport::Concern
       include RSpec::Rails::RailsExampleGroup
-      include ActionView::TestCase::Behavior
-      include RSpec::Rails::ViewAssigns
 
-      # @private
-      module ClassMethods
-        def determine_default_helper_class(_ignore)
-          described_class
-        end
-      end
-
-      # Returns an instance of ActionView::Base with the helper being specified
-      # mixed in, along with any of the built-in rails helpers.
-      def helper
-        _view.tap do |v|
-          v.extend(ApplicationHelper) if defined?(ApplicationHelper)
-          v.assign(view_assigns)
+      def assign(instance_variable_name, value)
+        [helper, controller].each do |object|
+          object.instance_variable_set("@#{instance_variable_name}", value)
         end
       end
 
     private
 
-      def _controller_path(example)
-        example.example_group.described_class.to_s.sub(/Helper/, '').underscore
-      end
-
       included do
-        before do |example|
-          controller.controller_path = _controller_path(example)
+        let(:controller_class) do
+          controller_class_name = described_class.name.gsub("Helper", "Controller")
+          if self.class.const_defined?("::#{controller_class_name}")
+            self.class.const_get(controller_class_name.to_sym)
+          elsif defined?(ApplicationController)
+            ApplicationController
+          else
+            ActionController::Base
+          end
         end
+
+        let(:controller) { controller_class.new }
+
+        let(:helper) { controller.view_context }
+
+        subject { helper }
       end
     end
   end

--- a/lib/rspec/rails/example/helper_example_group.rb
+++ b/lib/rspec/rails/example/helper_example_group.rb
@@ -6,6 +6,7 @@ module RSpec
     module HelperExampleGroup
       extend ActiveSupport::Concern
       include RSpec::Rails::RailsExampleGroup
+      include ActionView::TestCase::Behavior
 
       def assign(instance_variable_name, value)
         [helper, controller].each do |object|

--- a/lib/rspec/rails/example/helper_example_group.rb
+++ b/lib/rspec/rails/example/helper_example_group.rb
@@ -7,6 +7,7 @@ module RSpec
       extend ActiveSupport::Concern
       include RSpec::Rails::RailsExampleGroup
       include ActionView::TestCase::Behavior
+      include RSpec::Rails::ViewAssigns
 
       def assign(instance_variable_name, value)
         [helper, controller].each do |object|
@@ -32,6 +33,7 @@ module RSpec
 
         let(:helper) do
           @controller = controller
+          view.assign(view_assigns)
           view.extend(ApplicationHelper) if defined?(ApplicationHelper)
           view.extend(described_class)
           view

--- a/lib/rspec/rails/example/helper_example_group.rb
+++ b/lib/rspec/rails/example/helper_example_group.rb
@@ -32,6 +32,7 @@ module RSpec
 
         let(:helper) do
           view_context = controller.view_context
+          view_context.extend(ApplicationHelper) if defined?(ApplicationHelper)
           view_context.extend(described_class)
           view_context
         end

--- a/lib/rspec/rails/example/helper_example_group.rb
+++ b/lib/rspec/rails/example/helper_example_group.rb
@@ -30,7 +30,11 @@ module RSpec
 
         let(:controller) { controller_class.new }
 
-        let(:helper) { controller.view_context }
+        let(:helper) do
+          view_context = controller.view_context
+          view_context.extend(described_class)
+          view_context
+        end
 
         subject { helper }
       end

--- a/spec/rspec/rails/example/helper_example_group_spec.rb
+++ b/spec/rspec/rails/example/helper_example_group_spec.rb
@@ -2,9 +2,8 @@ require "spec_helper"
 
 module RSpec::Rails
   describe HelperExampleGroup do
-    module ::FoosHelper
-      def foo; end
-    end
+    module ::FoosHelper; end
+
     subject { HelperExampleGroup }
 
     it_behaves_like "an rspec-rails example group mixin", :helper,
@@ -97,7 +96,25 @@ module RSpec::Rails
       end
 
       it "returns a view context extended with the described helper module" do
-        expect(subject).to respond_to(:foo)
+        expect(subject).to be_a(FoosHelper)
+      end
+
+      context "ApplicationHelper exists" do
+        let!(:application_helper) { Module.new }
+
+        before { stub_const("ApplicationHelper", application_helper) }
+
+        it "returns a view context extended with the ApplicationHelper" do
+          expect(subject).to be_an(application_helper)
+        end
+
+        it "does not override the described module's methods" do
+          singleton_class = (class << subject; self; end)
+          higher_priority_mixin = singleton_class.ancestors.find do |ancestor|
+            ancestor == FoosHelper || ancestor == application_helper
+          end
+          expect(higher_priority_mixin).to eq(FoosHelper)
+        end
       end
     end
 

--- a/spec/rspec/rails/example/helper_example_group_spec.rb
+++ b/spec/rspec/rails/example/helper_example_group_spec.rb
@@ -2,7 +2,9 @@ require "spec_helper"
 
 module RSpec::Rails
   describe HelperExampleGroup do
-    module ::FoosHelper; end
+    module ::FoosHelper
+      def foo; end
+    end
     subject { HelperExampleGroup }
 
     it_behaves_like "an rspec-rails example group mixin", :helper,
@@ -92,6 +94,10 @@ module RSpec::Rails
       it "returns a view context associated with the controller" do
         expect(subject).to be_an(ActionView::Base)
         expect(subject.controller).to be_an(ActionController::Base)
+      end
+
+      it "returns a view context extended with the described helper module" do
+        expect(subject).to respond_to(:foo)
       end
     end
 

--- a/spec/rspec/rails/example/helper_example_group_spec.rb
+++ b/spec/rspec/rails/example/helper_example_group_spec.rb
@@ -8,6 +8,19 @@ module RSpec::Rails
     it_behaves_like "an rspec-rails example group mixin", :helper,
       './spec/helpers/', '.\\spec\\helpers\\'
 
+    context "ActionView::TestCase::Behavior" do
+      subject do
+        group = RSpec::Core::ExampleGroup.describe ::FoosHelper do
+          include HelperExampleGroup
+        end
+        group.new
+      end
+
+      it "mixes in ActionView::TestCase::Behavior" do
+        expect(subject).to be_an(ActionView::TestCase::Behavior)
+      end
+    end
+
     describe "#controller_class" do
       subject do
         group = RSpec::Core::ExampleGroup.describe ::FoosHelper do


### PR DESCRIPTION
This way it's possible to call helper methods defined on a controller in the helper's methods.