### PR TITLE
Allow to use have_enqueued_job matcher without passing block.

### DIFF
--- a/features/matchers/have_enqueued_job_matcher.feature
+++ b/features/matchers/have_enqueued_job_matcher.feature
@@ -72,3 +72,19 @@ Feature: have_enqueued_job matcher
       """
     When I run `rspec spec/jobs/upload_backups_job_spec.rb`
     Then the examples should all pass
+
+  Scenario: Checking job using syntax without a block
+    Given a file named "spec/jobs/upload_backups_job_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe UploadBackupsJob do
+        it "matches with enqueued job" do
+          ActiveJob::Base.queue_adapter = :test
+          UploadBackupsJob.perform_later
+          expect("fake").to have_enqueued_job.on_queue("default")
+        end
+      end
+      """
+    When I run `rspec spec/jobs/upload_backups_job_spec.rb`
+    Then the examples should all pass

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -55,12 +55,6 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
   end
 
   describe "have_enqueued_job" do
-    it "raises ArgumentError when no Proc passed to expect" do
-      expect {
-        expect(heavy_lifting_job.perform_later).to have_enqueued_job
-      }.to raise_error(ArgumentError)
-    end
-
     it "passess with default one number" do
       expect {
         heavy_lifting_job.perform_later
@@ -217,6 +211,11 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to raise_error("To use have_enqueued_job matcher set `ActiveJob::Base.queue_adapter = :test`")
 
       ActiveJob::Base.queue_adapter = queue_adapter
+    end
+
+    it "passes when used without block" do
+      hello_job.perform_later(:user_id => 2)
+      expect("fake-argument").to have_enqueued_job(hello_job).with(:user_id => 2).exactly(:once)
     end
   end
 end


### PR DESCRIPTION
It allows to test on job arguments that are dynamically created inside called block.

Example:

```ruby
class CreateUser
  def self.call
    user = User.create!
    DeliverWelcomeEmailJob.perform_later(user)
    user
  end
end

user = CreateUser.call
expect().to have_enqueued_job(DeliverWelcomeEmailJob).with(user)
```

This is not fully working yet, as rspec doesn't allow to call `expect()` without passing block or any argument:
```
     ArgumentError:
       You must pass either an argument or a block to `expect`.
```

Do you have an idea how can I bypass this check?