### PR TITLE
Warn if a fixture method is called from a `before(:context)` block.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Bug fixes:
 
 * Make it possible to write nested specs within helper specs on classes that are
   internal to helper classes. (Sam Phippen, Peter Swan, #1499).
+* Warn if a fixture method is called from a `before(:context)` block, instead of
+  crashing with a `undefined method for nil:NilClass`. (Sam Phippen, #1501)
 
 ### 3.4.0 / 2015-11-11
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.3.3...v3.4.0)

--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -14,6 +14,7 @@ module ExampleAppHooks
 
     def final_tasks
       copy_file 'spec/verify_active_record_spec.rb'
+      copy_file 'spec/verify_fixture_warning_spec.rb'
       run('bin/rake db:migrate')
       if ::Rails::VERSION::STRING.to_f < 4.1
         run('bin/rake db:migrate RAILS_ENV=test')

--- a/example_app_generator/spec/verify_fixture_warning_spec.rb
+++ b/example_app_generator/spec/verify_fixture_warning_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe "Fixture warnings" do
+  def generate_fixture_example_group(hook_type)
+    RSpec.describe do
+      include RSpec::Rails::RailsExampleGroup
+      fixtures :things
+
+      before(hook_type) do
+        things :a
+      end
+
+      it "" do
+
+      end
+    end
+  end
+
+  it "Warns when a fixture call is made in a before :context call" do
+    expect(RSpec).to receive(:warn_with).with(match(/Calling fixture method in before :context/))
+
+    generate_fixture_example_group(:context).run
+  end
+
+  it "Does not warn when a fixture call is made in a before :each call" do
+    expect(RSpec).not_to receive(:warn_with)
+
+    generate_fixture_example_group(:each).run
+  end
+
+end
+
+RSpec.describe "Global fixture warnings" do
+  def generate_fixture_example_group(hook_type)
+    RSpec.describe do
+      include RSpec::Rails::RailsExampleGroup
+
+      before(hook_type) do
+        things :a
+      end
+
+      it "" do
+
+      end
+    end
+  end
+  around do |ex|
+    RSpec.configuration.global_fixtures = [:things]
+    ex.call
+    RSpec.configuration.global_fixtures = []
+  end
+
+  it "warns when a global fixture call is made in a before :context call" do
+    expect(RSpec).to receive(:warn_with).with(match(/Calling fixture method in before :context/))
+
+    generate_fixture_example_group(:context).run
+  end
+
+  it "does not warn when a global fixture call is made in a before :each call" do
+    expect(RSpec).not_to receive(:warn_with)
+
+    generate_fixture_example_group(:each).run
+  end
+end

--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -28,6 +28,28 @@ module RSpec
             self.use_transactional_fixtures = RSpec.configuration.use_transactional_fixtures
           end
           self.use_instantiated_fixtures  = RSpec.configuration.use_instantiated_fixtures
+
+          def self.fixtures(*args)
+            orig_methods = private_instance_methods
+            super.tap do
+              new_methods = private_instance_methods - orig_methods
+              new_methods.each do |method_name|
+                proxy_method_warning_if_called_in_before_context_scope(method_name)
+              end
+            end
+          end
+
+          def self.proxy_method_warning_if_called_in_before_context_scope(method_name)
+            orig_implementation = instance_method(method_name)
+            define_method(method_name) do |*args, &blk|
+              if inspect.include?("before(:context)")
+                RSpec.warn_with("Calling fixture method in before :context ")
+              else
+                orig_implementation.bind(self).call(*args, &blk)
+              end
+            end
+          end
+
           fixtures RSpec.configuration.global_fixtures if RSpec.configuration.global_fixtures
         end
       end


### PR DESCRIPTION
Fixes #1442.

The basic approach here is to capture the addition of the fixture
methods to the example group instance and then monkeypatch them. The
monkeypatch checks to see if we're currently in a `before(:context)` hook
and if we are then it prints a warning and doesn't invoke the method.

The warning here is a little sparse at the moment, and I'd like to make
it more clear. One thing that's a little gross about this implementation
is that it uses the inspect string of the example group to determine if
we're in a `before(:context)` hook. As far as I can tell there isn't a
better way to make that determination, but maybe someone's got a clever
trick.