### PR TITLE
Fix `be_routable` description -- Renames BeRoutableMatcher to BeRoutable

### DIFF
--- a/lib/rspec/rails/matchers/routing_matchers.rb
+++ b/lib/rspec/rails/matchers/routing_matchers.rb
@@ -63,7 +63,7 @@ module RSpec
         end
 
         # @private
-        class BeRoutableMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
+        class BeRoutable < RSpec::Matchers::BuiltIn::BaseMatcher
           def initialize(scope)
             @scope = scope
           end
@@ -95,7 +95,7 @@ module RSpec
         #     expect(:post => "/another/path").to be_routable
         #     expect(:put  => "/yet/another/path").to be_routable
         def be_routable
-          BeRoutableMatcher.new(self)
+          BeRoutable.new(self)
         end
 
         # Helpers for matching different route types.

--- a/spec/rspec/rails/matchers/be_routable_spec.rb
+++ b/spec/rspec/rails/matchers/be_routable_spec.rb
@@ -6,6 +6,10 @@ describe "be_routable" do
 
   before { @routes = double("routes") }
 
+  it "provides a description" do
+    expect(be_routable.description).to eq("be routable")
+  end
+
   context "with should" do
     it "passes if routes recognize the path" do
       allow(routes).to receive(:recognize_path) { {} }


### PR DESCRIPTION
**Problem**
Previously, using `be_routable` in a one-liner...
``` ruby
RSpec.describe 'a not-routable route', type: :routing do
  let(:sad_route) { '/this/route/makes/me/sad' }
  specify { expect(get: sad_route).not_to be_routable }
end
```
...will output the following:
```
a not-routable route
  should not be routable matcher
```
`BaseMatcher#description` turns `BeRoutableMatcher` into "be routable matcher".

**Solution**
The solution implemented here is to rename `BeRoutableMatcher` to `BeRoutable` in order to rely on `BaseMatcher#description` to correctly return the following description:
```
a not-routable route
  should not be routable
```
This looks like the precedence in other matchers like `BeValid`.

**Alternate Solution**
Alternatively, `#description` could be overridden in `BeRoutableMatcher`:
``` ruby
def description
  "be routable"
end
``` 
I'd be happy to change PR if that's preferred :smile_cat: 