### PR TITLE
Add have_enqueued_jobs matcher

### DIFF
--- a/lib/rspec/rails/matchers.rb
+++ b/lib/rspec/rails/matchers.rb
@@ -1,5 +1,6 @@
 require 'rspec/core/warnings'
 require 'rspec/expectations'
+require 'rspec/rails/feature_check'
 
 module RSpec
   module Rails
@@ -17,3 +18,6 @@ require 'rspec/rails/matchers/be_a_new'
 require 'rspec/rails/matchers/relation_match_array'
 require 'rspec/rails/matchers/be_valid'
 require 'rspec/rails/matchers/have_http_status'
+if RSpec::Rails::FeatureCheck.has_active_job?
+  require 'rspec/rails/matchers/active_job'
+end

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -9,9 +9,9 @@ module RSpec
       module ActiveJob
         # @private
         class HaveEnqueuedJobs < RSpec::Matchers::BuiltIn::BaseMatcher
-          def initialize(number, only = nil)
-            @number = number
-            @only   = only
+          def initialize(only)
+            @only = only
+            set_expected_number(:exactly, 1)
           end
 
           def matches?(proc)
@@ -20,15 +20,47 @@ module RSpec
             before_block_jobs_size = enqueued_jobs_size(@only)
             proc.call
             @in_block_jobs_size = enqueued_jobs_size(@only) - before_block_jobs_size
-            @number == @in_block_jobs_size
+
+            case @expectation_type
+            when :exactly then @expected_number == @in_block_jobs_size
+            when :at_most then @expected_number >= @in_block_jobs_size
+            when :at_least then @expected_number <= @in_block_jobs_size
+            end
+          end
+
+          def exactly(count)
+            set_expected_number(:exactly, count)
+            self
+          end
+
+          def at_least(count)
+            set_expected_number(:at_least, count)
+            self
+          end
+
+          def at_most(count)
+            set_expected_number(:at_most, count)
+            self
+          end
+
+          def times
+            self
           end
 
           def failure_message
-            "expected to enqueue #{@number} jobs, but enqueued #{@in_block_jobs_size}"
+            "expected to enqueue #{message_expectation_modifier} #{@expected_number} jobs, but enqueued #{@in_block_jobs_size}"
           end
 
           def failure_message_when_negated
-            "expected not to enqueue #{@number} jobs, but enqueued #{@in_block_jobs_size}"
+            "expected not to enqueue #{message_expectation_modifier} #{@expected_number} jobs, but enqueued #{@in_block_jobs_size}"
+          end
+
+          def message_expectation_modifier
+            case @expectation_type
+            when :exactly then "exactly"
+            when :at_most then "at most"
+            when :at_least then "at least"
+            end
           end
 
           def supports_block_expectations?
@@ -38,11 +70,21 @@ module RSpec
         private
 
           def enqueued_jobs_size(only)
-            if only
-              queue_adapter.enqueued_jobs.count { |job| Array(only).include?(job.fetch(:job)) }
+            if only.any?
+              queue_adapter.enqueued_jobs.count { |job| only.include?(job.fetch(:job)) }
             else
               queue_adapter.enqueued_jobs.count
             end
+          end
+
+          def set_expected_number(relativity, count)
+            @expectation_type = relativity
+            @expected_number = case count
+                               when Numeric then count
+                               when :once then 1
+                               when :twice then 2
+                               when :thrice then 3
+                               end
           end
 
           def queue_adapter
@@ -52,20 +94,29 @@ module RSpec
       end
 
       # @api public
-      # Passess if `number` of jobs were enqueued inside block
+      # Passess if `count` of jobs were enqueued inside block
       #
       # @example
       #     expect {
       #       HeavyLiftingJob.perform_later
-      #     }.to have_enqueued_jobs(1)
+      #     }.to have_enqueued_jobs
       #
       #     expect {
       #       HelloJob.perform_later
       #       HeavyLiftingJob.perform_later
