### PR TITLE
Relax `rails` dependency constraint to support the `4.2.x` releases.

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |s|
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  s.add_runtime_dependency(%q<activesupport>, [">= 3.0", "<= 4.2"])
-  s.add_runtime_dependency(%q<actionpack>, [">= 3.0", "<= 4.2"])
-  s.add_runtime_dependency(%q<railties>, [">= 3.0", "<= 4.2"])
+  s.add_runtime_dependency(%q<activesupport>, [">= 3.0", "< 4.3"])
+  s.add_runtime_dependency(%q<actionpack>, [">= 3.0", "< 4.3"])
+  s.add_runtime_dependency(%q<railties>, [">= 3.0", "< 4.3"])
   %w[core expectations mocks support].each do |name|
     if RSpec::Rails::Version::STRING =~ /[a-zA-Z]+/ # prerelease builds
       s.add_runtime_dependency "rspec-#{name}", "= #{RSpec::Rails::Version::STRING}"


### PR DESCRIPTION
The previous constraint would only go as up as `4.2.0`, thus making `rspec-rails`
incompatible with any of the patch releases of the rails 4.2.x series.