### PR TITLE
Fix verified partial doubles with abstract classes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Gemfile-custom
 bundle
 .bundle
 specs.out
+spec/examples.txt

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ### 3.4.0 Dev
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.3.1...master)
 
+Bug Fixes:
+
+* Prevent `define_attribute_methods` from being called on abstract classes as
+  part of the verifying double lifecycle. (Jon Rowe, #1396)
+
 ### 3.3.1 / 2015-06-14
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.3.0...v3.3.1)
 

--- a/lib/rspec/rails/active_record.rb
+++ b/lib/rspec/rails/active_record.rb
@@ -11,7 +11,8 @@ module RSpec
             ::RSpec::Mocks.configuration.when_declaring_verifying_double do |possible_model|
               target = possible_model.target
 
-              if target.respond_to?(:define_attribute_methods) && ActiveRecord::Base != target
+              if target.respond_to?(:define_attribute_methods) && ActiveRecord::Base != target &&
+                 target.respond_to?(:abstract_class?) && !target.abstract_class?
                 target.define_attribute_methods
               end
             end

--- a/spec/rspec/rails/active_model_spec.rb
+++ b/spec/rspec/rails/active_model_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe "ActiveModel support" do
+  around do |ex|
+    old_value = RSpec::Mocks.configuration.verify_partial_doubles?
+    ex.run
+    RSpec::Mocks.configuration.verify_partial_doubles = old_value
+  end
+
+  RSpec.shared_examples_for "stubbing ActiveModel" do
+    before do
+      stub_const 'ActiveRecord' unless defined?(ActiveRecord)
+    end
+
+    it "allows you to stub `ActiveModel`" do
+      allow(ActiveModel).to receive(:inspect).and_return("stubbed inspect")
+      expect(ActiveModel.inspect).to eq "stubbed inspect"
+    end
+
+    it 'allows you to stub instances of `ActiveModel`' do
+      klass = Class.new { include ActiveModel::AttributeMethods; attr_accessor :name }
+      model = klass.new
+      allow(model).to receive(:name) { 'stubbed name' }
+      expect(model.name).to eq 'stubbed name'
+    end
+  end
+
+  context "with partial double verification enabled" do
+    before do
+      RSpec::Mocks.configuration.verify_partial_doubles = true
+    end
+
+    include_examples "stubbing ActiveModel"
+  end
+
+  context "with partial double verification disabled" do
+    before do
+      RSpec::Mocks.configuration.verify_partial_doubles = false
+    end
+
+    include_examples "stubbing ActiveModel"
+  end
+end

--- a/spec/rspec/rails/active_record_spec.rb
+++ b/spec/rspec/rails/active_record_spec.rb
@@ -12,12 +12,23 @@ RSpec.describe "ActiveRecord support" do
     end
   end
 
+  RSpec.shared_examples_for "stubbing abstract classes" do
+    it "allows you to stub abstract classes" do
+      klass = Class.new(ActiveRecord::Base) do
+                self.abstract_class = true
+              end
+      allow(klass).to receive(:find).and_return("stubbed find")
+      expect(klass.find(1)).to eq "stubbed find"
+    end
+  end
+
   context "with partial double verification enabled" do
     before do
       RSpec::Mocks.configuration.verify_partial_doubles = true
     end
 
     include_examples "stubbing ActiveRecord::Base"
+    include_examples "stubbing abstract classes"
   end
 
   context "with partial double verification disabled" do
@@ -26,5 +37,6 @@ RSpec.describe "ActiveRecord support" do
     end
 
     include_examples "stubbing ActiveRecord::Base"
+    include_examples "stubbing abstract classes"
   end
 end


### PR DESCRIPTION
As reported in rspec/rspec-mocks#975 abstract classes can't be verified currently due to the callback for defining attribute methods. This corrects that.

Fixes rspec/rspec-mocks#975.