-      #     }.to have_enqueued_jobs(1, only: HelloJob)
-      def have_enqueued_jobs(number = 1, options = {})
-        only = options[:only]
-        ActiveJob::HaveEnqueuedJobs.new(number, only)
+      #     }.to have_enqueued_jobs(HelloJob).exactly(:once)
+      #
+      #     expect {
+      #       HelloJob.perform_later
+      #       HelloJob.perform_later
+      #       HelloJob.perform_later
+      #     }.to have_enqueued_jobs(HelloJob).at_least(2).times
+      #
+      #     expect {
+      #       HelloJob.perform_later
+      #     }.to have_enqueued_jobs(HelloJob).at_most(:twice)
+      def have_enqueued_jobs(*jobs)
+        ActiveJob::HaveEnqueuedJobs.new(jobs)
       end
     end
   end

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -1,0 +1,72 @@
+require "active_job/base"
+
+module RSpec
+  module Rails
+    module Matchers
+      # Namespace for various implementations of ActiveJob features
+      #
+      # @api private
+      module ActiveJob
+        # @private
+        class HaveEnqueuedJobs < RSpec::Matchers::BuiltIn::BaseMatcher
+          def initialize(number, only = nil)
+            @number = number
+            @only   = only
+          end
+
+          def matches?(proc)
+            raise ArgumentError, "Proc have to be passed to expectation" unless Proc === proc
+
+            before_block_jobs_size = enqueued_jobs_size(@only)
+            proc.call
+            @in_block_jobs_size = enqueued_jobs_size(@only) - before_block_jobs_size
+            @number == @in_block_jobs_size
+          end
+
+          def failure_message
+            "expected to enqueue #{@number} jobs, but enqueued #{@in_block_jobs_size}"
+          end
+
+          def failure_message_when_negated
+            "expected not to enqueue jobs, but enqueued #{@in_block_jobs_size}"
+          end
+
+          def supports_block_expectations?
+            true
+          end
+
+        private
+
+          def enqueued_jobs_size(only)
+            if only
+              queue_adapter.enqueued_jobs.count { |job| Array(only).include?(job.fetch(:job)) }
+            else
+              queue_adapter.enqueued_jobs.count
+            end
+          end
+
+          def queue_adapter
+            ::ActiveJob::Base.queue_adapter
+          end
+        end
+      end
+
+      # @api public
+      # Passess if `number` of jobs were enqueued inside block
+      #
+      # @example
+      #     expect {
+      #       HeavyLiftingJob.perform_later
+      #     }.to have_enqueued_jobs(1)
+      #
+      #     expect {
+      #       HelloJob.perform_later
+      #       HeavyLiftingJob.perform_later
+      #     }.to have_enqueued_jobs(1, only: HelloJob)
+      def have_enqueued_jobs(number = 1, options = {})
+        only = options[:only]
+        ActiveJob::HaveEnqueuedJobs.new(number, only)
+      end
+    end
+  end
+end

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -15,7 +15,7 @@ module RSpec
           end
 
           def matches?(proc)
-            raise ArgumentError, "Proc have to be passed to expectation" unless Proc === proc
+            raise ArgumentError, "have_enqueued_jobs only supports block expectations" unless Proc === proc
 
             before_block_jobs_size = enqueued_jobs_size(@only)
             proc.call
@@ -28,7 +28,7 @@ module RSpec
           end
 
           def failure_message_when_negated
-            "expected not to enqueue jobs, but enqueued #{@in_block_jobs_size}"
+            "expected not to enqueue #{@number} jobs, but enqueued #{@in_block_jobs_size}"
           end
 
           def supports_block_expectations?

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -32,21 +32,21 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
   describe "have_enqueued_jobs" do
     it "raises ArgumentError when no Proc passed to expect" do
       expect {
-        expect(heavy_lifting_job.perform_later).to have_enqueued_jobs(1)
+        expect(heavy_lifting_job.perform_later).to have_enqueued_jobs
       }.to raise_error(ArgumentError)
     end
 
