### PR TITLE
If a view example's description contains no path elements, then do not attempt to load a helper based on the example description.

### DIFF
--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -14,7 +14,7 @@ module RSpec
       module ClassMethods
         def _default_helper
           base = metadata[:description].split('/')[0..-2].join('/')
-          (base.camelize + 'Helper').constantize if base
+          (base.camelize + 'Helper').constantize unless base.to_s.empty?
         rescue NameError
           nil
         end

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -34,6 +34,15 @@ module RSpec::Rails
         }.not_to raise_error
       end
 
+      it 'operates normally when the view has no path and there is a Helper class defined' do
+        class ::Helper; end
+        expect {
+          RSpec::Core::ExampleGroup.describe 'show.html.erb' do
+            include ViewExampleGroup
+          end
+        }.not_to raise_error
+      end
+
       context 'application helper exists' do
         before do
           if !Object.const_defined? 'ApplicationHelper'


### PR DESCRIPTION
This odd edge case was encountered in a Rails project where a "presenter" type class was being spec'd as a `ViewExampleGroup` (via the `type: :view`).  Since the example group for this class has a description with no path element, the `ViewExampleGroup` attempt to auto-load related helpers was trying to find (and load) a helper named `Helper`.

The actual issue was discovered when someone introduced (elsewhere within the specs) a _class_ named `Helper`.  Prior to this, the presenter  example group had not caused problems since there was no `Helper` module or class to load, but once this new class was introduced, we started seeing an exception:

```
.../actionpack-3.2.21/lib/abstract_controller/helpers.rb:153:in `include': wrong argument type Class (expected Module) (TypeError)
  from .../actionpack-3.2.21/lib/abstract_controller/helpers.rb:153:in `block in add_template_helper'
  from .../actionpack-3.2.21/lib/abstract_controller/helpers.rb:153:in `module_eval'
  from .../actionpack-3.2.21/lib/abstract_controller/helpers.rb:153:in `add_template_helper'
  from .../actionpack-3.2.21/lib/abstract_controller/helpers.rb:96:in `block in helper'
  from .../actionpack-3.2.21/lib/abstract_controller/helpers.rb:95:in `each'
  from .../actionpack-3.2.21/lib/abstract_controller/helpers.rb:95:in `helper'
  from .../rspec-rails-2.14.2/lib/rspec/rails/example/view_example_group.rb:150:in `block in <module:ViewExampleGroup>'
```

Previously-failing example and fix provided here.