### PR TITLE
Prepare to support Ruby 2.2 on Rails 3.2.22+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,8 @@ matrix:
     # MRI 2.2 is not supported on a few versions
     - rvm: 2.2
       env: RAILS_VERSION='~> 3.1.12'
+  allow_failures:
+    # Until the newest patch release with 2.2 support
     - rvm: 2.2
       env: RAILS_VERSION='~> 3.2.17'
-    - rvm: 2.2
-      env: RAILS_VERSION=3-2-stable
   fast_finish: true

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ Enhancements:
 * Include generator for `ActionMailer` mailer previews (Takashi Nakagawa, #1185)
 * Configure the `ActionMailer` preview path via a Railtie (Aaron Kromer, #1236)
 * Show all RSpec generators when running `rails generate` (Eliot Sykes, #1248)
-* Support Ruby 2.2 with Rails 4.x (Aaron Kromer, #1264)
+* Support Ruby 2.2 with Rails 3.2 and 4.x (Aaron Kromer, #1264, #1277)
 
 Bug Fixes:
 

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -24,3 +24,4 @@ else
 end
 
 gem "i18n", '< 0.7.0' if RUBY_VERSION < '1.9.3'
+gem "test-unit" if RUBY_VERSION >= '2.2.0' && version =~ /3[.-]2[.-]/

--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -1,6 +1,7 @@
 require 'delegate'
 require 'active_support'
 require 'active_support/concern'
+require 'active_support/core_ext/string'
 
 module RSpec
   module Rails
@@ -15,11 +16,33 @@ module RSpec
       # loaded.
       Assertions = Minitest::Assertions
     elsif RUBY_VERSION >= '2.2.0'
-      # Minitest has been removed from ruby core. However, we must be on an
-      # old Rails version and must load the Minitest 4.x gem
-      gem 'minitest' if defined?(Kernel.gem)
-      require 'minitest/unit'
-      Assertions = MiniTest::Assertions
+      # Minitest / TestUnit has been removed from ruby core. However, we are
+      # on an old Rails version and must load the appropriate gem
+      if ::Rails::VERSION::STRING >= '4.0.0'
+        # ActiveSupport 4.0.x has the minitest '~> 4.2' gem as a dependency
+        # This gem has no `lib/minitest.rb` file.
+        gem 'minitest' if defined?(Kernel.gem)
+        require 'minitest/unit'
+        Assertions = MiniTest::Assertions
+      elsif ::Rails::VERSION::STRING >= '3.2.21'
+        # TODO: Change the above check to >= '3.2.22' once it's released
+        begin
+          require 'test/unit/assertions'
+        rescue LoadError => e
+          raise LoadError, <<-ERR.squish, e.backtrace
+            Ruby 2.2+ has removed test/unit from the core library. Rails
+            requires this as a dependency. Please add test-unit gem to your
+            Gemfile: `gem 'test-unit', '~> 3.0'` (#{e.message})"
+          ERR
+        end
+        Assertions = Test::Unit::Assertions
+      else
+        abort <<-MSG.squish
+          Ruby 2.2+ is not supported on Rails #{::Rails::VERSION::STRING}.
+          Check the Rails release notes for the appropriate update with
+          support.
+        MSG
+      end
     else
       begin
         require 'test/unit/assertions'

--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -27,7 +27,17 @@ module RSpec
       elsif ::Rails::VERSION::STRING >= '3.2.21'
         # TODO: Change the above check to >= '3.2.22' once it's released
         begin
+          # Test::Unit "helpfully" sets up autoload for its `AutoRunner`.
+          # While we do not use reference it directly, when we load the
+          # `TestCase` classes from ActiveSupport, AS kindly references
+          # `AutoRunner` for everyone.
+          #
+          # We need to pre-emptively load 'test/unit' and make sure the version
+          # installed has `AutoRunner` (the 3.x line does so far). If so, we
+          # turn it off.
+          require 'test/unit'
           require 'test/unit/assertions'
+          Test::Unit::AutoRunner.need_auto_run = false if defined?(Test::Unit::AutoRunner)
         rescue LoadError => e
           raise LoadError, <<-ERR.squish, e.backtrace
             Ruby 2.2+ has removed test/unit from the core library. Rails

--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -28,13 +28,13 @@ module RSpec
         # TODO: Change the above check to >= '3.2.22' once it's released
         begin
           # Test::Unit "helpfully" sets up autoload for its `AutoRunner`.
-          # While we do not use reference it directly, when we load the
-          # `TestCase` classes from ActiveSupport, AS kindly references
-          # `AutoRunner` for everyone.
+          # While we do not reference it directly, when we load the `TestCase`
+          # classes from AS (ActiveSupport), AS kindly references `AutoRunner`
+          # for everyone.
           #
-          # We need to pre-emptively load 'test/unit' and make sure the version
-          # installed has `AutoRunner` (the 3.x line does so far). If so, we
-          # turn it off.
+          # To handle this we need to pre-emptively load 'test/unit' and make
+          # sure the version installed has `AutoRunner` (the 3.x line does to
+          # date). If so, we turn the auto runner off.
           require 'test/unit'
           require 'test/unit/assertions'
           Test::Unit::AutoRunner.need_auto_run = false if defined?(Test::Unit::AutoRunner)


### PR DESCRIPTION
This is in preparation for the next patch release. Similar steps are
being taken by Rails core. See:

https://github.com/rails/rails/commit/8f92edb2b4b6beb5c778283be7cbcef6bf7e596c