### PR TITLE
Add explicit access control tags to docs

### DIFF
--- a/lib/rspec/rails/matchers/be_a_new.rb
+++ b/lib/rspec/rails/matchers/be_a_new.rb
@@ -60,6 +60,7 @@ module RSpec
         end
       end
 
+      # @api public
       # Passes if actual is an instance of `model_class` and returns `false` for
       # `persisted?`. Typically used to specify instance variables assigned to
       # views by controller actions

--- a/lib/rspec/rails/matchers/be_new_record.rb
+++ b/lib/rspec/rails/matchers/be_new_record.rb
@@ -16,6 +16,7 @@ module RSpec
         end
       end
 
+      # @api public
       # Passes if actual returns `false` for `persisted?`.
       #
       # @example


### PR DESCRIPTION
Prior to the commit, docs for both RSpec::Rails::Matchers#be_a_new and
RSpec::Rails::Matchers#be_new_record incorrectly indicated that the
methods were private.

This commit corrects this issue, following the pattern used here:
https://github.com/rspec/rspec-rails/blame/1fb6f9f642e887df1b1ee344594de02d7de3b3fe/lib/rspec/rails/matchers/have_http_status.rb#L329
(f6c277f)

Fixes #1413