### PR TITLE
Bring RSpec current with rails 5 beta 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,11 +58,11 @@ matrix:
     - rvm: 2.2.2
       env: RAILS_VERSION=master
     - rvm: 2.2.2
-      env: RAILS_VERSION=5.0.0.beta2
+      env: RAILS_VERSION=5.0.0.beta3
     - rvm: 2.3.0
       env: RAILS_VERSION=master
     - rvm: 2.3.0
-      env: RAILS_VERSION=5.0.0.beta2
+      env: RAILS_VERSION=5.0.0.beta3
   exclude:
     # 3.0.x is not supported on MRI 2.0+
     - rvm: 2.0.0

--- a/example_app_generator/generate_action_mailer_specs.rb
+++ b/example_app_generator/generate_action_mailer_specs.rb
@@ -13,6 +13,7 @@ using_source_path(File.expand_path('..', __FILE__)) do
   comment_lines 'config/environments/test.rb', /action_mailer/
 
   initializer 'action_mailer.rb', <<-CODE
+  require "action_view/base"
     if ENV['DEFAULT_URL']
       if ::Rails::VERSION::STRING < '4.1'
         ExampleApp::Application.configure do

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -13,6 +13,8 @@ travis_retry_script = File.join(
 function_script_file = File.join(rspec_rails_repo_path, 'script/functions.sh')
 
 in_root do
+  prepend_to_file "Rakefile", "require 'active_support/all'"
+
   # Remove the existing rails version so we can properly use master or other
   # edge branches
   gsub_file 'Gemfile', /^.*\bgem 'rails.*$/, ''

--- a/lib/generators/rspec/mailer/templates/preview.rb
+++ b/lib/generators/rspec/mailer/templates/preview.rb
@@ -5,7 +5,7 @@ class <%= class_name %>Preview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/<%= file_path %>/<%= action %>
   def <%= action %>
-    <%= class_name %>.<%= action %>
+    <%= class_name %><%= Rails.version.to_f >= 5.0 ? "Mailer" : "" %>.<%= action %>
   end
 <% end -%>
 


### PR DESCRIPTION
Biggest issue here is a regression introduced in the rails controller
testing gem which forces us to do a require of
`action_controller/metal/rendering` in order to not give a NameError
when booting our test app.