### PR TITLE
Prevent running in production mode by default.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ Enhancements:
   `:use_fixtures => true`. (Aaron Kromer, #1372)
 * Include `rspec:request` generator for generating request specs; this is an
   alias of `rspec:integration` (Aaron Kromer, #1378)
+* Update `rails_helper` generator with a default check to abort the spec run
+  when the Rails environment is production. (Aaron Kromer, #1383)
 
 Bug Fixes:
 

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -1,7 +1,9 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)
+# Prevent database truncation if the environment is production
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
Many setups start tests by truncating the database tables. Running the
specs in production would, horribly, would delete all of the data. This
checks to make sure Rails is not in production before loading
rspec-rails and the configuration. If production mode is detected the
run will abort immediately.

Resolve #1382