### PR TITLE
Update gemspec capping Rails at 4.2

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |s|
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  s.add_runtime_dependency(%q<activesupport>, [">= 3.0"])
-  s.add_runtime_dependency(%q<actionpack>, [">= 3.0"])
-  s.add_runtime_dependency(%q<railties>, [">= 3.0"])
+  s.add_runtime_dependency(%q<activesupport>, [">= 3.0", "<= 4.2"])
+  s.add_runtime_dependency(%q<actionpack>, [">= 3.0", "<= 4.2"])
+  s.add_runtime_dependency(%q<railties>, [">= 3.0", "<= 4.2"])
   %w[core expectations mocks support].each do |name|
     if RSpec::Rails::Version::STRING =~ /[a-zA-Z]+/ # prerelease builds
       s.add_runtime_dependency "rspec-#{name}", "= #{RSpec::Rails::Version::STRING}"


### PR DESCRIPTION
According to the Rails blog the 4.2 release is the last in the 4.x line.
Plans for Rails 5.x support are still in the works and may not be on
rspec-rails 3.x.

To inform users and prevent accidental usage this limits the allowed
Rails versions in the gemspec.

- http://weblog.rubyonrails.org/2014/12/19/Rails-4-2-final/