### PR TITLE
Fixed Travis Run: Changed Gemfile to permit nokogiri 1.6.6.4 upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ if RUBY_VERSION < '1.9.2'
 elsif RUBY_VERSION < '1.9.3'
   gem 'nokogiri', '1.5.2'
 else
-  gem 'nokogiri', ['~> 1.5', '< 1.6.6.3']
+  gem 'nokogiri', ['~> 1.5', '< 1.6.6.5']
 end
 
 if RUBY_VERSION <= '1.8.7'


### PR DESCRIPTION
Fixed Travis Run: Changed Gemfile to permit nokogiri 1.6.6.4 upgrade:
 * Before (6 red builds): https://travis-ci.org/rspec/rspec-rails/builds/91909748
 * After: (0 red builds): https://travis-ci.org/jasnow/rspec-rails/builds/92564244
 
