### PR TITLE
Don't use Rake v11 with older rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,12 @@ end
 
 gem 'sqlite3', '~> 1.3.6'
 
+if RUBY_VERSION >= '1.9.3'
+  gem 'rake', '>= 10.0.0'
+else
+  gem 'rake', '~> 10.0' # rake 11 requires Ruby 1.9.3 or later
+end
+
 # Capybara versions that support RSpec 3 only support RUBY_VERSION >= 1.9.3
 if RUBY_VERSION >= '1.9.3'
   gem 'capybara', '~> 2.2.0', :require => false

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -32,6 +32,12 @@ in_root do
     |# Rack::Cache 1.3.0 requires Ruby >= 2.0.0
     |gem 'rack-cache', '< 1.3.0' if RUBY_VERSION < '2.0.0'
     |
+    |if RUBY_VERSION >= '1.9.3'
+    |  gem 'rake', '>= 10.0.0'
+    |else
+    |  gem 'rake', '~> 10.0' # rake 11 requires Ruby 1.9.3 or later
+    |end
+    |
     |gem 'rspec-rails',
     |    :path => '#{rspec_rails_repo_path}',
     |    :groups => [:development, :test]

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |s|
     end
   end
 
-  s.add_development_dependency 'rake',     '~> 10.0'
   s.add_development_dependency 'cucumber', '~> 1.3.5'
   s.add_development_dependency 'aruba',    '~> 0.5.4'
   s.add_development_dependency 'ammeter',  '1.1.2'


### PR DESCRIPTION
It doesn't work with Ruby 1.8.7 and 1.9.2.

The latest master build has 8 jobs failing because of the new release of Rake. And it’s hard to work on pull requests when you can’t get a green build :-)