### PR TITLE
Cache bundle directory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,36 @@
 language: ruby
 
+sudo: false
+
+# We deviate from the rspec-dev cache setting here.
+#
+# Travis has special bundler support where it knows to run `bundle clean`
+# before backing up the bundle so it doesn't grow indefinitely.
+#
+# For the other repos we changed to specifying the directory specifically to
+# avoid the `bundle clean` travis was doing, because Myron found that, when
+# running one of the a build for one repo, the "run the rspec-core and
+# rspec-rails spec suites" parts would take a while because it would _always_
+# have to install fresh gems (they weren't in the cache). This was happening
+# because travis was running `bundle clean` (due to the previous `cache:
+# bundler` config) against one repo which was was pruning gems installed for
+# the other repos.
+#
+# In our case, we aren't running the spec suites for the other repos so the
+# original `cache: bundler` is a better option.
+cache: bundler
+
+bundler_args: "--binstubs --without documentation --path ../bundle --retry=3 --jobs=3"
+
+before_install: "script/clone_all_rspec_repos"
+
+before_script:
+  # Rails 4.x complains with a bundler rails binstub in PROJECT_ROOT/bin/
+  - rm -f bin/rails
+  - bundle exec rails --version
+
+script: "script/run_build 2>&1"
+
 rvm:
   - 1.8.7
   - 2.2
@@ -19,19 +50,6 @@ env:
   - RAILS_VERSION=3-2-stable
   - RAILS_VERSION='~> 3.1.12'
   - RAILS_VERSION='~> 3.0.20'
-
-sudo: false
-
-bundler_args: "--binstubs --without documentation --path ../bundle --retry=3 --jobs=3"
-
-before_install: "script/clone_all_rspec_repos"
-
-before_script:
-  # Rails 4.x complains with a bundler rails binstub in PROJECT_ROOT/bin/
-  - rm -f bin/rails
-  - bundle exec rails --version
-
-script: "script/run_build 2>&1"
 
 matrix:
   exclude:


### PR DESCRIPTION
This also re-orders the listing of the settings to align with the
`rspec-dev` order. This makes manually comparing the files easier.