### PR TITLE
Add readme for mailer specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,36 @@ gem "capybara"
 For more information, see the [cucumber scenarios for feature
 specs](https://www.relishapp.com/rspec/rspec-rails/v/3-4/docs/feature-specs/feature-spec).
 
+## Mailer specs
+
+By default Mailer specs reside in the `spec/mailers` folder. Adding the metadata
+`:type => :mailer` to any context makes its examples be treated as mailer specs.
+
+`ActionMailer::TestCase::Behavior` is mixed into your mailer specs.
+
+```ruby
+require "rails_helper"
+
+RSpec.describe Notifications, :type => :mailer do
+  describe "notify" do
+    let(:mail) { Notifications.signup }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Signup")
+      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Hi")
+    end
+  end
+end
+```
+
+For more information, see the [cucumber scenarios for mailer specs
+](https://relishapp.com/rspec/rspec-rails/v/3-4/docs/mailer-specs).
+
 ## View specs
 
 View specs default to residing in the `spec/views` folder. Tagging any context

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ gem "capybara"
 ```
 
 For more information, see the [cucumber scenarios for feature
-specs](https://www.relishapp.com/rspec/rspec-rails/v/3-0/docs/feature-specs/feature-spec).
+specs](https://www.relishapp.com/rspec/rspec-rails/v/3-4/docs/feature-specs/feature-spec).
 
 ## View specs
 

--- a/features/mailer_specs/README.md
+++ b/features/mailer_specs/README.md
@@ -1,0 +1,26 @@
+By default Mailer specs reside in the `spec/mailers` folder. Adding the metadata
+`:type => :mailer` to any context makes its examples be treated as mailer specs.
+
+A mailer spec is a thin wrapper for an ActionMailer::TestCase, and includes all
+of the behavior and assertions that it provides, in addition to RSpec's own
+behavior and expectations.
+
+## Examples
+
+    require "rails_helper"
+
+    RSpec.describe Notifications, :type => :mailer do
+      describe "notify" do
+        let(:mail) { Notifications.signup }
+
+        it "renders the headers" do
+          expect(mail.subject).to eq("Signup")
+          expect(mail.to).to eq(["to@example.org"])
+          expect(mail.from).to eq(["from@example.com"])
+        end
+
+        it "renders the body" do
+          expect(mail.body.encoded).to match("Hi")
+        end
+      end
+    end

--- a/features/mailer_specs/mailer_spec.feature
+++ b/features/mailer_specs/mailer_spec.feature
@@ -1,0 +1,53 @@
+Feature: mailer spec
+
+  @rails_post_5
+  Scenario: simple passing example
+    Given a file named "spec/mailers/notifications_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe NotificationsMailer, :type => :mailer do
+        describe "notify" do
+          let(:mail) { NotificationsMailer.signup }
+
+          it "renders the headers" do
+            expect(mail.subject).to eq("Signup")
+            expect(mail.to).to eq(["to@example.org"])
+            expect(mail.from).to eq(["from@example.com"])
+          end
+
+          it "renders the body" do
+            expect(mail.body.encoded).to match("Hi")
+          end
+        end
+      end
+      """
+    When I run `rspec spec`
+    Then the example should pass
+
+  @rails_pre_5
+  Scenario: using URL helpers without default options
+    Given a file named "config/initializers/mailer_defaults.rb" with:
+      """ruby
+      # no default options
+      """
+    And a file named "spec/mailers/notifications_spec.rb" with:
+      """ruby
+      require 'rails_helper'
+
+      RSpec.describe Notifications, :type => :mailer do
+        let(:mail) { Notifications.signup }
+
+        it "renders the headers" do
+          expect(mail.subject).to eq("Signup")
+          expect(mail.to).to eq(["to@example.org"])
+          expect(mail.from).to eq(["from@example.com"])
+        end
+
+        it 'renders the body' do
+          expect(mail.body.encoded).to match("Hi")
+        end
+      end
+      """
+    When I run `rspec spec`
+    Then the examples should all pass


### PR DESCRIPTION
Fleshes out our documentation for mailer specs a little bit. Fixes #1552