### PR TITLE
Fix route helpers collision with asset helpers in view spec

### DIFF
--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -31,6 +31,16 @@ module RSpec
 
       # DSL exposed to view specs.
       module ExampleMethods
+        extend ActiveSupport::Concern
+
+        included do
+          include ::Rails.application.routes.url_helpers
+
+          if ::Rails.application.routes.respond_to?(:mounted_helpers)
+            include ::Rails.application.routes.mounted_helpers
+          end
+        end
+
         # @overload render
         # @overload render({:partial => path_to_file})
         # @overload render({:partial => path_to_file}, {... locals ...})

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -90,6 +90,27 @@ module RSpec::Rails
       end
     end
 
+    describe "routes helpers collides with asset helpers" do
+      let(:view_spec) do
+        Class.new do
+          include ActionView::Helpers::AssetTagHelper
+          include ViewExampleGroup::ExampleMethods
+        end.new
+      end
+
+      let(:test_routes) do
+        ActionDispatch::Routing::RouteSet.new.tap do |routes|
+          routes.draw { resources :images }
+        end
+      end
+
+      it "uses routes helpers" do
+        allow(::Rails.application).to receive(:routes).and_return(test_routes)
+        expect(view_spec.image_path(double(:to_param => "42"))).
+          to eq "/images/42"
+      end
+    end
+
     describe "#render" do
       let(:view_spec) do
         Class.new do


### PR DESCRIPTION
This fixes the problem when calling a route helper method that has the same name as an asset helper method, such as `video_path` or `image_path`. This is done by re-including `Rails.application.routes.url_helpers` in the context of view specs.

Note that the implementation to include `url_helpers` has been taken from `lib/rspec/rails/example/feature_example_group.rb`.

---

The bug I found was that when I tried to do `video_path(@video)`, I would get `"/videos/#<Video:0x007ff92ad2aa48>"` returned instead of `"/videos/42"`. This is because the [asset helper](http://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html#method-i-video_path) method was being called instead of routes helper.

By the way, I spent some time trying to write the failing unit spec instead of integration spec (using Cucumber) but couldn't get the example within the example to run. Please let me know if I should try again to rewrite it to be a unit spec, or if this is already okay.