-    it "passess with correct number" do
+    it "passess with default one number" do
       expect {
         heavy_lifting_job.perform_later
-      }.to have_enqueued_jobs(1)
+      }.to have_enqueued_jobs
     end
 
     it "counts only jobs enqueued in block" do
       heavy_lifting_job.perform_later
       expect {
         heavy_lifting_job.perform_later
-      }.to have_enqueued_jobs(1)
+      }.to have_enqueued_jobs.exactly(1)
     end
 
     it "passess when negated" do
@@ -55,8 +55,8 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
 
     it "fails when job is not enqueued" do
       expect {
-        expect { }.to have_enqueued_jobs(1)
-      }.to raise_error(/expected to enqueue 1 jobs, but enqueued 0/)
+        expect { }.to have_enqueued_jobs
+      }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
     end
 
     it "fails when too many jobs enqueued" do
@@ -64,36 +64,85 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
         expect {
           heavy_lifting_job.perform_later
           heavy_lifting_job.perform_later
-        }.to have_enqueued_jobs(1)
-      }.to raise_error(/expected to enqueue 1 jobs, but enqueued 2/)
+        }.to have_enqueued_jobs.exactly(1)
+      }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 2/)
     end
 
     it "reports correct number in fail error message" do
       heavy_lifting_job.perform_later
       expect {
-        expect { }.to have_enqueued_jobs(1)
-      }.to raise_error(/expected to enqueue 1 jobs, but enqueued 0/)
+        expect { }.to have_enqueued_jobs.exactly(1)
+      }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
     end
 
     it "fails when negated and job is enqueued" do
       expect {
         expect { heavy_lifting_job.perform_later }.not_to have_enqueued_jobs
-      }.to raise_error(/expected not to enqueue 1 jobs, but enqueued 1/)
+      }.to raise_error(/expected not to enqueue exactly 1 jobs, but enqueued 1/)
     end
 
-    it "passes with only option" do
+    it "passes with job name" do
       expect {
         hello_job.perform_later
         heavy_lifting_job.perform_later
-      }.to have_enqueued_jobs(1, :only => hello_job)
+      }.to have_enqueued_jobs(hello_job).exactly(1).times
     end
 
-    it "passes with only option as array" do
+    it "passes with multiple job names" do
       expect {
         hello_job.perform_later
         logging_job.perform_later
         heavy_lifting_job.perform_later
-      }.to have_enqueued_jobs(2, :only => [hello_job, logging_job])
+      }.to have_enqueued_jobs(hello_job, logging_job).exactly(2).times
+    end
+
+    it "passess with :once count" do
+      expect {
+        hello_job.perform_later
+      }.to have_enqueued_jobs.exactly(:once)
+    end
+
+    it "passess with :twice count" do
+      expect {
+        hello_job.perform_later
+        hello_job.perform_later
+      }.to have_enqueued_jobs.exactly(:twice)
+    end
+
+    it "passess with :thrice count" do
+      expect {
+        hello_job.perform_later
+        hello_job.perform_later
+        hello_job.perform_later
+      }.to have_enqueued_jobs.exactly(:thrice)
+    end
+
+    it "passess with at_least count when enqueued jobs are over limit" do
+      expect {
+        hello_job.perform_later
+        hello_job.perform_later
+      }.to have_enqueued_jobs.at_least(:once)
+    end
+
+    it "passess with at_most count when enqueued jobs are under limit" do
+      expect {
+        hello_job.perform_later
+      }.to have_enqueued_jobs.at_most(:once)
+    end
+
+    it "generates failure message with at least hint" do
+      expect {
+        expect { }.to have_enqueued_jobs.at_least(:once)
+      }.to raise_error(/expected to enqueue at least 1 jobs, but enqueued 0/)
+    end
+
+    it "generates failure message with at most hint" do
+      expect {
+        expect {
+          hello_job.perform_later
+          hello_job.perform_later
+        }.to have_enqueued_jobs.at_most(:once)
+      }.to raise_error(/expected to enqueue at most 1 jobs, but enqueued 2/)
     end
   end
 end

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
     it "fails when negated and job is enqueued" do
       expect {
         expect { heavy_lifting_job.perform_later }.not_to have_enqueued_jobs
-      }.to raise_error(/expected not to enqueue jobs, but enqueued 1/)
+      }.to raise_error(/expected not to enqueue 1 jobs, but enqueued 1/)
     end
 
     it "passes with only option" do

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -29,33 +29,33 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
     ActiveJob::Base.queue_adapter = :test
   end
 
