### PR TITLE
add load hook

### DIFF
--- a/lib/rspec/rails.rb
+++ b/lib/rspec/rails.rb
@@ -14,3 +14,5 @@ require 'rspec/rails/vendor/capybara'
 require 'rspec/rails/configuration'
 require 'rspec/rails/active_record'
 require 'rspec/rails/feature_check'
+
+ActiveSupport.run_load_hooks :rspec_rails, RSpec::Rails


### PR DESCRIPTION
I want loaded hook to configure in my gem after default `rspec-rails` configuration.

For example, [devise.gem](https://github.com/plataformatec/devise#test-helpers) can write in `devise/railtie.rb` like this

```ruby
  ActiveSupport.on_load :rspec_rails do
    RSpec.configuration.include Devise::TestHelpers, type: :controller
  end
```