### PR TITLE
Fix autoload error

### DIFF
--- a/example_app_generator/generate_action_mailer_specs.rb
+++ b/example_app_generator/generate_action_mailer_specs.rb
@@ -25,7 +25,7 @@ using_source_path(File.expand_path('..', __FILE__)) do
       end
     end
 
-    if defined?(ActionMailer)
+    if defined?(ActionMailer) && Rails::VERSION::MAJOR < 4
       # This will force the loading of ActionMailer settings
       ActionMailer::Base.smtp_settings
     end

--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -32,7 +32,7 @@ require_file_stub 'config/environment' do
     module ExampleApp
       class Application < Rails::Application
         config.eager_load = false
-        config.eager_load_paths.clear
+        config.eager_load_paths.clear if Rails::VERSION::MAJOR < 4
 
         # Don't care if the mailer can't send.
         config.action_mailer.raise_delivery_errors = false unless ENV['NO_ACTION_MAILER']


### PR DESCRIPTION
The specs are currently failing for using Rails 5.0.0.beta2. It looks like the changes from #1388 has something to do with it. I won’t claim to understand all (or anything) of that pull request, but by changing a few pieces, I got the spec suite running and not have only 1 failing spec locally. Let’s see what Travis says.

cc/ @cupakromer