### PR TITLE
Removed deprecated option from .gemspec

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.summary     = "RSpec for Rails"
   s.description = "rspec-rails is a testing framework for Rails 3.x and 4.x."
 
-  s.rubyforge_project  = "rspec"
-
   s.files            = `git ls-files -- lib/*`.split("\n")
   s.files           += %w[README.md License.txt Changelog.md Capybara.md .yardopts .document]
   s.test_files       = []


### PR DESCRIPTION
This PR is related to https://github.com/rspec/rspec-core/pull/1974
Thank you. 