### PR TITLE
Rubocop Upgrade

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,13 +6,16 @@ LineLength:
 
 Lint/NestedMethodDefinition:
   Enabled: false
-    
+
 # Over time we'd like to get this down, but this is what we're at now.
 MethodLength:
   Max: 50
-    
+
 # Over time we'd like to get this down, but this is what we're at now.
 Metrics/AbcSize:
+  Max: 40
+
+Metrics/PerceivedComplexity:
   Max: 40
 
 # We use spaces, so it's less of a change to stick with that.
@@ -53,10 +56,6 @@ PerlBackrefs:
     # We probably can refactor the backref out, but for now excluding it since
     # we can't use named matches in 1.8.7
     - lib/generators/rspec/scaffold/scaffold_generator.rb
-
-ParallelAssignment:
-  Exclude:
-    - lib/generators/rspec/mailer/mailer_generator.rb
 
 PerceivedComplexity:
   Exclude: 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,13 +4,23 @@ inherit_from: .rubocop_rspec_base.yml
 LineLength:
   Max: 186
 
+Lint/NestedMethodDefinition:
+  Enabled: false
+    
 # Over time we'd like to get this down, but this is what we're at now.
 MethodLength:
   Max: 50
+    
+# Over time we'd like to get this down, but this is what we're at now.
+Metrics/AbcSize:
+  Max: 40
 
 # We use spaces, so it's less of a change to stick with that.
 SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: space
+
+Style/MultilineOperationIndentation:
+  Enabled: false
 
 ################################################################################
 # Individual File Exclusions
@@ -43,3 +53,11 @@ PerlBackrefs:
     # We probably can refactor the backref out, but for now excluding it since
     # we can't use named matches in 1.8.7
     - lib/generators/rspec/scaffold/scaffold_generator.rb
+
+ParallelAssignment:
+  Exclude:
+    - lib/generators/rspec/mailer/mailer_generator.rb
+
+PerceivedComplexity:
+  Exclude: 
+    - lib/rspec/rails/example/controller_example_group.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ cache: bundler
 
 bundler_args: "--binstubs --without documentation --path ../bundle --retry=3 --jobs=3"
 
-before_install: "script/clone_all_rspec_repos"
+before_install:
+  - "script/clone_all_rspec_repos"
+  # Note this doesn't work on JRUBY 2.0.0 mode so we don't do it
+  - if [ "jruby" != "$TRAVIS_RUBY_VERSION" ]; then gem install bundler; fi
 
 before_script:
   # Rails 4.x complains with a bundler rails binstub in PROJECT_ROOT/bin/

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ if RUBY_VERSION <= '1.8.7'
   gem 'rubyzip', '< 1.0'
 end
 
-gem 'rubocop', "~> 0.23.0", :platform => [:ruby_19, :ruby_20, :ruby_21]
+gem 'rubocop', "~> 0.32.1", :platform => [:ruby_19, :ruby_20, :ruby_21]
 
 custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)
 eval_gemfile custom_gemfile if File.exist?(custom_gemfile)

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,12 @@ if RUBY_VERSION <= '1.8.7'
   gem 'rubyzip', '< 1.0'
 end
 
-gem 'rubocop', "~> 0.32.1", :platform => [:ruby_19, :ruby_20, :ruby_21]
+# There is no platform :ruby_193 and Rubocop only supports >= 1.9.3
+unless RUBY_VERSION == "1.9.2"
+  gem "rubocop",
+    "~> 0.32.1",
+    :platform => [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+end
 
 custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)
 eval_gemfile custom_gemfile if File.exist?(custom_gemfile)

--- a/lib/generators/rspec/mailer/mailer_generator.rb
+++ b/lib/generators/rspec/mailer/mailer_generator.rb
@@ -13,7 +13,8 @@ module Rspec
 
       def generate_fixtures_files
         actions.each do |action|
-          @action, @path = action, File.join(file_path, action)
+          @action = action
+          @path = File.join(file_path, action)
           template "fixture", File.join("spec/fixtures", @path)
         end
       end

--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -78,7 +78,7 @@ module Rspec
 
       def ns_parts
         @ns_parts ||= begin
-                        matches = ARGV[0].to_s.match(/\A(\w+)(?:\/|::)(\w+)/)
+                        matches = ARGV[0].to_s.match(%r{\A(\w+)(?:\/|::)(\w+)})
                         matches ? [matches[1], matches[2]] : []
                       end
       end

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -38,7 +38,7 @@ module RSpec
 
     # @private
     def self.initialize_configuration(config)
-      config.backtrace_exclusion_patterns << /vendor\//
+      config.backtrace_exclusion_patterns << %r{vendor\/}
       config.backtrace_exclusion_patterns << %r{ lib/rspec/rails }
 
       config.include RSpec::Rails::ControllerExampleGroup, :type => :controller

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -38,7 +38,7 @@ module RSpec
 
     # @private
     def self.initialize_configuration(config)
-      config.backtrace_exclusion_patterns << %r{vendor\/}
+      config.backtrace_exclusion_patterns << %r{vendor/}
       config.backtrace_exclusion_patterns << %r{ lib/rspec/rails }
 
       config.include RSpec::Rails::ControllerExampleGroup, :type => :controller

--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -2,12 +2,8 @@
 module RSpec
   module Rails
     # @private
-    # Disable some cops until https://github.com/bbatsov/rubocop/issues/1310
-    # rubocop:disable Style/IndentationConsistency
     module FeatureCheck
-    # rubocop:disable Style/IndentationWidth
     module_function
-      # rubocop:enable Style/IndentationWidth
 
       def can_check_pending_migrations?
         has_active_record_migration? &&
@@ -56,6 +52,5 @@ module RSpec
         end
       end
     end
-    # rubocop:enable Style/IndentationConsistency
   end
 end

--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -13,7 +13,7 @@ RSpec::Core::RakeTask.new(:spec => "spec:prepare")
 namespace :spec do
   types = begin
             dirs = Dir['./spec/**/*_spec.rb'].
-              map { |f| f.sub(/^\.\/(spec\/\w+)\/.*/, '\\1') }.
+              map { |f| f.sub(%r{^\.\/(spec\/\w+)\/.*}, '\\1') }.
               uniq.
               select { |f| File.directory?(f) }
             Hash[dirs.map { |d| [d.split('/').last, d] }]


### PR DESCRIPTION
This provides a basic update of Rubocop to 0.32.1 adding support for checking on Ruby 2.2. The following offenses have been left failing to allow for determining if they should simply be disabled:

> lib/rspec/rails/matchers/have_http_status.rb:183:21: C: Do not use trailing _s in
parallel assignment.

```
            status, _ = Rack::Utils::SYMBOL_TO_STATUS_CODE.find do |_, c|
                    ^
```

> lib/rspec/rails/tasks/rspec.rake:2:12: W: Assignment in condition - you probably meant
to use ==.

```
if default = Rake.application.instance_variable_get('@tasks')['default']
           ^
```