### PR TITLE
let request specs use integration test services

### DIFF
--- a/lib/rspec/rails/example/request_example_group.rb
+++ b/lib/rspec/rails/example/request_example_group.rb
@@ -11,6 +11,12 @@ module RSpec
       include RSpec::Rails::Matchers::RenderTemplate
       include ActionController::TemplateAssertions
 
+      begin
+        include ActionDispatch::IntegrationTest::Behavior
+      rescue NameError # rubocop:disable Lint/HandleExceptions
+        # rails is too old to provide integration test helpers
+      end
+
       # Delegates to `Rails.application`.
       def app
         ::Rails.application


### PR DESCRIPTION
Rails integration tests have some services like assert_select.
This pull request makes them available in request specs.

This is already the case for controller specs: https://github.com/rspec/rspec-rails/blob/4a2a078632990/lib/rspec/rails/example/controller_example_group.rb#L13

This came up while converting controller specs to request specs as suggested by the Rails 5 release notes.  (I have an API-only app so capybara is out)

This will be a no-op until Rails merges https://github.com/rails/rails/pull/23880