### PR TITLE
Backport pull requests #1303, #1305, #1310, #1318

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2015-01-08T19:12:50-08:00 from the rspec-dev repo.
+# This file was generated on 2015-02-08T20:55:32-08:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # This file contains defaults for RSpec projects. Individual projects

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Bug Fixes:
 
 * Add missing `require` to RSpec generator root fixing an issue where Rail's
   autoload does not find it in some environments. (Aaron Kromer, #1305)
+* `be_routable` matcher now has the correct description. (Tony Ta, #1310)
 
 ### 3.2.0 / 2015-02-03
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.1.0...v3.2.0)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+### Development
+
+Bug Fixes:
+
+* Add missing `require` to RSpec generator root fixing an issue where Rail's
+  autoload does not find it in some environments. (Aaron Kromer, #1305)
+
 ### 3.2.0 / 2015-02-03
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.1.0...v3.2.0)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Bug Fixes:
 * Add missing `require` to RSpec generator root fixing an issue where Rail's
   autoload does not find it in some environments. (Aaron Kromer, #1305)
 * `be_routable` matcher now has the correct description. (Tony Ta, #1310)
+* Fix dependency to allow Rails 4.2.x patches / pre-releases (Lucas Mazza, #1318)
 
 ### 3.2.0 / 2015-02-03
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.1.0...v3.2.0)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2015-01-08T19:12:50-08:00 from the rspec-dev repo.
+# This file was generated on 2015-02-08T20:55:32-08:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 version: "{build}"

--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -1,4 +1,5 @@
 require 'rails/generators/named_base'
+require 'rspec/rails/feature_check'
 
 # Weirdly named generators namespace (should be `RSpec`) for compatability with
 # rails loading.

--- a/lib/rspec/rails/matchers/routing_matchers.rb
+++ b/lib/rspec/rails/matchers/routing_matchers.rb
@@ -84,6 +84,10 @@ module RSpec
           def failure_message_when_negated
             "expected #{@actual.inspect} not to be routable, but it routes to #{@routing_options.inspect}"
           end
+
+          def description
+            "be routable"
+          end
         end
 
         # Passes if the route expression is recognized by the Rails router based on

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |s|
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  s.add_runtime_dependency(%q<activesupport>, [">= 3.0", "<= 4.2"])
-  s.add_runtime_dependency(%q<actionpack>, [">= 3.0", "<= 4.2"])
-  s.add_runtime_dependency(%q<railties>, [">= 3.0", "<= 4.2"])
+  s.add_runtime_dependency(%q<activesupport>, [">= 3.0", "< 4.3"])
+  s.add_runtime_dependency(%q<actionpack>, [">= 3.0", "< 4.3"])
+  s.add_runtime_dependency(%q<railties>, [">= 3.0", "< 4.3"])
   %w[core expectations mocks support].each do |name|
     if RSpec::Rails::Version::STRING =~ /[a-zA-Z]+/ # prerelease builds
       s.add_runtime_dependency "rspec-#{name}", "= #{RSpec::Rails::Version::STRING}"

--- a/script/clone_all_rspec_repos
+++ b/script/clone_all_rspec_repos
@@ -1,23 +1,24 @@
 #!/bin/bash
-# This file was generated on 2015-01-08T19:12:50-08:00 from the rspec-dev repo.
+# This file was generated on 2015-02-08T20:55:32-08:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e
 source script/functions.sh
 
-pushd ..
-
-clone_repo "rspec"
-clone_repo "rspec-core"
-clone_repo "rspec-expectations"
-clone_repo "rspec-mocks"
-
 if is_mri; then
+  pushd ..
+
+  clone_repo "rspec"
+  clone_repo "rspec-core"
+  clone_repo "rspec-expectations"
+  clone_repo "rspec-mocks"
   clone_repo "rspec-rails"
-fi
 
-if rspec_support_compatible; then
-  clone_repo "rspec-support"
-fi
+  if rspec_support_compatible; then
+    clone_repo "rspec-support"
+  fi
 
-popd
+  popd
+else
+  echo "Not cloning all repos since we are not on MRI and they are only needed for the MRI build"
+fi

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2015-01-08T19:12:50-08:00 from the rspec-dev repo.
+# This file was generated on 2015-02-08T20:55:32-08:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 function is_mri {
@@ -9,18 +9,6 @@ function is_mri {
   else
     return 1
   fi;
-}
-
-function is_jruby_20_mode {
-  if [ -z "$JRUBY_OPTS" ]; then
-    if ruby -e "exit(RUBY_VERSION == '2.0.0')"; then
-      return 0
-    else
-      return 1
-    fi
-  else
-    return 1
-  fi
 }
 
 function is_mri_192 {

--- a/script/run_build
+++ b/script/run_build
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2015-01-08T19:12:50-08:00 from the rspec-dev repo.
+# This file was generated on 2015-02-08T20:55:32-08:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e
@@ -21,8 +21,8 @@ if style_and_lint_enforced; then
   fold "rubocop" check_style_and_lint
 fi
 
-if is_jruby_20_mode; then
-  echo "Skipping other specs suites on JRuby 2.0 mode because it is so much slower"
-else
+if is_mri; then
   run_all_spec_suites
+else
+  echo "Skipping the rest of the build on non-MRI rubies"
 fi

--- a/script/travis_functions.sh
+++ b/script/travis_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2015-01-08T19:12:50-08:00 from the rspec-dev repo.
+# This file was generated on 2015-02-08T20:55:32-08:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # Taken from:

--- a/spec/rspec/rails/matchers/be_routable_spec.rb
+++ b/spec/rspec/rails/matchers/be_routable_spec.rb
@@ -6,6 +6,10 @@ describe "be_routable" do
 
   before { @routes = double("routes") }
 
+  it "provides a description" do
+    expect(be_routable.description).to eq("be routable")
+  end
+
   context "with should" do
     it "passes if routes recognize the path" do
       allow(routes).to receive(:recognize_path) { {} }


### PR DESCRIPTION
This backport the following PRs:

- Updates from rspec-dev (2015-02-08) #1303
- Add missing `require` to RSpec generator root #1305
- Fix `be_routable` description -- Defines BeRoutableMatcher#description #1310
- Relax `rails` dependency constraint to support the `4.2.x` releases. #1318