### PR TITLE
Add missing `require` to RSpec generator root

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+### Development
+
+Bug Fixes:
+
+* Add missing `require` to RSpec generator root fixing an issue where Rail's
+  autoload does not find it in some environments. (Aaron Kromer, #1305)
+
 ### 3.2.0 / 2015-02-03
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.1.0...v3.2.0)
 

--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -1,4 +1,5 @@
 require 'rails/generators/named_base'
+require 'rspec/rails/feature_check'
 
 # Weirdly named generators namespace (should be `RSpec`) for compatability with
 # rails loading.


### PR DESCRIPTION
Fix #1301.

This fixes an issue where Rail's autoload does not find it in some
environments.