### PR TITLE
Delegate properly to custom Resolver instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,3 +114,4 @@ branches:
   only:
     - master
     - /^\d+-\d+-maintenance$/
+    - fix_empty_view_rendering

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -32,6 +32,8 @@ in_root do
     |# Rack::Cache 1.3.0 requires Ruby >= 2.0.0
     |gem 'rack-cache', '< 1.3.0' if RUBY_VERSION < '2.0.0'
     |
+    |gem 'rake', '~> 10.0', '< 11'
+    |
     |gem 'rspec-rails',
     |    :path => '#{rspec_rails_repo_path}',
     |    :groups => [:development, :test]

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -40,16 +40,12 @@ module RSpec
       end
 
       # @private
-      class EmptyTemplateResolverFactory
-        def initialize(path)
-          @path = path
-        end
-
-        def resolver
-          if @path.is_a?(::ActionView::Resolver)
-            EmptyTemplateResolverDecorator.new(@path)
+      class EmptyTemplateResolver
+        def self.build(path)
+          if path.is_a?(::ActionView::Resolver)
+            EmptyTemplateResolverDecorator.new(path)
           else
-            EmptyTemplateFileSystemResolver.new(@path)
+            EmptyTemplateFileSystemResolver.new(path)
           end
         end
       end
@@ -125,13 +121,13 @@ module RSpec
       private
 
         def _path_decorator(*paths)
-          paths.map { |path| EmptyTemplateResolverFactory.new(path).resolver }
+          paths.map { |path| EmptyTemplateResolver.build(path) }
         end
       end
 
       # @private
       RESOLVER_CACHE = Hash.new do |hash, path|
-        hash[path] = EmptyTemplateResolverFactory.new(path).resolver
+        hash[path] = EmptyTemplateResolver.build(path)
       end
 
       included do

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -39,6 +39,7 @@ module RSpec
         self.class.render_views? || !controller.class.respond_to?(:view_paths)
       end
 
+      # @private
       class EmptyTemplateResolverFactory
         def initialize(path)
           @path = path
@@ -53,6 +54,10 @@ module RSpec
         end
       end
 
+      # Delegates find_templates to the submitted resolver and then returns templates
+      # with modified source
+      #
+      # @private
       class EmptyTemplateResolverDecorator
         def initialize(resolver)
           @resolver = resolver
@@ -78,8 +83,8 @@ module RSpec
         end
       end
 
-      # Delegates find_all to the submitted path set and then returns templates
-      # with modified source
+      # Delegates find_templates to the submitted path set and then returns
+      # templates with modified source
       #
       # @private
       class EmptyTemplateFileSystemResolver < ::ActionView::FileSystemResolver

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
     end
   end
 
-  s.add_development_dependency 'rake',     '~> 10.0'
+  s.add_development_dependency 'rake',     '~> 10.0', '< 11'
   s.add_development_dependency 'cucumber', '~> 1.3.5'
   s.add_development_dependency 'aruba',    '~> 0.5.4'
   s.add_development_dependency 'ammeter',  '1.1.2'


### PR DESCRIPTION
Let `EmptyTemplateResolver` creating instances of either `EmptyTemplateResolver::ResolverDecorator` or `EmptyTemplateResolver::FileSystemResolver`, depending on whether the given path is an `ActionView::Resolver` instance or not.

The new `EmptyTemplateResolver::ResolverDecorator` class simply delegates all method calls to its given resolver, except for `#find_templates` which it overrides to return templates that render with `EmptyTemplateHandler`.

Please note that the merge target is PR #1557, not master.