### PR TITLE
Check if path is a Resolver before decorating it

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -39,8 +39,8 @@ module RSpec
         self.class.render_views? || !controller.class.respond_to?(:view_paths)
       end
 
-      # Delegates find_all to the submitted path set and then returns templates
-      # with modified source
+      # Delegates find_templates to the submitted path set and then returns
+      # templates with modified source
       #
       # @private
       class EmptyTemplateResolver < ::ActionView::FileSystemResolver
@@ -81,7 +81,12 @@ module RSpec
       private
 
         def _path_decorator(path)
-          EmptyTemplateResolver.new(path)
+          case path
+          when Pathname, String
+            EmptyTemplateResolver.new(path.to_s)
+          else
+            path
+          end
         end
       end
 


### PR DESCRIPTION
When you prepend or append view paths, you can choose to do so with either a path (which may be looked up on the file system) or an instance of `ActionView::Resolver` which will then know how to do the lookup. We should not wrap `ActionView::Resolver` instances in an `EmptyTemplateResolver`.

I’m not sure where/whether to add a spec.

cc @pixeltrix (related to #1535)