### PR TITLE
add whitespace checks and fix end of line whitespace

### DIFF
--- a/features/Transactions.md
+++ b/features/Transactions.md
@@ -38,7 +38,7 @@ already ran. For example:
       it "does something" do
         expect(@widget).to do_something
       end
-        
+
       it "does something else" do
         expect(@widget).to do_something_else
       end
@@ -47,7 +47,7 @@ already ran. For example:
 The `@widget` is recreated in each of the two examples above, so each example
 has a different object, _and_ the underlying data is rolled back so the data
 backing the `@widget` in each example is new.
-        
+
 ### Data created in `before(:all)` are _not_ rolled back
 
 `before(:all)` hooks are invoked before the transaction is opened. You can use

--- a/features/controller_specs/Cookies.md
+++ b/features/controller_specs/Cookies.md
@@ -13,7 +13,7 @@ the following guidelines:
   * Access cookies through the `request` and `response` objects in the spec.
     * Use `request.cookies` before the action to set up state.
     * Use `response.cookies` after the action to specify outcomes.
-  * Use the `cookies` object in the controller action. 
+  * Use the `cookies` object in the controller action.
   * Use String keys.
 
 <pre>
@@ -42,7 +42,7 @@ sticking with string keys for consistency.
 
 The `cookies` method combines the `request` and `response` cookies. This can
 lead to confusion when setting cookies in the example in order to set up state
-for the controller action. 
+for the controller action.
 
     # does not work in rails 3.0.0 > 3.1.0
     cookies['foo'] = 'bar' # this is not visible in the controller
@@ -51,7 +51,6 @@ for the controller action.
 ### Future versions of Rails
 
 There is code in the master branch in rails that makes cookie access more
-consistent so you can use the same `cookies` object before and after the action, 
+consistent so you can use the same `cookies` object before and after the action,
 and you can use String or Symbol keys. We'll update these docs accordingly when
 that is released.
-

--- a/features/matchers/new_record_matcher.feature
+++ b/features/matchers/new_record_matcher.feature
@@ -6,7 +6,7 @@ Feature: be_a_new matcher
   You can also chain `with` on `be_a_new` with a hash of attributes to specify
   the subject has equal attributes.
 
-  Scenario: example spec with four be_a_new possibilities 
+  Scenario: example spec with four be_a_new possibilities
     Given a file named "spec/models/widget_spec.rb" with:
       """ruby
       require "rails_helper"

--- a/spec/rspec/rails_spec.rb
+++ b/spec/rspec/rails_spec.rb
@@ -1,0 +1,26 @@
+require 'rspec/support/spec/library_wide_checks'
+
+RSpec.describe "RSpec::Rails" do
+  include RSpec::Support::WhitespaceChecks
+
+  # Pasted from rspec-support lib/rspec/support/spec/library_wide_checks.rb:134
+  # Easier to do that here than to extract it out
+  RSpec::Matchers.define :be_well_formed do
+    match do |actual|
+      actual.empty?
+    end
+
+    failure_message do |actual|
+      actual.join("\n")
+    end
+  end
+
+  it "has no malformed whitespace", :slow do
+    error_messages = []
+    `git ls-files -z`.split("\x0").each do |filename|
+      error_messages << check_for_tab_characters(filename)
+      error_messages << check_for_extra_spaces(filename)
+    end
+    expect(error_messages.compact).to be_well_formed
+  end
+end


### PR DESCRIPTION
This adds the file spec/rspec/rails_spec.rb to check for whitespace problems
using the RSpec::Support::WhitespaceChecks module from PR #232 in rspec-support.
This also removes trailing whitespace from three files in the features directory.

`:be_well_formed` was taken from [rspec-support](https://github.com/rspec/rspec-support/blob/f82e762eb550e71fa01cc3a6291921bbcbb341fe/lib/rspec/support/spec/library_wide_checks.rb#L134-L142) and may have to be extracted later