### PR TITLE
Provide a summary for humans

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |s|
   s.authors     = ["David Chelimsky", "Andy Lindeman"]
   s.email       = "rspec@googlegroups.com"
   s.homepage    = "http://github.com/rspec/rspec-rails"
-  s.summary     = "rspec-rails-#{RSpec::Rails::Version::STRING}"
-  s.description = "RSpec for Rails"
+  s.summary     = "RSpec for Rails"
+  s.description = "rspec-rails is a testing framework for Rails 3.x and 4.x."
 
   s.rubyforge_project  = "rspec"
 


### PR DESCRIPTION
"rspec-rails-3" doesn't really add anything I don't already know (and especially if you use something like [label](https://github.com/jgorset/label) it looks pretty silly) — could we change it to something like "RSpec for Rails" and use the description for something even more descriptive? :cake: