### PR TITLE
Backport: Fix empty template rendering for Rails 4.2.5.1

### DIFF
--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -104,6 +104,10 @@ file "app/views/things/custom_action.html.erb",
      "This is a template for a custom action.",
      :force => true
 
+file "app/views/errors/401.html.erb",
+     "This is a template for rendering an error page",
+     :force => true
+
 # Use the absolute path so we can load it without active record too
 apply File.join(DEFAULT_SOURCE_PATH, 'generate_action_mailer_specs.rb')
 using_source_path(File.expand_path('..', __FILE__)) do

--- a/features/controller_specs/anonymous_controller.feature
+++ b/features/controller_specs/anonymous_controller.feature
@@ -31,7 +31,7 @@ Feature: anonymous controller
   end
   ```
 
-  Scenario: Specify error handling in `ApplicationController`
+  Scenario: Specify error handling in `ApplicationController` with redirect
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -59,6 +59,76 @@ Feature: anonymous controller
           it "redirects to the /401.html page" do
             get :index
             expect(response).to redirect_to("/401.html")
+          end
+        end
+      end
+      """
+    When I run `rspec spec`
+    Then the examples should all pass
+
+  Scenario: Specify error handling in `ApplicationController` with render
+    Given a file named "spec/controllers/application_controller_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      class ApplicationController < ActionController::Base
+        class AccessDenied < StandardError; end
+
+        rescue_from AccessDenied, :with => :access_denied
+
+      private
+
+        def access_denied
+          render "errors/401"
+        end
+      end
+
+      RSpec.describe ApplicationController, :type => :controller do
+        controller do
+          def index
+            raise ApplicationController::AccessDenied
+          end
+        end
+
+        describe "handling AccessDenied exceptions" do
+          it "renders the errors/401 template" do
+            get :index
+            expect(response).to render_template("errors/401")
+          end
+        end
+      end
+      """
+    When I run `rspec spec`
+    Then the examples should all pass
+
+  Scenario: Specify error handling in `ApplicationController` with render :file
+    Given a file named "spec/controllers/application_controller_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      class ApplicationController < ActionController::Base
+        class AccessDenied < StandardError; end
+
+        rescue_from AccessDenied, :with => :access_denied
+
+      private
+
+        def access_denied
+          render :file => "errors/401"
+        end
+      end
+
+      RSpec.describe ApplicationController, :type => :controller do
+        controller do
+          def index
+            raise ApplicationController::AccessDenied
+          end
+        end
+
+        describe "handling AccessDenied exceptions" do
+          it "renders the errors/401 template" do
+            get :index
+            expect(response).to render_template("errors/401")
           end
         end
       end

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -36,15 +36,11 @@ module RSpec
       # with modified source
       #
       # @private
-      class EmptyTemplatePathSetDecorator < ::ActionView::Resolver
-        attr_reader :original_path_set
+      class EmptyTemplateResolver < ::ActionView::FileSystemResolver
+      private
 
-        def initialize(original_path_set)
-          @original_path_set = original_path_set
-        end
-
-        def find_all(*args)
-          original_path_set.find_all(*args).map do |template|
+        def find_templates(*args)
+          super.map do |template|
             ::ActionView::Template.new(
               "",
               template.identifier,
@@ -78,23 +74,26 @@ module RSpec
       private
 
         def _path_decorator(path)
-          EmptyTemplatePathSetDecorator.new(ActionView::PathSet.new(Array.wrap(path)))
+          EmptyTemplateResolver.new(path)
         end
       end
 
       included do
         before do
           unless render_views?
-            @_empty_view_path_set_delegator = EmptyTemplatePathSetDecorator.new(controller.class.view_paths)
-            controller.class.view_paths = ::ActionView::PathSet.new.push(@_empty_view_path_set_delegator)
+            @_original_path_set = controller.class.view_paths
+
+            empty_template_path_set = @_original_path_set.map do |resolver|
+              EmptyTemplateResolver.new(resolver.to_s)
+            end
+
+            controller.class.view_paths = empty_template_path_set
             controller.extend(EmptyTemplates)
           end
         end
 
         after do
-          unless render_views?
-            controller.class.view_paths = @_empty_view_path_set_delegator.original_path_set
-          end
+          controller.class.view_paths = @_original_path_set unless render_views?
         end
       end
     end


### PR DESCRIPTION
Backport from https://github.com/rspec/rspec-rails/pull/1535

Refactor the template rendering overrides in controller specs to be more
compatible with the Action View public api. Previously `EmptyTemplatePathSetDecorator`
overrode the `find_all` method to wrap a path set. However `ActionView::PathSet`
is not public api so instead create a subclass of `ActionView::FileSystemResolver`
to return an empty template and treat `view_paths` as an array of string-like objects.