### PR TITLE
Change type meta tag in templates to Hash 1.9 syntax

### DIFF
--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -7,6 +7,8 @@ module Rspec
   module Generators
     # @private
     class Base < ::Rails::Generators::NamedBase
+      include RSpec::Rails::FeatureCheck
+
       def self.source_root(path = nil)
         if path
           @_rspec_source_root = path

--- a/lib/generators/rspec/controller/templates/controller_spec.rb
+++ b/lib/generators/rspec/controller/templates/controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>Controller, :type => :controller do
+RSpec.describe <%= class_name %>Controller, <%= type_metatag(:controller) %> do
 
 <% for action in actions -%>
   describe "GET #<%= action %>" do

--- a/lib/generators/rspec/controller/templates/view_spec.rb
+++ b/lib/generators/rspec/controller/templates/view_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "<%= file_name %>/<%= @action %>.html.<%= options[:template_engine] %>", :type => :view do
+RSpec.describe "<%= file_name %>/<%= @action %>.html.<%= options[:template_engine] %>", <%= type_metatag(:view) %> do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/lib/generators/rspec/feature/templates/feature_spec.rb
+++ b/lib/generators/rspec/feature/templates/feature_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.feature "<%= class_name.pluralize %>", :type => :feature do
+RSpec.feature "<%= class_name.pluralize %>", <%= type_metatag(:feature) %> do
   pending "add some scenarios (or delete) #{__FILE__}"
 end

--- a/lib/generators/rspec/helper/templates/helper_spec.rb
+++ b/lib/generators/rspec/helper/templates/helper_spec.rb
@@ -11,7 +11,7 @@ require 'rails_helper'
 #   end
 # end
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>Helper, :type => :helper do
+RSpec.describe <%= class_name %>Helper, <%= type_metatag(:helper) %> do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/lib/generators/rspec/integration/templates/request_spec.rb
+++ b/lib/generators/rspec/integration/templates/request_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "<%= class_name.pluralize %>", :type => :request do
+RSpec.describe "<%= class_name.pluralize %>", <%= type_metatag(:request) %> do
   describe "GET /<%= table_name %>" do
     it "works! (now write some real specs)" do
       get <%= index_helper %>_path

--- a/lib/generators/rspec/job/templates/job_spec.rb.erb
+++ b/lib/generators/rspec/job/templates/job_spec.rb.erb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>Job, :type => :job do
+RSpec.describe <%= class_name %>Job, <%= type_metatag(:job) %> do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/lib/generators/rspec/mailer/templates/mailer_spec.rb
+++ b/lib/generators/rspec/mailer/templates/mailer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>, :type => :mailer do
+RSpec.describe <%= class_name %>, <%= type_metatag(:mailer) %> do
 <% for action in actions -%>
   describe "<%= action %>" do
     let(:mail) { <%= class_name %>.<%= action %> }

--- a/lib/generators/rspec/model/templates/model_spec.rb
+++ b/lib/generators/rspec/model/templates/model_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>, :type => :model do
+RSpec.describe <%= class_name %>, <%= type_metatag(:model) %> do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/lib/generators/rspec/observer/templates/observer_spec.rb
+++ b/lib/generators/rspec/observer/templates/observer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>Observer, :type => :observer do
+RSpec.describe <%= class_name %>Observer, <%= type_metatag(:observer) %> do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -19,7 +19,7 @@ require 'rails_helper'
 # that an instance is receiving a specific message.
 
 <% module_namespacing do -%>
-RSpec.describe <%= controller_class_name %>Controller, :type => :controller do
+RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:controller) %> do
 
   # This should return the minimal set of attributes required to create a valid
   # <%= class_name %>. As you add validations to <%= class_name %>, be sure to

