### PR TITLE
Throw descriptive error when have_enqueued_job matcher is used with non test adapter

### DIFF
--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -158,6 +158,9 @@ module RSpec
       #       HelloJob.set(wait_until: Date.tomorrow.noon, queue: "low").perform_later(42)
       #     }.to have_enqueued_job.with(42).on_queue("low").at(Date.tomorrow.noon)
       def have_enqueued_job(job = nil)
+        unless ::ActiveJob::QueueAdapters::TestAdapter === ::ActiveJob::Base.queue_adapter
+          raise StandardError, "To use have_enqueued_job matcher set `ActiveJob::Base.queue_adapter = :test`"
+        end
         ActiveJob::HaveEnqueuedJob.new(job)
       end
     end

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -207,5 +207,16 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
         }.to have_enqueued_job(hello_job).with(42).on_queue("low").at(date).exactly(2).times
       }.to raise_error(message)
     end
+
+    it "throws descriptive error when no test adapter set" do
+      queue_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :inline
+
+      expect {
+        expect { heavy_lifting_job.perform_later }.to have_enqueued_job
+      }.to raise_error("To use have_enqueued_job matcher set `ActiveJob::Base.queue_adapter = :test`")
+
+      ActiveJob::Base.queue_adapter = queue_adapter
+    end
   end
 end


### PR DESCRIPTION
Otherwsie error is thrown:
```
NoMethodError:
  undefined method `enqueued_jobs' for ActiveJob::QueueAdapters::InlineAdapter:Class
```