### PR TITLE
Move #738 regression check to spec

### DIFF
--- a/features/controller_specs/controller_spec.feature
+++ b/features/controller_specs/controller_spec.feature
@@ -34,29 +34,6 @@ Feature: controller spec
     When I run `rspec spec`
     Then the example should pass
 
-  Scenario: controller is extended with a helper module
-    Given a file named "spec/controllers/widgets_controller_spec.rb" with:
-      """ruby
-      require "rails_helper"
-
-      module MyHelper
-        def my_variable
-        end
-      end
-
-      RSpec.configure {|c| c.include MyHelper }
-
-      RSpec.describe WidgetsController, :type => :controller do
-        let(:my_variable) { 'is a value' }
-
-        describe 'something' do
-          specify { expect(my_variable).to eq 'is a value' }
-        end
-      end
-      """
-    When I run `rspec spec`
-    Then the example should pass
-
   Scenario: setting a different content type for example json (request type)
     Given a file named "spec/controllers/widgets_controller_spec.rb" with:
       """ruby

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -28,6 +28,24 @@ module RSpec::Rails
         allow(example).to receive_messages(:controller => controller)
         expect(example.subject).to eq(controller)
       end
+
+      it "doesn't cause let definition priority to be changed" do
+        # before #738 implicit subject definition for controllers caused
+        # external methods to take precedence over our let definitions
+
+        with_isolated_config do |config|
+          mod = Module.new do
+            def my_helper
+              "other_value"
+            end
+          end
+          config.include mod
+          group.class_exec do
+            let(:my_helper) { "my_value" }
+          end
+          expect(group.new.my_helper).to eq "my_value"
+        end
+      end
     end
 
     context "with explicit subject" do


### PR DESCRIPTION
This is confusing and not useful as documentation, all #738 was intended
to do was to prevent our let definitions from being defined earlier than
3rd party inclusions (and hence being overridden) which was confusing
behaviour, so move it to a spec.

/cc @samphippen @myronmarston 