--- a/lib/generators/rspec/scaffold/templates/edit_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/edit_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-RSpec.describe "<%= ns_table_name %>/edit", :type => :view do
+RSpec.describe "<%= ns_table_name %>/edit", <%= type_metatag(:view) %> do
   before(:each) do
     @<%= ns_file_name %> = assign(:<%= ns_file_name %>, <%= class_name %>.create!(<%= '))' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>

--- a/lib/generators/rspec/scaffold/templates/index_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/index_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-RSpec.describe "<%= ns_table_name %>/index", :type => :view do
+RSpec.describe "<%= ns_table_name %>/index", <%= type_metatag(:view) %> do
   before(:each) do
     assign(:<%= table_name %>, [
 <% [1,2].each_with_index do |id, model_index| -%>

--- a/lib/generators/rspec/scaffold/templates/new_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/new_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-RSpec.describe "<%= ns_table_name %>/new", :type => :view do
+RSpec.describe "<%= ns_table_name %>/new", <%= type_metatag(:view) %> do
   before(:each) do
     assign(:<%= ns_file_name %>, <%= class_name %>.new(<%= '))' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>

--- a/lib/generators/rspec/scaffold/templates/routing_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/routing_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 <% module_namespacing do -%>
-RSpec.describe <%= controller_class_name %>Controller, :type => :routing do
+RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:routing) %> do
   describe "routing" do
 
 <% unless options[:singleton] -%>

--- a/lib/generators/rspec/scaffold/templates/show_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/show_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-RSpec.describe "<%= ns_table_name %>/show", :type => :view do
+RSpec.describe "<%= ns_table_name %>/show", <%= type_metatag(:view) %> do
   before(:each) do
     @<%= ns_file_name %> = assign(:<%= ns_file_name %>, <%= class_name %>.create!(<%= '))' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>

--- a/lib/generators/rspec/view/templates/view_spec.rb
+++ b/lib/generators/rspec/view/templates/view_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "<%= file_path %>/<%= @action %>", :type => :view do
+RSpec.describe "<%= file_path %>/<%= @action %>", <%= type_metatag(:view) %> do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -37,6 +37,18 @@ module RSpec
       def has_action_mailer_preview?
         has_action_mailer? && defined?(::ActionMailer::Preview)
       end
+
+      def has_1_9_hash_syntax?
+        ::Rails::VERSION::STRING > '4.0'
+      end
+
+      def type_metatag(type)
+        if has_1_9_hash_syntax?
+          "type: :#{type}"
+        else
+          ":type => :#{type}"
+        end
+      end
     end
     # rubocop:enable Style/IndentationConsistency
   end

--- a/spec/generators/rspec/controller/controller_generator_spec.rb
+++ b/spec/generators/rspec/controller/controller_generator_spec.rb
@@ -19,7 +19,7 @@ describe Rspec::Generators::ControllerGenerator, :type => :generator do
       describe 'the spec' do
         it { is_expected.to exist }
         it { is_expected.to contain(/require 'rails_helper'/) }
-        it { is_expected.to contain(/^RSpec.describe PostsController, :type => :controller/) }
+        it { is_expected.to contain(/^RSpec.describe PostsController, #{type_metatag(:controller)}/) }
       end
     end
     describe 'skipped with a flag' do
@@ -72,13 +72,13 @@ describe Rspec::Generators::ControllerGenerator, :type => :generator do
           subject { file('spec/views/posts/index.html.erb_spec.rb') }
           it { is_expected.to exist }
           it { is_expected.to contain(/require 'rails_helper'/) }
-          it { is_expected.to contain(/^RSpec.describe "posts\/index.html.erb", :type => :view/) }
+          it { is_expected.to contain(/^RSpec.describe "posts\/index.html.erb", #{type_metatag(:view)}/) }
         end
         describe 'show.html.erb' do
           subject { file('spec/views/posts/show.html.erb_spec.rb') }
           it { is_expected.to exist }
           it { is_expected.to contain(/require 'rails_helper'/) }
-          it { is_expected.to contain(/^RSpec.describe "posts\/show.html.erb", :type => :view/) }
+          it { is_expected.to contain(/^RSpec.describe "posts\/show.html.erb", #{type_metatag(:view)}/) }
         end
       end
       describe 'with haml' do
@@ -89,7 +89,7 @@ describe Rspec::Generators::ControllerGenerator, :type => :generator do
           subject { file('spec/views/posts/index.html.haml_spec.rb') }
           it { is_expected.to exist }
           it { is_expected.to contain(/require 'rails_helper'/) }
-          it { is_expected.to contain(/^RSpec.describe "posts\/index.html.haml", :type => :view/) }
+          it { is_expected.to contain(/^RSpec.describe "posts\/index.html.haml", #{type_metatag(:view)}/) }
         end
       end
     end

--- a/spec/generators/rspec/feature/feature_generator_spec.rb
+++ b/spec/generators/rspec/feature/feature_generator_spec.rb
@@ -23,7 +23,7 @@ describe Rspec::Generators::FeatureGenerator, :type => :generator do
           expect(feature_spec).to contain(/require 'rails_helper'/)
         end
         it "contains the feature" do
-          expect(feature_spec).to contain(/^RSpec.feature "Posts", :type => :feature/)
+          expect(feature_spec).to contain(/^RSpec.feature \"Posts\", #{type_metatag(:feature)}/)
         end
       end
     end

--- a/spec/generators/rspec/helper/helper_generator_spec.rb
+++ b/spec/generators/rspec/helper/helper_generator_spec.rb
@@ -18,7 +18,7 @@ describe Rspec::Generators::HelperGenerator, :type => :generator do
     describe 'the spec' do
       it { is_expected.to exist }
       it { is_expected.to contain(/require 'rails_helper'/) }
-      it { is_expected.to contain(/^RSpec.describe PostsHelper, :type => :helper/) }
+      it { is_expected.to contain(/^RSpec.describe PostsHelper, #{type_metatag(:helper)}/) }
     end
   end
   describe 'skipped with a flag' do

--- a/spec/generators/rspec/integration/integration_generator_spec.rb
+++ b/spec/generators/rspec/integration/integration_generator_spec.rb
@@ -26,7 +26,7 @@ describe Rspec::Generators::IntegrationGenerator, :type => :generator do
     subject { file('spec/requests/posts_spec.rb') }
     it { is_expected.to exist }
     it { is_expected.to contain(/require 'rails_helper'/) }
-    it { is_expected.to contain(/^RSpec.describe "Posts", :type => :request/) }
+    it { is_expected.to contain(/^RSpec.describe \"Posts\", #{type_metatag(:request)}/) }
     it { is_expected.to contain(/describe "GET \/posts"/) }
     it { is_expected.to contain(/get posts_index_path/) }
   end

--- a/spec/generators/rspec/job/job_generator_spec.rb
+++ b/spec/generators/rspec/job/job_generator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Rspec::Generators::JobGenerator, :type => :generator, :skip => !R
 
     it { is_expected.to exist }
     it { is_expected.to contain(/require 'rails_helper'/) }
-    it { is_expected.to contain(/describe UserJob, :type => :job/) }
+    it { is_expected.to contain(/describe UserJob, #{type_metatag(:job)}/) }
 
   end
 end

--- a/spec/generators/rspec/mailer/mailer_generator_spec.rb
+++ b/spec/generators/rspec/mailer/mailer_generator_spec.rb
@@ -17,7 +17,7 @@ describe Rspec::Generators::MailerGenerator, :type => :generator do
       end
       it { is_expected.to exist }
       it { is_expected.to contain(/require "rails_helper"/) }
-      it { is_expected.to contain(/^RSpec.describe Posts, :type => :mailer/) }
+      it { is_expected.to contain(/^RSpec.describe Posts, #{type_metatag(:mailer)}/) }
       it { is_expected.to contain(/describe "index" do/) }
       it { is_expected.to contain(/describe "show" do/) }
     end

--- a/spec/generators/rspec/model/model_generator_spec.rb
+++ b/spec/generators/rspec/model/model_generator_spec.rb
@@ -27,7 +27,7 @@ describe Rspec::Generators::ModelGenerator, :type => :generator do
 
         it { is_expected.to exist }
         it { is_expected.to contain(/require 'rails_helper'/) }
-        it { is_expected.to contain(/^RSpec.describe Posts, :type => :model/) }
+        it { is_expected.to contain(/^RSpec.describe Posts, #{type_metatag(:model)}/) }
       end
 
       describe 'the fixtures' do

--- a/spec/generators/rspec/observer/observer_generator_spec.rb
+++ b/spec/generators/rspec/observer/observer_generator_spec.rb
@@ -16,6 +16,6 @@ describe Rspec::Generators::ObserverGenerator, :type => :generator do
   describe 'the spec' do
     it { is_expected.to exist }
     it { is_expected.to contain(/require 'rails_helper'/) }
-    it { is_expected.to contain(/^RSpec.describe PostsObserver, :type => :observer/) }
+    it { is_expected.to contain(/^RSpec.describe PostsObserver, #{type_metatag(:observer)}/) }
   end
 end

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -13,7 +13,7 @@ describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
     describe 'with no options' do
       before { run_generator %w(posts) }
       it { is_expected.to contain(/require 'rails_helper'/) }
-      it { is_expected.to contain(/^RSpec.describe PostsController, :type => :controller/) }
+      it { is_expected.to contain(/^RSpec.describe PostsController, #{type_metatag(:controller)}/) }
     end
 
     describe 'with --no-controller_specs' do
@@ -25,7 +25,7 @@ describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
   describe 'namespaced controller spec' do
     subject { file('spec/controllers/admin/posts_controller_spec.rb') }
     before  { run_generator %w(admin/posts) }
-    it { is_expected.to contain(/^RSpec.describe Admin::PostsController, :type => :controller/)}
+    it { is_expected.to contain(/^RSpec.describe Admin::PostsController, #{type_metatag(:controller)}/)}
   end
 
   describe 'view specs' do
@@ -36,7 +36,7 @@ describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
         subject { file("spec/views/posts/edit.html.erb_spec.rb") }
         it { is_expected.to exist }
         it { is_expected.to contain(/require 'rails_helper'/) }
-        it { is_expected.to contain(/^RSpec.describe "(.*)\/edit", :type => :view/) }
+        it { is_expected.to contain(/^RSpec.describe "(.*)\/edit", #{type_metatag(:view)}/) }
         it { is_expected.to contain(/it "renders the edit (.*) form"/) }
       end
 
@@ -44,7 +44,7 @@ describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
         subject { file("spec/views/posts/index.html.erb_spec.rb") }
         it { is_expected.to exist }
         it { is_expected.to contain(/require 'rails_helper'/) }
-        it { is_expected.to contain(/^RSpec.describe "(.*)\/index", :type => :view/) }
+        it { is_expected.to contain(/^RSpec.describe "(.*)\/index", #{type_metatag(:view)}/) }
         it { is_expected.to contain(/it "renders a list of (.*)"/) }
       end
 
@@ -52,7 +52,7 @@ describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
         subject { file("spec/views/posts/new.html.erb_spec.rb") }
         it { is_expected.to exist }
         it { is_expected.to contain(/require 'rails_helper'/) }
-        it { is_expected.to contain(/^RSpec.describe "(.*)\/new", :type => :view/) }
+        it { is_expected.to contain(/^RSpec.describe "(.*)\/new", #{type_metatag(:view)}/) }
         it { is_expected.to contain(/it "renders new (.*) form"/) }
       end
 
@@ -60,7 +60,7 @@ describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
         subject { file("spec/views/posts/show.html.erb_spec.rb") }
         it { is_expected.to exist }
         it { is_expected.to contain(/require 'rails_helper'/) }
-        it { is_expected.to contain(/^RSpec.describe "(.*)\/show", :type => :view/) }
+        it { is_expected.to contain(/^RSpec.describe "(.*)\/show", #{type_metatag(:view)}/) }
         it { is_expected.to contain(/it "renders attributes in <p>"/) }
       end
     end
@@ -136,7 +136,7 @@ describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
     describe 'with default options' do
       before { run_generator %w(posts) }
       it { is_expected.to contain(/require "rails_helper"/) }
-      it { is_expected.to contain(/^RSpec.describe PostsController, :type => :routing/) }
+      it { is_expected.to contain(/^RSpec.describe PostsController, #{type_metatag(:routing)}/) }
       it { is_expected.to contain(/describe "routing"/) }
     end
 

--- a/spec/generators/rspec/view/view_generator_spec.rb
+++ b/spec/generators/rspec/view/view_generator_spec.rb
@@ -14,7 +14,7 @@ describe Rspec::Generators::ViewGenerator, :type => :generator do
       run_generator %w(posts index)
       file('spec/views/posts/index.html.erb_spec.rb').tap do |f|
         expect(f).to contain(/require 'rails_helper'/)
-        expect(f).to contain(/^RSpec.describe "posts\/index", :type => :view/)
+        expect(f).to contain(/^RSpec.describe \"posts\/index\", #{type_metatag(:view)}/)
       end
     end
 
@@ -23,7 +23,7 @@ describe Rspec::Generators::ViewGenerator, :type => :generator do
         run_generator %w(admin/posts index)
         file('spec/views/admin/posts/index.html.erb_spec.rb').tap do |f|
           expect(f).to contain(/require 'rails_helper'/)
-          expect(f).to contain(/^RSpec.describe "admin\/posts\/index", :type => :view/)
+          expect(f).to contain(/^RSpec.describe \"admin\/posts\/index\", #{type_metatag(:view)}/)
         end
       end
     end
@@ -34,7 +34,7 @@ describe Rspec::Generators::ViewGenerator, :type => :generator do
       run_generator %w(posts index --template_engine haml)
       file('spec/views/posts/index.html.haml_spec.rb').tap do |f|
         expect(f).to contain(/require 'rails_helper'/)
-        expect(f).to contain(/^RSpec.describe "posts\/index", :type => :view/)
+        expect(f).to contain(/^RSpec.describe \"posts\/index\", #{type_metatag(:view)}/)
       end
     end
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,4 +1,6 @@
 module Helpers
+  include RSpec::Rails::FeatureCheck
+
   def with_isolated_config
     original_config = RSpec.configuration
     RSpec.configuration = RSpec::Core::Configuration.new


### PR DESCRIPTION
I often go into specs created by the generators and change the hash syntax. Does rspec-rails plan to support Ruby 1.8.7 much longer?