### PR TITLE
Fix error with inheritance of outer group's anonymous controller

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@ Bug Fixes:
   monkey-patching is disabled. (Rebecca Skinner, #1231)
 * Fix `NoMethodError` caused by calling `RSpec.feature` when Capybara is not
   available or the Capybara version is < 2.4.0. (Aaron Kromer, #1261)
+* Fix `ArgumentError` when when using an anonymous controller which inherits an
+  outer group's anonymous controller. (Yuji Nakayama, #1260)
 
 ### 3.1.0 / 2014-09-04
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.0.2...v3.1.0)

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -64,7 +64,7 @@ module RSpec
               if superclass == root_controller || superclass.abstract?
                 "AnonymousController"
               else
-                superclass.to_s
+                superclass.name
               end
             end
           end

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -169,6 +169,16 @@ module RSpec::Rails
         group.controller(abstract_controller) { }
         expect(controller_class.name).to eq "AnonymousController"
       end
+
+      it "sets name as AnonymousController if it inherits outer group's anonymous controller" do
+        outer_group = group_for ApplicationController
+        outer_group.controller { }
+
+        inner_group = group.describe { }
+        inner_group.controller(outer_group.controller_class) { }
+
+        expect(inner_group.controller_class.name).to eq "AnonymousController"
+      end
     end
 
     context "in a namespace" do


### PR DESCRIPTION
This fixes an error raised with the following spec:

```ruby
require 'rails_helper'

describe ApplicationController do
  controller do
    def index
      head status
    end
  end

  context 'when #status returns 200' do
    controller(controller_class) do # Inheriting the outer group's anonymous controller
      def status
        200
      end
    end

    it 'returns status 200' do
      expect(get(:index).status).to eq(200)
    end
  end
end
```

and run:

```bash
$ bundle exec rspec
F

Failures:

  1) ApplicationController when #status returns 200 returns status 200
     Failure/Error: Unable to find matching line from backtrace
     ArgumentError:
       '#<class:0x007fdad27a6340>' is not a supported controller name. This can lead to potential routing problems. See http://guides.rubyonrails.org/routing.html#specifying-a-controller-to-use
     # /Users/me/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/actionpack-4.1.8/lib/action_dispatch/routing/mapper.rb:249:in `default_controller_and_action'
     # /Users/me/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/actionpack-4.1.8/lib/action_dispatch/routing/mapper.rb:117:in `normalize_options!'
     # /Users/me/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/actionpack-4.1.8/lib/action_dispatch/routing/mapper.rb:65:in `initialize'
```

FYI the spec was passing on RSpec 2.14, though I'm not sure whether the support for inheritance of anonymous controller was intentional.