### PR TITLE
Switching to the real SEMVER format

### DIFF
--- a/lib/rspec/rails/version.rb
+++ b/lib/rspec/rails/version.rb
@@ -3,7 +3,7 @@ module RSpec
     # Version information for RSpec Rails.
     module Version
       # Current version of RSpec Rails, in semantic versioning format.
-      STRING = '3.3.0.pre'
+      STRING = '3.3.0-pre'
     end
   end
 end


### PR DESCRIPTION
SEMVER describes "pre-release" information as being appended to the version by a dash.