### PR TITLE
Fix regression mailer preview path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,11 @@ Enhancements:
 * Update `rails_helper` generator with a default check to abort the spec run
   when the Rails environment is production. (Aaron Kromer, #1383)
 
+Bug Fixes:
+
+* Fix regression with the railtie resulting in undefined method `preview_path=`
+  on Rails 3.x and 4.0 (Aaron Kromer, #1388)
+
 ### 3.2.2 / 2015-06-03
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.2.1...v3.2.2)
 

--- a/example_app_generator/generate_action_mailer_specs.rb
+++ b/example_app_generator/generate_action_mailer_specs.rb
@@ -14,11 +14,25 @@ using_source_path(File.expand_path('..', __FILE__)) do
 
   initializer 'action_mailer.rb', <<-CODE
     if ENV['DEFAULT_URL']
-      Rails.application.configure do
-        config.action_mailer.default_url_options = { :host => ENV['DEFAULT_URL'] }
+      if ::Rails::VERSION::STRING < '4.1'
+        ExampleApp::Application.configure do
+          config.action_mailer.default_url_options = { :host => ENV['DEFAULT_URL'] }
+        end
+      else
+        Rails.application.configure do
+          config.action_mailer.default_url_options = { :host => ENV['DEFAULT_URL'] }
+        end
       end
     end
+
+    if defined?(ActionMailer)
+      # This will force the loading of ActionMailer settings
+      ActionMailer::Base.smtp_settings
+    end
   CODE
+  gsub_file 'config/initializers/action_mailer.rb',
+            /ExampleApp/,
+            Rails.application.class.parent.to_s
 
   copy_file 'spec/support/default_preview_path'
   chmod 'spec/support/default_preview_path', 0755

--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -32,6 +32,7 @@ require_file_stub 'config/environment' do
     module ExampleApp
       class Application < Rails::Application
         config.eager_load = false
+        config.eager_load_paths.clear
 
         # Don't care if the mailer can't send.
         config.action_mailer.raise_delivery_errors = false unless ENV['NO_ACTION_MAILER']
@@ -58,3 +59,7 @@ if ENV['DEFAULT_URL']
 elsif defined?(::ActionMailer::Preview)
   puts Rails.application.config.action_mailer.preview_path
 end
+
+# This will force the loading of ActionMailer settings to ensure we do not
+# accicentally set something we should not
+ActionMailer::Base.smtp_settings

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -52,17 +52,17 @@ module RSpec
       end
 
       def supports_action_mailer_previews?(config)
-        # If the action mailer railtie isn't loaded the config will not
-        # respond.
+        # These checks avoid loading `ActionMailer`. Using `defined?` has the
+        # side-effect of the class getting loaded if it is available. This is
+        # problematic because loading `ActionMailer::Base` will cause it to
+        # read the config settings; this is the only time the config is read.
+        # If the config is loaded now, any settings declared in a config block
+        # in an initializer will be ignored.
         #
-        # This string version check avoids loading the ActionMailer class, as
-        # would happen using `defined?`. This is necessary because the
-        # ActionMailer class only loads it's settings once, at load time. If we
-        # load the class now any settings declared in a config block in an
-        # initializer will be ignored.
-        #
-        # We cannot use `config.action_mailer.respond_to?(:preview_path)` here
-        # as it will always return `true`.
+        # If the action mailer railtie has not been loaded then `config` will
+        # not respond to the method. However, we cannot use
+        # `config.action_mailer.respond_to?(:preview_path)` here as it will
+        # always return `true`.
         config.respond_to?(:action_mailer) && ::Rails::VERSION::STRING > '4.1'
       end
     end

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -29,19 +29,12 @@ module RSpec
     private
 
       def setup_preview_path(app)
-        # If the action mailer railtie isn't loaded the config will not respond
         return unless supports_action_mailer_previews?(app.config)
         options = app.config.action_mailer
         config_default_preview_path(options) if config_preview_path?(options)
       end
 
       def config_preview_path?(options)
-        # This string version check avoids loading the ActionMailer class, as
-        # would happen using `defined?`. This is necessary because the
-        # ActionMailer class only loads it's settings once, at load time. If we
-        # load the class now any settings declared in a config block in an
-        # initializer will be ignored.
-        #
         # We cannot use `respond_to?(:show_previews)` here as it will always
         # return `true`.
         if ::Rails::VERSION::STRING < '4.2'
@@ -59,8 +52,18 @@ module RSpec
       end
 
       def supports_action_mailer_previews?(config)
-        config.respond_to?(:action_mailer) &&
-          config.action_mailer.respond_to?(:preview_path)
+        # If the action mailer railtie isn't loaded the config will not
+        # respond.
+        #
+        # This string version check avoids loading the ActionMailer class, as
+        # would happen using `defined?`. This is necessary because the
+        # ActionMailer class only loads it's settings once, at load time. If we
+        # load the class now any settings declared in a config block in an
+        # initializer will be ignored.
+        #
+        # We cannot use `config.action_mailer.respond_to?(:preview_path)` here
+        # as it will always return `true`.
+        config.respond_to?(:action_mailer) && ::Rails::VERSION::STRING > '4.1'
       end
     end
   end


### PR DESCRIPTION
This fixes the regression where setting the `ActionMailer` preview path leaked into versions which does not support it (Rails before 4.1).

The cause of the regression was a series of failures:

- The integration spec did not force `ActionMailer::Base` to load; thus the incorrect setting was not loaded exposing the issue
- In the case of older Rails versions, it was believed that the mailer spec's script defaulting to the "development" environment would be sufficient. However, when shelling out the existing Ruby `ENV` was already available, resulting in the `RAILS_ENV` already being set to "test". Thus the test was not explicitly testing the code as expected.
- The implementation code itself made a note about `config.action_mailer.show_previews` always returning `true`, yet code slightly further down was relying on `config.action_mailer.preview_path` being able to return `false` (which it never will)

This fixes each of these issues.

Based on minimal local testing it appears that `defined?(ActionMailer)`, while possibly loading `ActionMailer`, will _not_ force the configuration to load. The configuration is only with `ActionMailer::Base`.

I'm weary :weary: about switching out the logic yet again regarding: `defined?(ActionMailer)` vs `config.respond_to?(:action_mailer)`. It's possible that on any further version the behavior of the config being loaded or the config changing to always respond `true` can occur. For now, it seems that `config.respond_to?(:action_mailer)` is working and stable. Though I'm always open to further discussion.

Resolve #1386

/cc @tagliala, @olance, @myronmarston 