### PR TITLE
Namespace check shouldn't fail on symbols; fixes #1412

### DIFF
--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -12,7 +12,7 @@ module RSpec
       generators.test_framework :rspec
 
       generators do
-        ::Rails::Generators.hidden_namespaces.reject! { |namespace| namespace.start_with?("rspec") }
+        ::Rails::Generators.hidden_namespaces.reject! { |namespace| namespace.to_s.start_with?("rspec") }
       end
 
       rake_tasks do


### PR DESCRIPTION
Fixes https://github.com/rspec/rspec-rails/issues/1412 by converting symbols to strings in check.

This can also be backported cleanly to 3.3.2.