### PR TITLE
Fixing index view tests for a scaffold with multiple float attributes

### DIFF
--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -92,6 +92,7 @@ generate('helper things')
 generate('scaffold widget name:string category:string instock:boolean foo_id:integer bar_id:integer --force')
 generate('observer widget') if ::Rails::VERSION::STRING.to_f < 4.0
 generate('scaffold gadget') # scaffold with no attributes
+generate('scaffold ticket original_price:float discounted_price:float')
 generate('scaffold admin/account name:string') # scaffold with nested resource
 generate('rspec:feature gadget')
 generate('controller things custom_action')

--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -150,9 +150,9 @@ module Rspec
         case attribute.type
         when :string
           attribute.name.titleize
-        when :integer
+        when :integer, :float
           @attribute_id_map ||= {}
-          @attribute_id_map[attribute] ||= @attribute_id_map.keys.size.next
+          @attribute_id_map[attribute] ||= @attribute_id_map.keys.size.next + attribute.default
         else
           attribute.default
         end

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -63,6 +63,22 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
       end
     end
 
+    describe 'with multiple integer attributes index' do
+      before { run_generator %w(posts upvotes:integer downvotes:integer) }
+      subject { file("spec/views/posts/index.html.erb_spec.rb") }
+      it { is_expected.to exist }
+      it { is_expected.to contain('assert_select "tr>td", :text => 2.to_s, :count => 2') }
+      it { is_expected.to contain('assert_select "tr>td", :text => 3.to_s, :count => 2') }
+    end
+
+    describe 'with multiple float attributes index' do
+      before { run_generator %w(posts upvotes:float downvotes:float) }
+      subject { file("spec/views/posts/index.html.erb_spec.rb") }
+      it { is_expected.to exist }
+      it { is_expected.to contain('assert_select "tr>td", :text => 2.5.to_s, :count => 2') }
+      it { is_expected.to contain('assert_select "tr>td", :text => 3.5.to_s, :count => 2') }
+    end
+
     if Rails.version.to_f >= 4.0
       describe 'with reference attribute' do
         before { run_generator %w(posts title:string author:references) }


### PR DESCRIPTION
If a model has multiple float attributes, the auto generated tests are failing because of duplicate value(All attributes have the default value and tests check that the count is equal to 2). This fixes it. The issue still exists for double attributes but I'd like to know what you think about this before I do any further work.