### PR TITLE
Favor https: over git: protocol remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ RSpec repos as well. Add the following to your `Gemfile`:
 
 ```ruby
 %w[rspec-core rspec-expectations rspec-mocks rspec-rails rspec-support].each do |lib|
-  gem lib, :git => "git://github.com/rspec/#{lib}.git", :branch => 'master'
+  gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => 'master'
 end
 ```
 


### PR DESCRIPTION
From Bundler docs on Security:

> http:// and git:// URLs are insecure. A man-in-the-middle attacker
could tamper with the code as you check it out, and potentially supply
you with malicious code instead of the code you meant to check out.
Because the :github shortcut uses a git:// URL in Bundler 1.x versions,
we recommend using using HTTPS URLs or overriding the :github shortcut
with your own HTTPS git source.

Source: http://bundler.io/git.html