### PR TITLE
Add negated template examples

### DIFF
--- a/example_app_generator/travis_retry_bundle_install.sh
+++ b/example_app_generator/travis_retry_bundle_install.sh
@@ -4,4 +4,8 @@ set -e
 source FUNCTIONS_SCRIPT_FILE
 
 echo "Starting bundle install using shared bundle path"
-travis_retry eval "bundle install --gemfile ./Gemfile --path REPLACE_BUNDLE_PATH --retry=3 --jobs=3"
+if is_mri_192_plus; then
+  travis_retry eval "RUBYOPT=$RUBYOPT:'--enable rubygems' bundle install --gemfile ./Gemfile --path REPLACE_BUNDLE_PATH --retry=3 --jobs=3"
+else
+  travis_retry eval "bundle install --gemfile ./Gemfile --path REPLACE_BUNDLE_PATH --retry=3 --jobs=3"
+fi

--- a/features/matchers/render_template_matcher.feature
+++ b/features/matchers/render_template_matcher.feature
@@ -23,6 +23,10 @@ Feature: render_template matcher
             expect(subject).to render_template("index")
             expect(subject).to render_template("gadgets/index")
           end
+
+          it "does not render a different template" do
+            expect(subject).to_not render_template("gadgets/show")
+          end
         end
       end
       """
@@ -42,6 +46,10 @@ Feature: render_template matcher
           expect(view).to render_template(:index)
           expect(view).to render_template("index")
           expect(view).to render_template("gadgets/index")
+        end
+
+        it "does not render a different template" do
+          expect(view).to_not render_template("gadgets/show")
         end
       end
       """

--- a/features/request_specs/request_spec.feature
+++ b/features/request_specs/request_spec.feature
@@ -46,6 +46,10 @@ Feature: request spec
           expect(response.body).to include("Widget was successfully created.")
         end
 
+        it "does not render a different template" do
+          get "/widgets/new"
+          expect(response).to_not render_template(:show)
+        end
       end
       """
     When I run `rspec spec/requests/widget_management_spec.rb`


### PR DESCRIPTION
This adds examples for negating `render_template` matchers to assertain what's going on for #1539