### PR TITLE
Address yard issues

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,6 +1,8 @@
 --no-private
 --exclude features
 --exclude lib/generators/([^/]+/)*.*_spec.rb
+--exclude lib/generators/([^/]+/)*templates/([^/]+/)*.rb
+--exclude lib/generators/([^/]+/)*templates/.+\.rb
 --markup markdown
 --template-path yard/template/
 -

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,10 @@ gemspec
 rspec_dependencies_gemfile = File.expand_path("../Gemfile-rspec-dependencies", __FILE__)
 eval_gemfile rspec_dependencies_gemfile
 
+gem 'yard', '~> 0.8.7', :require => false
+
 ### deps for rdoc.info
 group :documentation do
-  gem 'yard',          '0.8.7.3', :require => false
   gem 'redcarpet',     '2.3.0'
   gem 'github-markup', '1.0.0'
 end

--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/string'
 
 module RSpec
   module Rails
+    # @private
     def self.disable_testunit_autorun
       # `Test::Unit::AutoRunner.need_auto_run=` was introduced to the test-unit
       # gem in version 2.4.9. Previous to this version `Test::Unit.run=` was

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -84,23 +84,25 @@ module RSpec
       # but requires this workaround:
       config.add_setting :rendering_views, :default => false
 
-      def config.render_views=(val)
-        self.rendering_views = val
-      end
+      config.instance_exec do
+        def render_views=(val)
+          self.rendering_views = val
+        end
 
-      def config.render_views
-        self.rendering_views = true
-      end
+        def render_views
+          self.rendering_views = true
+        end
 
-      def config.render_views?
-        rendering_views
-      end
+        def render_views?
+          rendering_views
+        end
 
-      def config.infer_spec_type_from_file_location!
-        DIRECTORY_MAPPINGS.each do |type, dir_parts|
-          escaped_path = Regexp.compile(dir_parts.join('[\\\/]') + '[\\\/]')
-          define_derived_metadata(:file_path => escaped_path) do |metadata|
-            metadata[:type] ||= type
+        def infer_spec_type_from_file_location!
+          DIRECTORY_MAPPINGS.each do |type, dir_parts|
+            escaped_path = Regexp.compile(dir_parts.join('[\\\/]') + '[\\\/]')
+            define_derived_metadata(:file_path => escaped_path) do |metadata|
+              metadata[:type] ||= type
+            end
           end
         end
       end

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -122,7 +122,13 @@ module RSpec
         end
       end
 
-      attr_reader :controller, :routes
+      # @!attribute [r]
+      # Returns the controller object instance under test.
+      attr_reader :controller
+
+      # @!attribute [r]
+      # Returns the Rails routes used for the spec.
+      attr_reader :routes
 
       # @private
       #

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -1,5 +1,10 @@
 module RSpec
   module Rails
+    # @private
+    ControllerAssertionDelegator = RSpec::Rails::AssertionDelegator.new(
+      ActionDispatch::Assertions::RoutingAssertions
+    )
+
     # Container module for controller spec functionality.
     module ControllerExampleGroup
       extend ActiveSupport::Concern
@@ -9,7 +14,7 @@ module RSpec
       include RSpec::Rails::Matchers::RedirectTo
       include RSpec::Rails::Matchers::RenderTemplate
       include RSpec::Rails::Matchers::RoutingMatchers
-      include RSpec::Rails::AssertionDelegator.new(ActionDispatch::Assertions::RoutingAssertions)
+      include ControllerAssertionDelegator
 
       # Class-level DSL for controller specs.
       module ClassMethods

--- a/lib/rspec/rails/example/routing_example_group.rb
+++ b/lib/rspec/rails/example/routing_example_group.rb
@@ -2,13 +2,18 @@ require "action_dispatch/testing/assertions/routing"
 
 module RSpec
   module Rails
+    # @private
+    RoutingAssertionDelegator =  RSpec::Rails::AssertionDelegator.new(
+      ActionDispatch::Assertions::RoutingAssertions
+    )
+
     # Container module for routing spec functionality.
     module RoutingExampleGroup
       extend ActiveSupport::Concern
       include RSpec::Rails::RailsExampleGroup
       include RSpec::Rails::Matchers::RoutingMatchers
       include RSpec::Rails::Matchers::RoutingMatchers::RouteHelpers
-      include RSpec::Rails::AssertionDelegator.new(ActionDispatch::Assertions::RoutingAssertions)
+      include RSpec::Rails::RoutingAssertionDelegator
 
       # Class-level DSL for route specs.
       module ClassMethods

--- a/lib/rspec/rails/example/routing_example_group.rb
+++ b/lib/rspec/rails/example/routing_example_group.rb
@@ -42,6 +42,8 @@ module RSpec
         end
       end
 
+      # @!attribute [r]
+      # @private
       attr_reader :routes
 
       # @private

--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -1,6 +1,7 @@
 # @api private
 module RSpec
   module Rails
+    # @private
     # Disable some cops until https://github.com/bbatsov/rubocop/issues/1310
     # rubocop:disable Style/IndentationConsistency
     module FeatureCheck

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -6,6 +6,8 @@ module RSpec
     module ViewRendering
       extend ActiveSupport::Concern
 
+      # @!attribute [r]
+      # Returns the controller object instance under test.
       attr_accessor :controller
 
       # DSL methods

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -8,7 +8,11 @@ module RSpec
 
       # @!attribute [r]
       # Returns the controller object instance under test.
-      attr_accessor :controller
+      attr_reader :controller
+
+      # @private
+      attr_writer :controller
+      private :controller=
 
       # DSL methods
       module ClassMethods


### PR DESCRIPTION
This makes YARD available in the dev/test environment again, fixing the `bin/yard` failure. It also updates the docs to get minimal 100% coverage and addresses the outstanding warnings.

Fix #1297