### PR TITLE
Label Rspec as @private for docs, update other modules visibility

### DIFF
--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -1,6 +1,7 @@
 require 'rails/generators/named_base'
 require 'rspec/rails/feature_check'
 
+# @private
 # Weirdly named generators namespace (should be `RSpec`) for compatability with
 # rails loading.
 module Rspec

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -5,6 +5,7 @@ module RSpec
       ActionDispatch::Assertions::RoutingAssertions
     )
 
+    # @api public
     # Container module for controller spec functionality.
     module ControllerExampleGroup
       extend ActiveSupport::Concern

--- a/lib/rspec/rails/example/feature_example_group.rb
+++ b/lib/rspec/rails/example/feature_example_group.rb
@@ -1,5 +1,6 @@
 module RSpec
   module Rails
+    # @api public
     # Container module for routing spec functionality.
     module FeatureExampleGroup
       extend ActiveSupport::Concern

--- a/lib/rspec/rails/example/helper_example_group.rb
+++ b/lib/rspec/rails/example/helper_example_group.rb
@@ -2,6 +2,7 @@ require 'rspec/rails/view_assigns'
 
 module RSpec
   module Rails
+    # @api public
     # Container module for helper specs.
     module HelperExampleGroup
       extend ActiveSupport::Concern

--- a/lib/rspec/rails/example/job_example_group.rb
+++ b/lib/rspec/rails/example/job_example_group.rb
@@ -1,5 +1,6 @@
 module RSpec
   module Rails
+    # @api public
     # Container module for job spec functionality. It is only available if
     # ActiveJob has been loaded before it.
     module JobExampleGroup

--- a/lib/rspec/rails/example/mailer_example_group.rb
+++ b/lib/rspec/rails/example/mailer_example_group.rb
@@ -1,5 +1,6 @@
 module RSpec
   module Rails
+    # @api public
     # Container module for mailer spec functionality. It is only available if
     # ActionMailer has been loaded before it.
     module MailerExampleGroup

--- a/lib/rspec/rails/example/model_example_group.rb
+++ b/lib/rspec/rails/example/model_example_group.rb
@@ -1,5 +1,6 @@
 module RSpec
   module Rails
+    # @api public
     # Container class for model spec functionality. Does not provide anything
     # special over the common RailsExampleGroup currently.
     module ModelExampleGroup

--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -4,6 +4,7 @@ require 'rspec/rails/matchers'
 
 module RSpec
   module Rails
+    # @api public
     # Common rails example functionality.
     module RailsExampleGroup
       extend ActiveSupport::Concern

--- a/lib/rspec/rails/example/request_example_group.rb
+++ b/lib/rspec/rails/example/request_example_group.rb
@@ -1,5 +1,6 @@
 module RSpec
   module Rails
+    # @api public
     # Container class for request spec functionality.
     module RequestExampleGroup
       extend ActiveSupport::Concern

--- a/lib/rspec/rails/example/routing_example_group.rb
+++ b/lib/rspec/rails/example/routing_example_group.rb
@@ -7,6 +7,7 @@ module RSpec
       ActionDispatch::Assertions::RoutingAssertions
     )
 
+    # @api public
     # Container module for routing spec functionality.
     module RoutingExampleGroup
       extend ActiveSupport::Concern

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -2,6 +2,7 @@ require 'rspec/rails/view_assigns'
 
 module RSpec
   module Rails
+    # @api public
     # Container class for view spec functionality.
     module ViewExampleGroup
       extend ActiveSupport::Concern

--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -1,4 +1,3 @@
-# @api private
 module RSpec
   module Rails
     # @private

--- a/lib/rspec/rails/matchers.rb
+++ b/lib/rspec/rails/matchers.rb
@@ -4,6 +4,7 @@ require 'rspec/rails/feature_check'
 
 module RSpec
   module Rails
+    # @api public
     # Container module for Rails specific matchers.
     module Matchers
     end

--- a/lib/rspec/rails/matchers/be_valid.rb
+++ b/lib/rspec/rails/matchers/be_valid.rb
@@ -33,6 +33,7 @@ module RSpec
         end
       end
 
+      # @api public
       # Passes if the given model instance's `valid?` method is true, meaning
       # all of the `ActiveModel::Validations` passed and no errors exist. If a
       # message is not given, a default message is shown listing each error.

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -2,6 +2,7 @@ require 'action_view/testing/resolvers'
 
 module RSpec
   module Rails
+    # @api public
     # Helpers for optionally rendering views in controller specs.
     module ViewRendering
       extend ActiveSupport::Concern


### PR DESCRIPTION
This should remove the broken documentation links, which it does but it also labels everything under `RSpec` as private :/ This is for rspec/rspec.github.io#50...
<img width="316" alt="screen shot 2015-10-20 at 21 52 04" src="https://cloud.githubusercontent.com/assets/162976/10605106/d7e8b12e-7774-11e5-8d1c-efcc12670a44.png">
<img width="680" alt="screen shot 2015-10-20 at 21 52 10" src="https://cloud.githubusercontent.com/assets/162976/10605115/e53bf052-7774-11e5-8286-a0f72a24b6a9.png">
