### PR TITLE
Update supported RSpec versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,4 @@ matrix:
       env: RAILS_VERSION='~> 4.0.4'
     - rvm: 2.2
       env: RAILS_VERSION=4-0-stable
-  allow_failures:
-    # Allow Rails 4.2.0 to fail until https://github.com/rails/rails-dom-testing/issues/28 is resolved
-    - env: RAILS_VERSION='~> 4.2.0'
-    - env: RAILS_VERSION=4-2-stable
   fast_finish: true


### PR DESCRIPTION
Rails 4.2.0 has been officially released. Drop usage of the RC line and
use the main releases.

Rails `master` is now targeting Rails 5.x. Plans for Rails 5.x support
with RSpec is not official yet. Until we determine our planned support line
drop support for Rails `master` on rspec-rails `master`.