-  describe "have_enqueued_jobs" do
+  describe "have_enqueued_job" do
     it "raises ArgumentError when no Proc passed to expect" do
       expect {
-        expect(heavy_lifting_job.perform_later).to have_enqueued_jobs
+        expect(heavy_lifting_job.perform_later).to have_enqueued_job
       }.to raise_error(ArgumentError)
     end
 
     it "passess with default one number" do
       expect {
         heavy_lifting_job.perform_later
-      }.to have_enqueued_jobs
+      }.to have_enqueued_job
     end
 
     it "counts only jobs enqueued in block" do
       heavy_lifting_job.perform_later
       expect {
         heavy_lifting_job.perform_later
-      }.to have_enqueued_jobs.exactly(1)
+      }.to have_enqueued_job.exactly(1)
     end
 
     it "passess when negated" do
-      expect { }.not_to have_enqueued_jobs
+      expect { }.not_to have_enqueued_job
     end
 
     it "fails when job is not enqueued" do
       expect {
-        expect { }.to have_enqueued_jobs
+        expect { }.to have_enqueued_job
       }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
     end
 
@@ -64,20 +64,20 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
         expect {
           heavy_lifting_job.perform_later
           heavy_lifting_job.perform_later
-        }.to have_enqueued_jobs.exactly(1)
+        }.to have_enqueued_job.exactly(1)
       }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 2/)
     end
 
     it "reports correct number in fail error message" do
       heavy_lifting_job.perform_later
       expect {
-        expect { }.to have_enqueued_jobs.exactly(1)
+        expect { }.to have_enqueued_job.exactly(1)
       }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
     end
 
     it "fails when negated and job is enqueued" do
       expect {
-        expect { heavy_lifting_job.perform_later }.not_to have_enqueued_jobs
+        expect { heavy_lifting_job.perform_later }.not_to have_enqueued_job
       }.to raise_error(/expected not to enqueue exactly 1 jobs, but enqueued 1/)
     end
 
@@ -85,28 +85,28 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       expect {
         hello_job.perform_later
         heavy_lifting_job.perform_later
-      }.to have_enqueued_jobs(hello_job).exactly(1).times
+      }.to have_enqueued_job(hello_job).exactly(1).times
     end
 
-    it "passes with multiple job names" do
+    it "passes with multiple jobs" do
       expect {
         hello_job.perform_later
         logging_job.perform_later
         heavy_lifting_job.perform_later
-      }.to have_enqueued_jobs(hello_job, logging_job).exactly(2).times
+      }.to have_enqueued_job(hello_job).and have_enqueued_job(logging_job)
     end
 
     it "passess with :once count" do
       expect {
         hello_job.perform_later
-      }.to have_enqueued_jobs.exactly(:once)
+      }.to have_enqueued_job.exactly(:once)
     end
 
     it "passess with :twice count" do
       expect {
         hello_job.perform_later
         hello_job.perform_later
-      }.to have_enqueued_jobs.exactly(:twice)
+      }.to have_enqueued_job.exactly(:twice)
     end
 
     it "passess with :thrice count" do
@@ -114,25 +114,25 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
         hello_job.perform_later
         hello_job.perform_later
         hello_job.perform_later
-      }.to have_enqueued_jobs.exactly(:thrice)
+      }.to have_enqueued_job.exactly(:thrice)
     end
 
     it "passess with at_least count when enqueued jobs are over limit" do
       expect {
         hello_job.perform_later
         hello_job.perform_later
-      }.to have_enqueued_jobs.at_least(:once)
+      }.to have_enqueued_job.at_least(:once)
     end
 
     it "passess with at_most count when enqueued jobs are under limit" do
       expect {
         hello_job.perform_later
-      }.to have_enqueued_jobs.at_most(:once)
+      }.to have_enqueued_job.at_most(:once)
     end
 
     it "generates failure message with at least hint" do
       expect {
-        expect { }.to have_enqueued_jobs.at_least(:once)
+        expect { }.to have_enqueued_job.at_least(:once)
       }.to raise_error(/expected to enqueue at least 1 jobs, but enqueued 0/)
     end
 
