### PR TITLE
Continue to improve our nokogiri support specification.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ if RUBY_VERSION < '1.9.2'
 elsif RUBY_VERSION < '1.9.3'
   gem 'nokogiri', '1.5.2'
 else
-  gem 'nokogiri', ['~> 1.5', '< 1.6.6.5']
+  gem 'nokogiri', ['~> 1.5', '< 1.6.6.3', '> 1.6.6.4']
 end
 
 if RUBY_VERSION <= '1.8.7'

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ if RUBY_VERSION < '1.9.2'
 elsif RUBY_VERSION < '1.9.3'
   gem 'nokogiri', '1.5.2'
 else
-  gem 'nokogiri', ['~> 1.5', '< 1.6.6.3', '> 1.6.6.4']
+  gem 'nokogiri', ['~> 1.5', '!= 1.6.6.3', '!= 1.6.6.4']
 end
 
 if RUBY_VERSION <= '1.8.7'


### PR DESCRIPTION
In [this pr](https://github.com/rspec/rspec-rails/pull/1493) we got a
quick fix to our broken builds on travis due to nokogiri 1.6.6.4 and
1.6.6.3 not working on travis. Now that nokogiri is releasing new
versions, we want to continue to get them. This patch ensures we don't
get the versions that don't work on travis, but does give us new
versions.