### PR TITLE
Ensure rspec core is loaded if rspec-rails is.

### DIFF
--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -1,3 +1,4 @@
+require 'rspec/core'
 require 'rspec/rails/feature_check'
 
 # Namespace for all core RSpec projects.


### PR DESCRIPTION
I don't think loading rspec/rails here is necessarily right, since Rails
might not be required yet and I don't think we should be the ones to
force that. Could be wrong here, but only loading rspec is more
conservative so choosing that for now.

Loading rspec seems important though, so that various version checks
work correctly.

See https://github.com/tpope/fivemat/issues/29 for motivation.