### PR TITLE
Fix `be_routable` description -- Defines BeRoutableMatcher#description

### DIFF
--- a/lib/rspec/rails/matchers/routing_matchers.rb
+++ b/lib/rspec/rails/matchers/routing_matchers.rb
@@ -84,6 +84,10 @@ module RSpec
           def failure_message_when_negated
             "expected #{@actual.inspect} not to be routable, but it routes to #{@routing_options.inspect}"
           end
+
+          def description
+            "be routable"
+          end
         end
 
         # Passes if the route expression is recognized by the Rails router based on

--- a/spec/rspec/rails/matchers/be_routable_spec.rb
+++ b/spec/rspec/rails/matchers/be_routable_spec.rb
@@ -6,6 +6,10 @@ describe "be_routable" do
 
   before { @routes = double("routes") }
 
+  it "provides a description" do
+    expect(be_routable.description).to eq("be routable")
+  end
+
   context "with should" do
     it "passes if routes recognize the path" do
       allow(routes).to receive(:recognize_path) { {} }


### PR DESCRIPTION
Alternate implementation of https://github.com/rspec/rspec-rails/pull/1307
Thanks for the feedback @JonRowe @cupakromer! :joy_cat: 

**Problem**
Previously, using `be_routable` in a one-liner...
``` ruby
RSpec.describe 'a not-routable route', type: :routing do
  let(:sad_route) { '/this/route/makes/me/sad' }
  specify { expect(get: sad_route).not_to be_routable }
end
```
...will output the following:
```
a not-routable route
  should not be routable matcher
```
`BaseMatcher#description` turns `BeRoutableMatcher` into "be routable matcher".

**Solution**
`BeRoutableMatcher#description` is defined to override `BaseMatcher#description`...
``` ruby
class BeRoutableMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
  # ...
  def description
    "be routable"
  end
end
``` 
...to correctly output:
```
a not-routable route
  should not be routable
```