### PR TITLE
Do not leak TestUnit specific methods after Rails 4

### DIFF
--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -201,7 +201,7 @@ module RSpec
             select do |m|
               m.to_s =~ /^(assert|flunk|refute)/
             end
-          methods + [:build_message]
+          methods + test_unit_specific_methods
         end
 
         def define_assertion_delegators
@@ -209,6 +209,18 @@ module RSpec
             define_method(m.to_sym) do |*args, &block|
               assertion_delegator.send(m.to_sym, *args, &block)
             end
+          end
+        end
+
+        # Starting on Rails 4, Minitest is the default testing framework so no
+        # need to add TestUnit specific methods.
+        if ::Rails::VERSION::STRING >= '4.0.0'
+          def test_unit_specific_methods
+            []
+          end
+        else
+          def test_unit_specific_methods
+            [:build_message]
           end
         end
       end

--- a/spec/rspec/rails/assertion_adapter_spec.rb
+++ b/spec/rspec/rails/assertion_adapter_spec.rb
@@ -25,4 +25,16 @@ describe RSpec::Rails::MinitestAssertionAdapter do
   it "does not expose Minitest's message method" do
     expect(methods).not_to include("message")
   end
+
+  if ::Rails::VERSION::STRING >= '4.0.0'
+    # In Ruby <= 1.8.7 Object#methods returns Strings instead of Symbols. They
+    # are all converted to Symbols to ensure we always compare them correctly.
+    it 'does not leak TestUnit specific methods into the AssertionDelegator' do
+      expect(methods.map(&:to_sym)).to_not include(:build_message)
+    end
+  else
+    it 'includes methods required by TestUnit into the AssertionDelegator' do
+      expect(methods.map(&:to_sym)).to include(:build_message)
+    end
+  end
 end


### PR DESCRIPTION
TestUnit requires the build_message method to be defined for its assertions to work properly. After Rails 4, Minitest is used instead of TestUnit so the method should not be included anymore. This is problematic because when using RSpec configured with
```ruby
config.expect_with :test_unit
```
the TestUnit assertions try to call build_message on the MinitestAssertionAdapter which will crash.