### PR TITLE
Prevent Rails 3.2.22.1 on Ruby 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,8 +104,6 @@ matrix:
     - rvm: 2.3.0
       env: RAILS_VERSION='~> 3.1.12'
   allow_failures:
-    - rvm: 1.8.7
-      env: RAILS_VERSION='~> 3.2.17'
     - rvm: 2.2.2
       env: RAILS_VERSION=master
     - rvm: 2.3.0

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -25,9 +25,15 @@ Gem::Specification.new do |s|
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  s.add_runtime_dependency %q<activesupport>, ">= 3.0"
-  s.add_runtime_dependency %q<actionpack>,    ">= 3.0"
-  s.add_runtime_dependency %q<railties>,      ">= 3.0"
+  version_string = ['>= 3.0']
+
+  if RUBY_VERSION <= '1.8.7' && ENV['RAILS_VERSION'] != '3-2-stable'
+    version_string << '!= 3.2.22.1'
+  end
+
+  s.add_runtime_dependency %q<activesupport>, version_string
+  s.add_runtime_dependency %q<actionpack>,    version_string
+  s.add_runtime_dependency %q<railties>,      version_string
   %w[core expectations mocks support].each do |name|
     if RSpec::Rails::Version::STRING =~ /[a-zA-Z]+/ # prerelease builds
       s.add_runtime_dependency "rspec-#{name}", "= #{RSpec::Rails::Version::STRING}"


### PR DESCRIPTION
Assuming this works it'll fix our builds elsewhere and improves upon @samphippen's quick travis fix :)