### PR TITLE
Halve the time it takes to run view specs by enabling the resolver cache

### DIFF
--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -114,7 +114,7 @@ module RSpec
 
             render_options = { :template => template }
             render_options[:handlers] = [handler] if handler
-            render_options[:formats] = [format] if format
+            render_options[:formats] = [format.to_sym] if format
             render_options[:locales] = [locale] if locale
 
             render_options

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -155,9 +155,6 @@ module RSpec
             view.lookup_context.prefixes << _controller_path
           end
 
-          # fixes bug with differing formats
-          view.lookup_context.view_paths.each(&:clear_cache)
-
           controller.controller_path = _controller_path
           controller.request.path_parameters[:controller] = _controller_path
           controller.request.path_parameters[:action]     = _inferred_action unless _inferred_action =~ /^_/

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -121,7 +121,7 @@ module RSpec::Rails
           view_spec.render
 
           if ::Rails::VERSION::STRING >= '3.2'
-            expect(view_spec.received.first).to eq([{:template => "widgets/new", :locales=>['en'], :formats=>['html'], :handlers=>['erb']}, {}, nil])
+            expect(view_spec.received.first).to eq([{:template => "widgets/new", :locales=>['en'], :formats=>[:html], :handlers=>['erb']}, {}, nil])
           else
             expect(view_spec.received.first).to eq([{:template => "widgets/new.en.html.erb"}, {}, nil])
           end


### PR DESCRIPTION
Hi,

Recently at FutureLearn we have taken some time to try and speed up our tests.

We have lots of view specs in our test suite, and we noticed that they took quite a while to run. This surprised us given that one of the benefits of testing views independently is speed. We found that one of the reasons for this slowness was that rspec-rails had disabled the ActionView resolver cache, increasing the time it took to load views.

There are two commits in this pull request. The first contains a fix the original issue which caused the cache to be disabled, the second enables the cache again. Please see their respective commit messages for more detail. When running our tests against this branch, it halves the time it takes us to run our view specs.

I'd like to hear peoples thoughts on this change, particularly:
+ Could converting the format to a symbol introduce breaking changes for anyone? The FutureLearn and rspec-rails test suites are fine, but I don't know if people are testing views in other ways.
+ Are there any other reasons why a user of rspec-rails might want ActionView's resolver cache to be disabled?