### PR TITLE
Fix action mailer preview path setup.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Bug Fixes:
 
 * Fix auto-including of generic `Helper` object for view specs sitting in the
   `app/views` root (David Daniell, #1289)
+* Remove pre-loading of ActionMailer in the Railtie (Aaron Kromer, #1327)
 
 ### 3.2.1 / 2015-02-23
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.2.0...v3.2.1)

--- a/example_app_generator/generate_action_mailer_specs.rb
+++ b/example_app_generator/generate_action_mailer_specs.rb
@@ -1,0 +1,32 @@
+require 'active_support'
+require 'active_support/core_ext/module'
+
+# We need to copy this method from Thor for older Rails versions
+def comment_lines(path, flag, *args)
+  flag = flag.respond_to?(:source) ? flag.source : flag
+  gsub_file(path, /^(\s*)([^#|\n]*#{flag})/, '\1# \2', *args)
+end
+
+using_source_path(File.expand_path('..', __FILE__)) do
+  # Comment out the default mailer stuff
+  comment_lines 'config/environments/development.rb', /action_mailer/
+  comment_lines 'config/environments/test.rb', /action_mailer/
+
+  initializer 'action_mailer.rb', <<-CODE
+    if ENV['DEFAULT_URL']
+      Rails.application.configure do
+        config.action_mailer.default_url_options = { :host => ENV['DEFAULT_URL'] }
+      end
+    end
+  CODE
+
+  copy_file 'spec/support/default_preview_path'
+  chmod 'spec/support/default_preview_path', 0755
+  gsub_file 'spec/support/default_preview_path',
+            /ExampleApp/,
+            Rails.application.class.parent.to_s
+  if skip_active_record?
+    comment_lines 'spec/support/default_preview_path', /active_record/
+  end
+  copy_file 'spec/verify_mailer_preview_path_spec.rb'
+end

--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# Transparent helper to simply document code sections
+def require_file_stub(name)
+  yield
+end
+
+ENV['RAILS_ENV'] ||= 'development'
+
+require_file_stub 'config/environment' do
+  # Load the Rails application.
+  require_file_stub 'config/application' do
+    require_file_stub 'config/boot' do
+      # Set up gems listed in the Gemfile.
+      ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+      require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+    end
+
+    # Pick the frameworks you want:
+    require "active_record/railtie"
+    require "action_controller/railtie"
+    require "action_mailer/railtie" unless ENV['NO_ACTION_MAILER']
+    require "action_view/railtie"
+
+    # Require the gems listed in Gemfile, including any gems
+    # you've limited to :test, :development, or :production.
+    if Rails::VERSION::STRING.to_f < 3.1
+      Bundler.require(:default, Rails.env)
+    else
+      Bundler.require(*Rails.groups)
+    end
+
+    module ExampleApp
+      class Application < Rails::Application
+        config.eager_load = false
+
+        # Don't care if the mailer can't send.
+        config.action_mailer.raise_delivery_errors = false unless ENV['NO_ACTION_MAILER']
+
+        if ENV['CUSTOM_PREVIEW_PATH']
+          config.action_mailer.preview_path = ENV['CUSTOM_PREVIEW_PATH']
+        end
+        if ENV['SHOW_PREVIEWS']
+          config.action_mailer.show_previews = (ENV['SHOW_PREVIEWS'] == 'true')
+        end
+      end
+    end
+
+    I18n.enforce_available_locales = true if I18n.respond_to?(:enforce_available_locales)
+  end
+
+  # Initialize the Rails application.
+  Rails.application.initialize!
+end
+
+exit if ENV['NO_ACTION_MAILER']
+if ENV['DEFAULT_URL']
+  puts ActionMailer::Base.default_url_options[:host]
+elsif defined?(::ActionMailer::Preview)
+  puts Rails.application.config.action_mailer.preview_path
+end

--- a/example_app_generator/spec/verify_mailer_preview_path_spec.rb
+++ b/example_app_generator/spec/verify_mailer_preview_path_spec.rb
@@ -1,0 +1,183 @@
+require 'rails_helper'
+require 'rspec/rails/feature_check'
+
+RSpec.describe 'Action Mailer railtie hook' do
+  CaptureExec = Struct.new(:io, :exit_status) do
+    def ==(str)
+      io == str
+    end
+  end
+
+  def capture_exec(*ops)
+    io = if RUBY_VERSION.to_f < 1.9
+           IO.popen(ops.join(' '))
+         else
+           ops << { :err => [:child, :out] }
+           IO.popen(ops)
+         end
+    # Necessary to ignore warnings from Rails code base
+    out =  io.readlines.reject { |line|
+      line =~ /warning: circular argument reference/
+    }.join.chomp
+    CaptureExec.new(out, $?.exitstatus)
+  end
+
+  def have_no_preview
+    have_attributes(:io => be_blank, :exit_status => 0)
+  end
+
+  let(:exec_script) {
+    File.expand_path(File.join(__FILE__, '../support/default_preview_path'))
+  }
+
+  if RSpec::Rails::FeatureCheck.has_action_mailer_show_preview?
+    context 'in the development environment' do
+      let(:custom_env) { { 'RAILS_ENV' => rails_env } }
+      let(:rails_env) { 'development' }
+
+      it 'sets the preview path to the default rspec path' do
+        expect(capture_exec(custom_env, exec_script)).to eq(
+          "#{::Rails.root}/spec/mailers/previews"
+        )
+      end
+
+      it 'respects the setting from `show_previews`' do
+        expect(
+          capture_exec(
+            custom_env.merge('SHOW_PREVIEWS' => 'false'),
+            exec_script
+          )
+        ).to have_no_preview
+      end
+
+      it 'respects a custom `preview_path`' do
+        expect(
+          capture_exec(
+            custom_env.merge('CUSTOM_PREVIEW_PATH' => '/custom/path'),
+            exec_script
+          )
+        ).to eq('/custom/path')
+      end
+
+      it 'allows initializers to set options' do
+        expect(
+          capture_exec(
+            custom_env.merge('DEFAULT_URL' => 'test-host'),
+            exec_script
+          )
+        ).to eq('test-host')
+      end
+
+      it 'handles action mailer not being available' do
+        expect(
+          capture_exec(
+            custom_env.merge('NO_ACTION_MAILER' => 'true'),
+            exec_script
+          )
+        ).to have_no_preview
+      end
+    end
+
+    context 'in a non-development environment' do
+      let(:custom_env) { { 'RAILS_ENV' => rails_env } }
+      let(:rails_env) { 'test' }
+
+      it 'does not set the preview path by default' do
+        expect(capture_exec(custom_env, exec_script)).to have_no_preview
+      end
+
+      it 'respects the setting from `show_previews`' do
+        expect(
+          capture_exec(custom_env.merge('SHOW_PREVIEWS' => 'true'), exec_script)
+        ).to eq("#{::Rails.root}/spec/mailers/previews")
+      end
+
+      it 'allows initializers to set options' do
+        expect(
+          capture_exec(
+            custom_env.merge('DEFAULT_URL' => 'test-host'),
+            exec_script
+          )
+        ).to eq('test-host')
+      end
+
+      it 'handles action mailer not being available' do
+        expect(
+          capture_exec(
+            custom_env.merge('NO_ACTION_MAILER' => 'true'),
+            exec_script
+          )
+        ).to have_no_preview
+      end
+    end
+  elsif RSpec::Rails::FeatureCheck.has_action_mailer_preview?
+    context 'in the development environment', 'without `show_previews`' do
+      let(:custom_env) { { 'RAILS_ENV' => rails_env } }
+      let(:rails_env) { 'development' }
+
+      it 'sets the preview path to the default rspec path' do
+        expect(capture_exec(custom_env, exec_script)).to eq(
+          "#{::Rails.root}/spec/mailers/previews"
+        )
+      end
+
+      it 'respects a custom `preview_path`' do
+        expect(
+          capture_exec(
+            custom_env.merge('CUSTOM_PREVIEW_PATH' => '/custom/path'),
+            exec_script
+          )
+        ).to eq('/custom/path')
+      end
+
+      it 'allows initializers to set options' do
+        expect(
+          capture_exec(
+            custom_env.merge('DEFAULT_URL' => 'test-host'),
+            exec_script
+          )
+        ).to eq('test-host')
+      end
+
+      it 'handles action mailer not being available' do
+        expect(
+          capture_exec(
+            custom_env.merge('NO_ACTION_MAILER' => 'true'),
+            exec_script
+          )
+        ).to have_no_preview
+      end
+    end
+
+    context 'in a non-development environment', 'without `show_previews`' do
+      let(:custom_env) { { 'RAILS_ENV' => rails_env } }
+      let(:rails_env) { 'test' }
+
+      it 'does not set the preview path by default' do
+        expect(capture_exec(custom_env, exec_script)).to have_no_preview
+      end
+
+      it 'respects a custom `preview_path`' do
+        expect(
+          capture_exec(
+            custom_env.merge('CUSTOM_PREVIEW_PATH' => '/custom/path'),
+            exec_script
+          )
+        ).to eq('/custom/path')
+      end
+
+      it 'handles action mailer not being available' do
+        expect(
+          capture_exec(
+            custom_env.merge('NO_ACTION_MAILER' => 'true'),
+            exec_script
+          )
+        ).to have_no_preview
+      end
+    end
+  else
+    it 'handles no action mailer preview' do
+      expect(capture_exec(exec_script)).to have_no_preview
+    end
+  end
+end

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -23,27 +23,44 @@ module RSpec
       # sets the default for the `preview_path`
       initializer "rspec_rails.action_mailer",
                   :before => "action_mailer.set_configs" do |app|
-        if ::RSpec::Rails::FeatureCheck.has_action_mailer_preview?
-          options = app.config.action_mailer
-          # Rails 4.1 does not have `show_previews`
-          if ::ActionMailer::Base.respond_to?(:show_previews=)
-            options.show_previews ||= ::Rails.env.development?
-            set_preview_path = options.show_previews
-          else
-            set_preview_path = ::Rails.env.development?
-          end
+        setup_preview_path(app)
+      end
 
-          if set_preview_path
-            rspec_preview_path = "#{::Rails.root}/spec/mailers/previews"
-            config_preview_path = options.preview_path
-            if config_preview_path.blank?
-              options.preview_path = rspec_preview_path
-            elsif config_preview_path != rspec_preview_path
-              warn "Action Mailer `preview_path` is not the RSpec default. " \
-                   "Preview path is set to: #{config_preview_path}"
-            end
-          end
+    private
+
+      def setup_preview_path(app)
+        # If the action mailer railtie isn't loaded the config will not respond
+        return unless supports_action_mailer_previews?(app.config)
+        options = app.config.action_mailer
+        config_default_preview_path(options) if config_preview_path?(options)
+      end
+
+      def config_preview_path?(options)
+        # This string version check avoids loading the ActionMailer class, as
+        # would happen using `defined?`. This is necessary because the
+        # ActionMailer class only loads it's settings once, at load time. If we
+        # load the class now any settings declared in a config block in an
+        # initializer will be ignored.
+        #
+        # We cannot use `respond_to?(:show_previews)` here as it will always
+        # return `true`.
+        if ::Rails::VERSION::STRING < '4.2'
+          ::Rails.env.development?
+        elsif options.show_previews.nil?
+          options.show_previews = ::Rails.env.development?
+        else
+          options.show_previews
         end
+      end
+
+      def config_default_preview_path(options)
+        return unless options.preview_path.blank?
+        options.preview_path = "#{::Rails.root}/spec/mailers/previews"
+      end
+
+      def supports_action_mailer_previews?(config)
+        config.respond_to?(:action_mailer) &&
+          config.action_mailer.respond_to?(:preview_path)
       end
     end
   end

--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -38,6 +38,11 @@ module RSpec
         has_action_mailer? && defined?(::ActionMailer::Preview)
       end
 
+      def has_action_mailer_show_preview?
+        has_action_mailer_preview? &&
+          ::ActionMailer::Base.respond_to?(:show_previews=)
+      end
+
       def has_1_9_hash_syntax?
         ::Rails::VERSION::STRING > '4.0'
       end


### PR DESCRIPTION
This removes the unnecessary warning about a preview path set to a
location other than `/spec/mailers/preview`.

This does not force `ActionMailer` to load when the Railtie runs by
removing the `defined?` check. This is necessary because the
`ActionMailer` class only loads it's settings once, after it is first
loaded. If we load the class in our Railtie any custom settings declared
in a config block in an initializer will be ignored.

An improved spec suite for the different permutations of availability of
action mailer previews is included as well.

Resolve #1313, #1325 