### PR TITLE
Update directory structure documentation

### DIFF
--- a/features/directory_structure.feature
+++ b/features/directory_structure.feature
@@ -5,7 +5,8 @@ Feature: Directory Structure
 
   - Model specs reside in the `spec/models` directory
   - Controller specs reside in the `spec/controllers` directory
-  - Request specs reside in the `spec/requests` directory
+  - Request specs reside in the `spec/requests` directory. The directory
+    can also be named `integration` or `api`.
   - Feature specs reside in the `spec/features` directory
   - View specs reside in the `spec/views` directory
   - Helper specs reside in the `spec/helpers` directory


### PR DESCRIPTION
The website docs were not considering that request specs could also be
located inside a folder named 'integration' or 'api'.