### PR TITLE
Patch mocks to properly handle JSON monkey patches

### DIFF
--- a/lib/rspec/rails/extensions.rb
+++ b/lib/rspec/rails/extensions.rb
@@ -1,1 +1,2 @@
 require 'rspec/rails/extensions/active_record/proxy'
+require 'rspec/rails/extensions/active_support/json'

--- a/lib/rspec/rails/extensions/active_support/json.rb
+++ b/lib/rspec/rails/extensions/active_support/json.rb
@@ -1,0 +1,67 @@
+RSpec.configure do |c|
+  c.before(:suite) do
+    if defined?(::RSpec::Mocks)
+      # Need to require the base file to setup internal support require helpers
+      require 'rspec/mocks'
+      require 'rspec/mocks/test_double'
+      ::RSpec::Mocks::TestDouble.module_exec do
+        # @private
+        def as_json(*args, &block)
+          return method_missing(:as_json, *args, &block) unless null_object?
+          __mock_proxy.record_message_received(:as_json, *args, &block)
+          nil
+        end
+
+        # @private
+        def to_json(*args, &block)
+          return method_missing(:to_json, *args, &block) unless null_object?
+          __mock_proxy.record_message_received(:to_json, *args, &block)
+          "null"
+        end
+
+        # @private
+        remove_method(:respond_to?)
+        def respond_to?(message, incl_private = false)
+          return true if null_object?
+          if [:to_json, :as_json].include?(message)
+            public_methods(false).include?(message)
+          else
+            super
+          end
+        end
+      end
+
+      require 'rspec/mocks/verifying_double'
+      ::RSpec::Mocks::VerifyingDouble.module_exec do
+        # @private
+        def as_json(*args, &block)
+          verify_on_mock_proxy(:as_json, *args)
+          super
+        end
+
+        # @private
+        def to_json(*args, &block)
+          verify_on_mock_proxy(:to_json, *args)
+          super
+        end
+
+      private
+
+        def verify_on_mock_proxy(message, *args)
+          # Null object conditional is an optimization. If not a null object,
+          # validity of method expectations will have been checked at
+          # definition time.
+          return unless null_object?
+
+          if @__sending_message == message
+            __mock_proxy.ensure_implemented(message)
+          else
+            __mock_proxy.ensure_publicly_implemented(message, self)
+          end
+
+          __mock_proxy.validate_arguments!(message, args)
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/rails/extensions/active_support/json_spec.rb
+++ b/spec/rspec/rails/extensions/active_support/json_spec.rb
@@ -1,0 +1,196 @@
+require "spec_helper"
+require "active_support"
+if ::Rails::VERSION::STRING > '4.1'
+  require "active_support/core_ext/object/json"
+else
+  require "active_support/core_ext/object/to_json"
+end
+require "rspec/rails/extensions/active_support/json"
+
+RSpec.describe "Patch mocks to work with Active Support's json patches" do
+
+  shared_examples "verifies the patch arguments" do
+    it "verifies arguments" do
+      allow(subject).to receive(patch)
+      expect { subject.send(patch, :too, :many) }.to raise_error(ArgumentError)
+    end
+  end
+
+  shared_examples "intercepts Active Support's patch" do |message, opts|
+    opts ||= {}
+    context "intercepts Active Support's ##{message}" do
+      defaults = { :to_json => "null", :as_json => nil }
+
+      let(:patch) { message }
+      let(:default) { defaults[patch] }
+
+      it "responds to the message" do
+        expect(subject).to respond_to(patch)
+      end
+
+      it "defines a sane default implementation" do
+        expect(subject.send(patch)).to eq(default)
+      end
+
+      it "records the message being received" do
+        subject.send(patch)
+        expect(subject).to have_received(patch)
+      end
+
+      it "doesn't interfere with a stubbed response" do
+        allow(subject).to receive(patch).and_return(:stubbed)
+        expect(subject.send(patch)).to be(:stubbed)
+      end
+
+      include_examples "verifies the patch arguments" if opts[:verified]
+    end
+  end
+
+  shared_examples "ignores Active Support's patch" do |message, opts|
+    opts ||= {}
+    context "ignores Active Support's ##{message}" do
+      let(:patch) { message }
+
+      it "raises errors when messages not allowed or expected are received" do
+        expect { subject.send(patch) }.to raise_error(
+          /received unexpected message :#{patch} with \(no args\)/
+        )
+      end
+
+      it "does not respond to the message when not allowed or expected" do
+        expect(subject).not_to respond_to(patch)
+      end
+
+      it "does respond to the message when allowed or expected" do
+        allow(subject).to receive(patch)
+        expect(subject).to respond_to(patch)
+      end
+
+      it "returns a stubbed value" do
+        allow(subject).to receive(patch).and_return(:stubbed)
+        expect(subject.send(patch)).to be(:stubbed)
+      end
+
+      it "captures a set expectation" do
+        expect(subject).to receive(patch)
+        subject.send(patch)
+      end
+
+      include_examples "verifies the patch arguments" if opts[:verified]
+    end
+  end
+
+  context "using a `spy`" do
+    subject(:a_spy) { spy }
+
+    include_examples "intercepts Active Support's patch", :to_json
+    include_examples "intercepts Active Support's patch", :as_json
+  end
+
+  context "using an `instance_spy`" do
+    subject(:the_spy) { instance_spy(String) }
+
+    include_examples "intercepts Active Support's patch", :to_json, :verified => true
+    include_examples "intercepts Active Support's patch", :as_json, :verified => true
+  end
+
+  context "using a `class_spy`" do
+    subject(:the_spy) { class_spy(String) }
+
+    include_examples "intercepts Active Support's patch", :to_json, :verified => true
+    include_examples "intercepts Active Support's patch", :as_json, :verified => true
+  end
+
+  context "using an `object_spy`" do
+    subject(:the_spy) { object_spy('test') }
+
+    include_examples "intercepts Active Support's patch", :to_json
+    include_examples "intercepts Active Support's patch", :as_json
+  end
+
+  context "using a `double`" do
+    subject(:a_double) { double }
+
+    include_examples "ignores Active Support's patch", :to_json
+    include_examples "ignores Active Support's patch", :as_json
+  end
+
+  context "using an `instance_double`" do
+    subject(:the_double) { instance_double(String) }
+
+    include_examples "ignores Active Support's patch", :to_json, :verified => true
+    include_examples "ignores Active Support's patch", :as_json, :verified => true
+  end
+
+  context "using a `class_double`" do
+    subject(:the_double) { class_double(String) }
+
+    include_examples "ignores Active Support's patch", :to_json, :verified => true
+    include_examples "ignores Active Support's patch", :as_json, :verified => true
+  end
+
+  context "using an `object_double`" do
+    subject(:the_double) { object_double('test') }
+
+    include_examples "ignores Active Support's patch", :to_json
+    include_examples "ignores Active Support's patch", :as_json
+  end
+
+  it "doesn't interfere with a partial mock's native representation" do
+    obj = { :foo => "a test", :bar => 123 }
+    allow(obj).to receive(:equal?).and_return(false)
+    expect(obj.to_json).to eq("{\"foo\":\"a test\",\"bar\":123}")
+    expect(obj.as_json).to eq({ "foo" => "a test", "bar" => 123 })
+  end
+
+  context "with BasicObject" do
+    if defined?(::BasicObject)
+      before(:example) do
+        basic_object = Class.new do
+          undef :as_json
+          undef :to_json
+        end
+        stub_const("BasicObject", basic_object)
+      end
+    else
+      # Sanity check to ensure Rails didn't change this on us
+      before(:context) do
+        expect(BasicObject).not_to respond_to(:as_json)
+        expect(BasicObject).not_to respond_to(:to_json)
+      end
+    end
+
+    basic_object_not_implemented_to_json =
+      /BasicObject( class)? does not implement.+to_json/
+    basic_object_not_implemented_as_json =
+      /BasicObject( class)? does not implement.+as_json/
+
+    it "doesn't pollute spies" do
+      expect(instance_spy(BasicObject)).not_to respond_to(:to_json)
+      expect { instance_spy(BasicObject).to_json }.to raise_error(
+        basic_object_not_implemented_to_json
+      )
+      expect { instance_spy(BasicObject, :to_json => 'test') }.to raise_error(
+        basic_object_not_implemented_to_json
+      )
+
+      expect(instance_spy(BasicObject)).not_to respond_to(:as_json)
+      expect { instance_spy(BasicObject).as_json }.to raise_error(
+        basic_object_not_implemented_as_json
+      )
+      expect { instance_spy(BasicObject, :as_json => 'test') }.to raise_error(
+        basic_object_not_implemented_as_json
+      )
+    end
+
+    it "doesn't pollute doubles" do
+      expect { instance_double(BasicObject, :to_json => 'test') }.to raise_error(
+        basic_object_not_implemented_to_json
+      )
+      expect { instance_double(BasicObject, :as_json => 'test') }.to raise_error(
+        basic_object_not_implemented_as_json
+      )
+    end
+  end
+
+end


### PR DESCRIPTION
Fix #1309

Rails adds a nearly global monkey patch to make converting objects into
JSON easier. It adds both `to_json` and `as_json` methods on nearly all
core object types; including `Object` but not `BasicObject`.

That prevents a RSpec double or spy from working as expected. Since the
double/spy object inherits these patches from `Object` they are not able
to intercept them in the normal `method_missing` manner.

We work around that by applying a monkey patch directly on the RSpec
mocks modules. This is necessary, instead of creating a new module and
including it, because Ruby does not recognize new modules included on an
existing module for classes which have already included the base module.

Additionally, we must copy some of the `private` internals of the mock
in order to preserve behavior. This is not a desirable approach but is
necessary.

/cc @chav02 @JonRowe @myronmarston 
