### PR TITLE
Disable the test-unit gem autorunner.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ Bug Fixes:
   autoload does not find it in some environments. (Aaron Kromer, #1305)
 * `be_routable` matcher now has the correct description. (Tony Ta, #1310)
 * Fix dependency to allow Rails 4.2.x patches / pre-releases (Lucas Mazza, #1318)
+* Disable the `test-unit` gem's autorunner on projects running Rails < 4.1 and
+  Ruby < 2.2 (Aaron Kromer, #1320)
 
 ### 3.2.0 / 2015-02-03
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.1.0...v3.2.0)

--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -61,6 +61,8 @@ module RSpec
         require 'rubysl-test-unit' if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
         require 'test/unit/assertions'
       end
+      # Turn off test unit's auto runner for those using the gem
+      Test::Unit::AutoRunner.need_auto_run = false if defined?(Test::Unit::AutoRunner)
       # Constant aliased to either Minitest or TestUnit, depending on what is
       # loaded.
       Assertions = Test::Unit::Assertions


### PR DESCRIPTION
For some reason the test-unit gem loads it's autorunner by default.
Though the test-unit included with Ruby does not. The original code for
loading test-unit pre-dates widespread usage of the test-unit gem.

We took care of disabling the autorunner for Ruby 2.2+ since the
test-unit gem is now required for Rails 3.2. For older Ruby versions we
attempt to only load the `test/unit/assertions` module. When using the
`test-unit` gem however, Rails will auto require it for us, which loads
the main test-unit code, thus enabling the autorunner.

Resolve #1312