### PR TITLE
Rails exclusion filters

### DIFF
--- a/features/.nav
+++ b/features/.nav
@@ -6,6 +6,7 @@
 - Changelog.md
 - RailsVersions.md (Rails versions)
 - directory_structure.feature
+- backtrace_filtering.feature
 - model_specs:
   - transactional_examples.feature
 - mocks:

--- a/features/backtrace_filtering.feature
+++ b/features/backtrace_filtering.feature
@@ -1,0 +1,45 @@
+Feature: backtrace filtering
+
+  The following configuration setting will filter out lines in backtraces that come from Rails gems in order to reduce the noise in test failure output:
+
+  ```ruby
+  RSpec.configure do |config|
+    config.filter_rails_from_backtrace!
+  end
+  ```
+
+  `rspec` will always show the full backtrace output when run with the `--backtrace` commandline option.
+
+  Background: Using `filter_rails_from_backtrace!`
+    Given a file named "spec/failing_spec.rb" with:
+    """ruby
+    require "rails_helper"
+
+    RSpec.configure do |config|
+      config.filter_rails_from_backtrace!
+    end
+
+    RSpec.describe "Controller", :type => :controller do
+      controller do
+        def index
+          raise "Something went wrong."
+        end
+      end
+
+      describe "GET index" do
+        it "raises an error" do
+          get :index
+        end
+      end
+    end
+    """
+
+  Scenario: Using the bare `rspec` command
+    When I run `rspec`
+    Then the output should contain "1 example, 1 failure"
+    And the output should not contain "activesupport"
+
+  Scenario: Using `rspec --backtrace`
+    When I run `rspec --backtrace`
+    Then the output should contain "1 example, 1 failure"
+    And the output should contain "activesupport"

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -58,4 +58,9 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+
+  # Filter lines from Rails gems in backtraces.
+  config.filter_rails_from_backtrace!
+  # arbitrary gems may also be filtered via:
+  # config.filter_gems_from_backtrace("gem name")
 end

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -92,9 +92,9 @@ module RSpec
 
         # Adds exclusion filters for gems included with Rails
         def filter_rails_from_backtrace!
-          filter_gems_from_backtrace "actionmailer", "actionpack" ,"actionview"
+          filter_gems_from_backtrace "actionmailer", "actionpack", "actionview"
           filter_gems_from_backtrace "activemodel", "activerecord",
-            "activesupport", "activejob"
+                                     "activesupport", "activejob"
         end
       end
 

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -89,6 +89,13 @@ module RSpec
             end
           end
         end
+
+        # Adds exclusion filters for gems included with Rails
+        def filter_rails_from_backtrace!
+          filter_gems_from_backtrace "actionmailer", "actionpack" ,"actionview"
+          filter_gems_from_backtrace "activemodel", "activerecord",
+            "activesupport", "activejob"
+        end
       end
 
       config.include RSpec::Rails::ControllerExampleGroup, :type => :controller

--- a/spec/generators/rspec/install/install_generator_spec.rb
+++ b/spec/generators/rspec/install/install_generator_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe Rspec::Generators::InstallGenerator, :type => :generator do
     match(/config\.use_transactional_fixtures/m)
   end
 
+  def filter_rails_from_backtrace
+    match(/config\.filter_rails_from_backtrace!/m)
+  end
+
   setup_default_destination
 
   let(:rails_helper) { content_for('spec/rails_helper.rb') }
@@ -67,6 +71,12 @@ RSpec.describe Rspec::Generators::InstallGenerator, :type => :generator do
     specify "with default fixture path" do
       run_generator
       expect(rails_helper).to use_transactional_fixtures
+    end
+
+    specify "excluding rails gems from the backtrace" do
+      run_generator
+
+      expect(rails_helper).to filter_rails_from_backtrace
     end
 
     if RSpec::Rails::FeatureCheck.can_maintain_test_schema?

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 require 'rspec/support/spec/in_sub_process'
 
 RSpec.describe "Configuration" do
-
   include RSpec::Support::InSubProcess
 
   subject(:config) { RSpec::Core::Configuration.new }
@@ -102,7 +101,7 @@ RSpec.describe "Configuration" do
   specify "#filter_rails_from_backtrace! adds exclusion patterns for rails gems" do
     config.filter_rails_from_backtrace!
 
-    gems = %w(
+    gems = %w[
       actionmailer
       actionpack
       actionview
@@ -110,10 +109,10 @@ RSpec.describe "Configuration" do
       activerecord
       activesupport
       activejob
-    )
+    ]
     exclusions = config.backtrace_exclusion_patterns.map(&:to_s)
     aggregate_failures do
-      gems.each { |gem| expect(exclusions).to include(%r(#{gem})) }
+      gems.each { |gem| expect(exclusions).to include(/#{gem}/) }
     end
   end
 
@@ -247,5 +246,4 @@ RSpec.describe "Configuration" do
       expect(group.new).to be_a(RSpec::Rails::MailerExampleGroup)
     end
   end
-
 end

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -99,6 +99,24 @@ RSpec.describe "Configuration" do
     end
   end
 
+  specify "#filter_rails_from_backtrace! adds exclusion patterns for rails gems" do
+    config.filter_rails_from_backtrace!
+
+    gems = %w(
+      actionmailer
+      actionpack
+      actionview
+      activemodel
+      activerecord
+      activesupport
+      activejob
+    )
+    exclusions = config.backtrace_exclusion_patterns.map(&:to_s)
+    aggregate_failures do
+      gems.each { |gem| expect(exclusions).to include(%r(#{gem})) }
+    end
+  end
+
   describe "#infer_spec_type_from_file_location!" do
     def in_inferring_type_from_location_environment
       in_sub_process do


### PR DESCRIPTION
Rails in backtraces can get quite spammy, and the configuration option
to `filter_gems_from_backtrace` is not well-known since it is not found
in the generator's `rails_helper.rb`.

This adds `filter_rails_from_backtrace!` as a convenience method for
nixing rails gems in the backtrace and adds it to `rails_helper.rb` to
raise awareness.

Credit to @smcabrera for the idea and pairing