### PR TITLE
Expose path to view specs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Bug fixes:
   internal to helper classes. (Sam Phippen, Peter Swan, #1499).
 * Warn if a fixture method is called from a `before(:context)` block, instead of
   crashing with a `undefined method for nil:NilClass`. (Sam Phippen, #1501)
+* Expose path to view specs (Ryan Clark, Sarah Mei, Sam Phippen, #1402)
 
 ### 3.4.0 / 2015-11-11
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.3.3...v3.4.0)

--- a/features/view_specs/view_spec.feature
+++ b/features/view_specs/view_spec.feature
@@ -2,7 +2,7 @@ Feature: view spec
 
   View specs live in spec/views and render view templates in isolation.
 
-  Scenario: passing spec that renders the described view file
+  Scenario: View specs render the described view file
     Given a file named "spec/views/widgets/index.html.erb_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -24,7 +24,7 @@ Feature: view spec
     When I run `rspec spec/views`
     Then the examples should all pass
 
-  Scenario: passing spec with before and nesting
+  Scenario: View specs can have before block and nesting
     Given a file named "spec/views/widgets/index.html.erb_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -51,7 +51,7 @@ Feature: view spec
     When I run `rspec spec/views`
     Then the examples should all pass
 
-  Scenario: passing spec with explicit template rendering
+  Scenario: View specs can explicitly render templates
     Given a file named "spec/views/widgets/widget.html.erb_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -73,7 +73,7 @@ Feature: view spec
     When I run `rspec spec/views`
     Then the examples should all pass
 
-  Scenario: passing spec with a description that includes the format and handler
+  Scenario: View specs can have description that includes the format and handler
     Given a file named "spec/views/widgets/widget.xml.erb_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -105,7 +105,7 @@ Feature: view spec
     When I run `rspec spec/views`
     Then the examples should all pass
 
-  Scenario: passing spec with rendering of locals in a partial
+  Scenario: View specs can render locals in a partial
     Given a file named "spec/views/widgets/_widget.html.erb_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -127,7 +127,7 @@ Feature: view spec
     When I run `rspec spec/views`
     Then the examples should all pass
 
-  Scenario: passing spec with rendering of locals in an implicit partial
+  Scenario: View specs can render locals in an implicit partial
     Given a file named "spec/views/widgets/_widget.html.erb_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -149,7 +149,7 @@ Feature: view spec
     When I run `rspec spec/views`
     Then the examples should all pass
 
-  Scenario: passing spec with rendering of text
+  Scenario: View specs can render text
     Given a file named "spec/views/widgets/direct.html.erb_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -166,7 +166,7 @@ Feature: view spec
     When I run `rspec spec/views`
     Then the examples should all pass
 
-  Scenario: passing view spec that stubs a helper method
+  Scenario: View specs can stub a helper method
     Given a file named "app/helpers/application_helper.rb" with:
       """ruby
       module ApplicationHelper
@@ -199,7 +199,7 @@ Feature: view spec
     When I run `rspec spec/views/secrets`
     Then the examples should all pass
 
-  Scenario: request.path_parameters should match Rails by using symbols for keys
+  Scenario: View specs use symbols for keys in `request.path_parameters` to match Rails style
     Given a file named "spec/views/widgets/index.html.erb_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -207,6 +207,37 @@ Feature: view spec
       RSpec.describe "controller.request.path_parameters" do
         it "matches the Rails environment by using symbols for keys" do
           [:controller, :action].each { |k| expect(controller.request.path_parameters.keys).to include(k) }
+        end
+      end
+      """
+    When I run `rspec spec/views`
+    Then the examples should all pass
+
+  Scenario: View spec actions that do not require extra parameters have `request.fullpath` set
+    Given a file named "spec/views/widgets/index.html.erb_spec.rb" with:
+    """ruby
+      require "rails_helper"
+
+      RSpec.describe "widgets/index" do
+        it "has a request.fullpath that is defined" do
+          expect(controller.request.fullpath).to eq widgets_path
+        end
+      end
+      """
+    When I run `rspec spec/views`
+    Then the examples should all pass
+
+  Scenario: View spec actions that require extra parameters have `request.fullpath` set when the developer supplies them
+    Given a file named "spec/views/widgets/show.html.erb_spec.rb" with:
+    """ruby
+      require "rails_helper"
+
+      RSpec.describe "widgets/show" do
+        it "displays the widget with id: 1" do
+          widget = Widget.create!(:name => "slicer")
+          controller.extra_params = { :id => widget.id }
+
+          expect(controller.request.fullpath).to eq widget_path(widget)
         end
       end
       """

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -1,4 +1,6 @@
 require 'rspec/rails/view_assigns'
+require 'rspec/rails/view_spec_methods'
+require 'rspec/rails/view_path_builder'
 
 module RSpec
   module Rails
@@ -159,6 +161,12 @@ module RSpec
           controller.controller_path = _controller_path
           controller.request.path_parameters[:controller] = _controller_path
           controller.request.path_parameters[:action]     = _inferred_action unless _inferred_action =~ /^_/
+          controller.request.path = ViewPathBuilder.new(::Rails.application.routes).path_for(controller.request.path_parameters)
+          ViewSpecMethods.add_to(::ActionView::TestCase::TestController)
+        end
+
+        after do
+          ViewSpecMethods.remove_from(::ActionView::TestCase::TestController)
         end
 
         let(:_default_file_to_render) do |example|

--- a/lib/rspec/rails/view_path_builder.rb
+++ b/lib/rspec/rails/view_path_builder.rb
@@ -1,0 +1,29 @@
+module RSpec
+  module Rails
+    # Builds paths for view specs using a particular route set.
+    class ViewPathBuilder
+      def initialize(route_set)
+        self.class.send(:include, route_set.url_helpers)
+      end
+
+      # Given a hash of parameters, build a view path, if possible.
+      # Returns nil if no path can be built from the given params.
+      #
+      # @example
+      #     # path can be built because all required params are present in the hash
+      #     view_path_builder = ViewPathBuilder.new(::Rails.application.routes)
+      #     view_path_builder.path_for({ :controller => 'posts', :action => 'show', :id => '54' })
+      #     # => "/post/54"
+      #
+      # @example
+      #     # path cannot be built because the params are missing a required element (:id)
+      #     view_path_builder.path_for({ :controller => 'posts', :action => 'delete' })
+      #     # => nil
+      def path_for(path_params)
+        url_for(path_params.merge(:only_path => true))
+      rescue => e
+        e.message
+      end
+    end
+  end
+end

--- a/lib/rspec/rails/view_spec_methods.rb
+++ b/lib/rspec/rails/view_spec_methods.rb
@@ -1,0 +1,56 @@
+module RSpec
+  module Rails
+    # Adds methods (generally to ActionView::TestCase::TestController).
+    # Intended for use in view specs.
+    module ViewSpecMethods
+      module_function
+
+      # Adds methods `extra_params=` and `extra_params` to the indicated class.
+      # When class is `::ActionView::TestCase::TestController`, these methods
+      # are exposed in view specs on the `controller` object.
+      def add_to(klass)
+        return if klass.method_defined?(:extra_params) && klass.method_defined?(:extra_params=)
+
+        klass.module_exec do
+          # Set any extra parameters that rendering a URL for this view
+          # would require.
+          #
+          # @example
+          #
+          #     # In "spec/views/widgets/show.html.erb_spec.rb":
+          #     before do
+          #       widget = Widget.create!(:name => "slicer")
+          #       controller.extra_params = { :id => widget.id }
+          #     end
+          def extra_params=(hash)
+            @extra_params = hash
+            request.path =
+              ViewPathBuilder.new(::Rails.application.routes).path_for(
+                extra_params.merge(request.path_parameters)
+              )
+          end
+
+          # Use to read extra parameters that are set in the view spec.
+          #
+          # @example
+          #
+          #     # After the before in the above example:
+          #     controller.extra_params
+          #     # => { :id => 4 }
+          def extra_params
+            @extra_params ||= {}
+            @extra_params.dup.freeze
+          end
+        end
+      end
+
+      # Removes methods `extra_params=` and `extra_params` from the indicated class.
+      def remove_from(klass)
+        klass.module_exec do
+          undef extra_params= if klass.method_defined?(:extra_params=)
+          undef extra_params  if klass.method_defined?(:extra_params)
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/rails/view_spec_methods_spec.rb
+++ b/spec/rspec/rails/view_spec_methods_spec.rb
@@ -1,0 +1,72 @@
+module RSpec::Rails
+  RSpec.describe ViewSpecMethods do
+    before do
+      class ::VCSampleClass; end
+    end
+
+    after do
+      Object.send(:remove_const, :VCSampleClass)
+    end
+
+    describe ".add_extra_params_accessors_to" do
+      describe "when accessors are not yet defined" do
+        it "adds them as instance methods" do
+          ViewSpecMethods.add_to(VCSampleClass)
+
+          expect(VCSampleClass.instance_methods.map(&:to_sym)).to(include(:extra_params=))
+          expect(VCSampleClass.instance_methods.map(&:to_sym)).to(include(:extra_params))
+        end
+
+        describe "the added #extra_params reader" do
+          it "raises an error when a user tries to mutate it" do
+            ViewSpecMethods.add_to(VCSampleClass)
+
+            expect {
+              VCSampleClass.new.extra_params[:id] = 4
+            }.to raise_error(/can't modify frozen/)
+          end
+        end
+      end
+
+      describe "when accessors are already defined" do
+        before do
+          class ::VCSampleClass
+            def extra_params; end
+
+            def extra_params=; end
+          end
+        end
+
+        it "does not redefine them" do
+          ViewSpecMethods.add_to(VCSampleClass)
+          expect(VCSampleClass.new.extra_params).to be_nil
+        end
+      end
+    end
+
+    describe ".remove_extra_params_accessors_from" do
+      describe "when accessors are defined" do
+        before do
+          ViewSpecMethods.add_to(VCSampleClass)
+        end
+
+        it "removes them" do
+          ViewSpecMethods.remove_from(VCSampleClass)
+
+          expect(VCSampleClass.instance_methods).to_not include("extra_params=")
+          expect(VCSampleClass.instance_methods).to_not include(:extra_params=)
+          expect(VCSampleClass.instance_methods).to_not include("extra_params")
+          expect(VCSampleClass.instance_methods).to_not include(:extra_params)
+        end
+      end
+
+      describe "when accessors are not defined" do
+        it "does nothing" do
+          expect {
+            ViewSpecMethods.remove_from(VCSampleClass)
+          }.to_not change { VCSampleClass.instance_methods }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix for https://github.com/rspec/rspec-rails/issues/1347.

Expose inferred path data to view specs, since we already expose inferred controller & action. This will allow view specs to exercise views that depend on the current page.

We did two implementations - the first commit uses `rescue nil` - the second one has no rescues but uses somewhat awkward logic to iterate through the routes to find a matching one.

If you know of a better way to implement this without rescue...would love to hear about it.