@@ -141,7 +141,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
         expect {
           hello_job.perform_later
           hello_job.perform_later
-        }.to have_enqueued_jobs.at_most(:once)
+        }.to have_enqueued_job.at_most(:once)
       }.to raise_error(/expected to enqueue at most 1 jobs, but enqueued 2/)
     end
   end

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+require "rspec/rails/feature_check"
+if RSpec::Rails::FeatureCheck.has_active_job?
+  require "rspec/rails/matchers/active_job"
+end
+
+RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_active_job? do
+  include RSpec::Rails::Matchers
+
+  let(:heavy_lifting_job) do
+    Class.new(ActiveJob::Base) do
+      def perform; end
+    end
+  end
+
+  let(:hello_job) do
+    Class.new(ActiveJob::Base) do
+      def perform; end
+    end
+  end
+
+  let(:logging_job) do
+    Class.new(ActiveJob::Base) do
+      def perform; end
+    end
+  end
+
+  before do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  describe "have_enqueued_jobs" do
+    it "raises ArgumentError when no Proc passed to expect" do
+      expect {
+        expect(heavy_lifting_job.perform_later).to have_enqueued_jobs(1)
+      }.to raise_error(ArgumentError)
+    end
+
+    it "passess with correct number" do
+      expect {
+        heavy_lifting_job.perform_later
+      }.to have_enqueued_jobs(1)
+    end
+
+    it "counts only jobs enqueued in block" do
+      heavy_lifting_job.perform_later
+      expect {
+        heavy_lifting_job.perform_later
+      }.to have_enqueued_jobs(1)
+    end
+
+    it "passess when negated" do
+      expect { }.not_to have_enqueued_jobs
+    end
+
+    it "fails when job is not enqueued" do
+      expect {
+        expect { }.to have_enqueued_jobs(1)
+      }.to raise_error(/expected to enqueue 1 jobs, but enqueued 0/)
+    end
+
+    it "fails when too many jobs enqueued" do
+      expect {
+        expect {
+          heavy_lifting_job.perform_later
+          heavy_lifting_job.perform_later
+        }.to have_enqueued_jobs(1)
+      }.to raise_error(/expected to enqueue 1 jobs, but enqueued 2/)
+    end
+
+    it "reports correct number in fail error message" do
+      heavy_lifting_job.perform_later
+      expect {
+        expect { }.to have_enqueued_jobs(1)
+      }.to raise_error(/expected to enqueue 1 jobs, but enqueued 0/)
+    end
+
+    it "fails when negated and job is enqueued" do
+      expect {
+        expect { heavy_lifting_job.perform_later }.not_to have_enqueued_jobs
+      }.to raise_error(/expected not to enqueue jobs, but enqueued 1/)
+    end
+
+    it "passes with only option" do
+      expect {
+        hello_job.perform_later
+        heavy_lifting_job.perform_later
+      }.to have_enqueued_jobs(1, :only => hello_job)
+    end
+
+    it "passes with only option as array" do
+      expect {
+        hello_job.perform_later
+        logging_job.perform_later
+        heavy_lifting_job.perform_later
+      }.to have_enqueued_jobs(2, :only => [hello_job, logging_job])
+    end
+  end
+end


### PR DESCRIPTION
There is still 3 more matchers to be added `have_enqueued_with`, `have_performed_jobs` and `have_performed_with`, but I can work on them in another PR, unless you want all in one.

Anyway, I would like to get feedback on implementation and naming, as I'm not familiar with rspec codebase.

I didn't figure out why I don't have to clear enqueued jobs after/before each test, but the tests are passing so somehow this queue is cleared.
You can compare it with https://github.com/rails/rails/blob/master/activejob/lib/active_job/test_helper.rb#L22-L23

Refs #1334 