### PR TITLE
Display previously hidden RSpec generators in generator usage docs output by 'rails g'

### DIFF
--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -11,6 +11,10 @@ module RSpec
       generators.integration_tool :rspec
       generators.test_framework :rspec
 
+      generators do
+        ::Rails::Generators.hidden_namespaces.reject! { |namespace| namespace.start_with?("rspec") }
+      end
+
       rake_tasks do
         load "rspec/rails/tasks/rspec.rake"
       end


### PR DESCRIPTION
Related to #722 and #749
