### PR TITLE
Rework integration of rails-controller-testing

### DIFF
--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -20,7 +20,7 @@ in_root do
   gsub_file "Gemfile", /.*debugger.*/, ''
 
   if Rails::VERSION::STRING >= '5.0.0'
-    append_to_file('Gemfile', "gem 'rails-controller-testing', :git => 'https://github.com/rails/rails-controller-testing'\n")
+    append_to_file('Gemfile', "gem 'rails-controller-testing', :git => 'https://github.com/rails/rails-controller-testing', require: false\n")
   end
 
   # Nokogiri version is pinned in rspec-rails' Gemfile since it tend to cause installation problems

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -49,6 +49,25 @@ module RSpec
       config.include RSpec::Rails::FeatureExampleGroup,    :type => :feature
     end
 
+    # rubocop:disable HandleExceptions
+    # Tries to load and include rails-controller-testing
+    #
+    # @api private
+    def self.add_rails_controller_testing(config)
+      require 'rails/controller/testing/test_process'
+      require 'rails/controller/testing/template_assertions'
+      require 'rails/controller/testing/integration'
+
+      [:controller, :view, :request].each do |type|
+        config.include ::Rails::Controller::Testing::TestProcess, :type => type
+        config.include ::Rails::Controller::Testing::TemplateAssertions, :type => type
+        config.include ::Rails::Controller::Testing::Integration, :type => type
+      end
+    rescue LoadError
+      # rails-controller-testing is not included
+    end
+    # rubocop:enable HandleExceptions
+
     # @private
     def self.initialize_configuration(config)
       config.backtrace_exclusion_patterns << /vendor\//
@@ -112,14 +131,7 @@ module RSpec
       end
 
       add_test_type_configurations(config)
-
-      if defined?(::Rails::Controller::Testing)
-        [:controller, :view, :request].each do |type|
-          config.include ::Rails::Controller::Testing::TestProcess, :type => type
-          config.include ::Rails::Controller::Testing::TemplateAssertions, :type => type
-          config.include ::Rails::Controller::Testing::Integration, :type => type
-        end
-      end
+      add_rails_controller_testing(config)
 
       if defined?(ActionMailer)
         config.include RSpec::Rails::MailerExampleGroup, :type => :mailer


### PR DESCRIPTION
/cc @samphippen

# Problem

When adding `rails-controller-testing` to your Gemfile, you're actually loading a bit more than you wish. In our case we ended up with some helpers missing from our view specs for instance.
I assume that all the various unnecessary includes performed in [rails-controller-testing.rb](https://github.com/rails/rails-controller-testing/blob/master/lib/rails-controller-testing.rb) are to blame.

# Solution

The only interesting bit about rails-controller-testing is actually these requires

```ruby
require 'rails/controller/testing/test_process'
require 'rails/controller/testing/integration'
require 'rails/controller/testing/template_assertions'
```

So I would recommend to use

```ruby
gem 'rails-controller-testing`, require: false
```

Now I changed the code here so instead of using `defined?(::Rails::Controller::Testing)` and assume that the gem was loaded before, I'm using a rescue block to catch `LoadError`. If the gem isn't present, the block will silently failed, otherwise it will perform the proper inclusion required by RSpec.

# Follow-up

I started my work here but I think something should be changed in rails-controller-testing so that an automatic load of the gem doesn't assume that everybody's using minitest...