### PR TITLE
Remove unnecessary code :skull:

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,8 @@ Bug Fixes:
   available or the Capybara version is < 2.4.0. (Aaron Kromer, #1261)
 * Fix `ArgumentError` when when using an anonymous controller which inherits an
   outer group's anonymous controller. (Yuji Nakayama, #1260)
+* Fix "Test is not a class (TypeError)" error when using a custom `Test` class
+  in Rails 4.1 and 4.2. (Aaron Kromer, #1295)
 
 ### 3.1.0 / 2014-09-04
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.0.2...v3.1.0)

--- a/lib/rspec/rails/matchers.rb
+++ b/lib/rspec/rails/matchers.rb
@@ -9,17 +9,6 @@ module RSpec
   end
 end
 
-begin
-  require 'test/unit/assertionfailederror'
-rescue LoadError
-  module Test
-    module Unit
-      class AssertionFailedError < StandardError
-      end
-    end
-  end
-end
-
 require 'rspec/rails/matchers/have_rendered'
 require 'rspec/rails/matchers/redirect_to'
 require 'rspec/rails/matchers/routing_matchers'


### PR DESCRIPTION
The matchers no longer attempt to use `AssertionFailedError` instead
they use `ActiveSupport::TestCase::Assertion`.

Fix #1294