### PR TITLE
modify error message when redirected but expecting to render a template

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ### 3.4.0 Development
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.3.3...master)
 
+Enhancements:
+
+* Improved the failure message for `have_rendered` matcher on a redirect
+  response. (Alex Egan, #1440)
+
 Bug Fixes:
 
 * Fix another load order issued which causes an undefined method `fixture_path` error

--- a/lib/rspec/rails/matchers/have_rendered.rb
+++ b/lib/rspec/rails/matchers/have_rendered.rb
@@ -21,6 +21,11 @@ module RSpec
             match_check
           end
 
+          # Uses normalize_argument_to_redirection to find and format
+          # the redirect location. normalize_argument_to_redirection is private
+          # in ActionDispatch::Assertions::ResponseAssertions so we call it
+          # here using #send. This will keep the error message format consistent
+          # @api private
           def check_redirect
             response = @scope.response
             return unless response.respond_to?(:redirect?) && response.redirect?

--- a/lib/rspec/rails/matchers/have_rendered.rb
+++ b/lib/rspec/rails/matchers/have_rendered.rb
@@ -9,18 +9,32 @@ module RSpec
             @expected = Symbol === expected ? expected.to_s : expected
             @message = message
             @scope = scope
+            @redirect_is = nil
           end
 
           # @api private
           def matches?(*)
-            match_unless_raises ActiveSupport::TestCase::Assertion do
+            match_check = match_unless_raises ActiveSupport::TestCase::Assertion do
               @scope.assert_template expected, @message
             end
+            check_redirect unless match_check
+            match_check
+          end
+
+          def check_redirect
+            response = @scope.response
+            return unless response.respond_to?(:redirect?) && response.redirect?
+            @redirect_is = @scope.send(:normalize_argument_to_redirection, response.location)
           end
 
           # @api private
           def failure_message
-            rescued_exception.message
+            if @redirect_is
+              rescued_exception.message[/.* but /] +
+                "was a redirect to <#{@redirect_is}>"
+            else
+              rescued_exception.message
+            end
           end
 
           # @api private

--- a/spec/rspec/rails/matchers/have_rendered_spec.rb
+++ b/spec/rspec/rails/matchers/have_rendered_spec.rb
@@ -95,7 +95,7 @@ require "spec_helper"
           message = "expecting <'template_name'> but rendering with <[]>"
           raise ActiveSupport::TestCase::Assertion.new(message)
         end
-        def normalize_argument_to_redirection(*)
+        def normalize_argument_to_redirection(response_redirect_location)
           "http://test.host/widgets/1"
         end
         it "gives informative error message" do

--- a/spec/rspec/rails/matchers/have_rendered_spec.rb
+++ b/spec/rspec/rails/matchers/have_rendered_spec.rb
@@ -88,6 +88,24 @@ require "spec_helper"
           end.to raise_exception("oops")
         end
       end
+
+      context "when fails with a redirect" do
+        let(:response) { ActionController::TestResponse.new(302) }
+        def assert_template(*)
+          message = "expecting <'template_name'> but rendering with <[]>"
+          raise ActiveSupport::TestCase::Assertion.new(message)
+        end
+        def normalize_argument_to_redirection(*)
+          "http://test.host/widgets/1"
+        end
+        it "gives informative error message" do
+          response = ActionController::TestResponse.new(302)
+          response.location = "http://test.host/widgets/1"
+          expect do
+            expect(response).to send(template_expectation, "template_name")
+          end.to raise_exception("expecting <'template_name'> but was a redirect to <http://test.host/widgets/1>")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This change modifies the error message when using `expect(response).to have_rendered(:template)` when the response is a redirect.

The current error message is
```
expecting <"template_name"> but rendering with <[]>
```

This change would modify it to be
```
expecting <'template_name'> but was a redirect to <(redirect location)>
```

This will make the problem a bit more clear.

Because the matcher calls assert_template for this, the actual exception is being passed from assert_template to have_rendered, so when the assert_template fails it was just passing the error message along. This change checks to see if the response is a redirect after the assertion fails, and if so replaces the second half of the error message with a message that gives the actual reason for the failure.