### PR TITLE
Allow to specify a custom automatic mapping `directory -> type`

### DIFF
--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -94,8 +94,14 @@ module RSpec
           rendering_views
         end
 
-        def infer_spec_type_from_file_location!
-          DIRECTORY_MAPPINGS.each do |type, dir_parts|
+        def infer_spec_type_from_file_location!(list = {})
+          custom = list.inject({}) do |r, (k, v)|
+            dir = v ? v.to_s : "#{ k }s"
+            r[k] = ['spec', dir]
+            r
+          end
+
+          DIRECTORY_MAPPINGS.merge(custom).each do |type, dir_parts|
             escaped_path = Regexp.compile(dir_parts.join('[\\\/]') + '[\\\/]')
             define_derived_metadata(:file_path => escaped_path) do |metadata|
               metadata[:type] ||= type

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -148,6 +148,30 @@ RSpec.describe "Configuration" do
     include_examples "infers type from location", :routing, "spec/routing"
     include_examples "infers type from location", :view, "spec/views"
     include_examples "infers type from location", :feature, "spec/features"
+
+    context "with a custom definition" do
+      context "use an array" do
+        def in_inferring_type_from_location_environment
+          in_sub_process do
+            RSpec.configuration.infer_spec_type_from_file_location!([:worker])
+            yield
+          end
+        end
+
+        include_examples "infers type from location", :worker, "spec/workers"
+      end
+
+      context "use a hash" do
+        def in_inferring_type_from_location_environment
+          in_sub_process do
+            RSpec.configuration.infer_spec_type_from_file_location!(sidekiq: :workers)
+            yield
+          end
+        end
+
+        include_examples "infers type from location", :sidekiq, "spec/workers"
+      end
+    end
   end
 
   it "fixture support is included with metadata `:use_fixtures`" do


### PR DESCRIPTION
Hi everyone!
I've faced a strange (for me) behaviour of `infer_spec_type_from_file_location!`. I supposed that it will grep the first sub folder in spec, convert into singular and set that value into type. But after didn't get it in my project and looked into the source code, I found a static set of supported type. Well, it's fine solution too, but it would be useful to extend this set. So my pool request allows to do next:

```ruby
  config.infer_spec_type_from_file_location!(sidekiq: :workers, export: :exports)
  # or a shorter version
  config.infer_spec_type_from_file_location!([:worker, :export]) # => spec/workers -> :worker, spec/exports -> :export
```