### PR TITLE
Update travis to specify specific branches to run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,3 +89,8 @@ matrix:
     - rvm: 2.2
       env: RAILS_VERSION='~> 3.1.12'
   fast_finish: true
+
+branches:
+  only:
+    - master
+    - /^\d+-\d+-maintenance$/


### PR DESCRIPTION
This moves the Travis CI config inline with the rest of the RSpec repos.
This will also help reduce the load on the Travis system for rspec-rails
PRs when the PR branch is a branch in the repo itself.