### PR TITLE
Delegate properly to custom Resolver instances

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,11 @@ else
   gem 'rake', '~> 10.0' # rake 11 requires Ruby 1.9.3 or later
 end
 
+# Version 3 of mime-types 3 requires Ruby 2.0
+if RUBY_VERSION < '2.0.0'
+  gem 'mime-types', '< 3'
+end
+
 # Capybara versions that support RSpec 3 only support RUBY_VERSION >= 1.9.3
 if RUBY_VERSION >= '1.9.3'
   gem 'capybara', '~> 2.2.0', :require => false

--- a/example_app_generator/app/views/foo.html
+++ b/example_app_generator/app/views/foo.html
@@ -1,0 +1,1 @@
+Static template named 'foo.html'

--- a/example_app_generator/app/views/some_templates/bar.html
+++ b/example_app_generator/app/views/some_templates/bar.html
@@ -1,0 +1,1 @@
+Static template named 'bar.html'

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -38,6 +38,11 @@ in_root do
     |  gem 'rake', '~> 10.0' # rake 11 requires Ruby 1.9.3 or later
     |end
     |
+    |# Version 3 of mime-types 3 requires Ruby 2.0
+    |if RUBY_VERSION < '2.0.0'
+    |  gem 'mime-types', '< 3'
+    |end
+    |
     |gem 'rspec-rails',
     |    :path => '#{rspec_rails_repo_path}',
     |    :groups => [:development, :test]

--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -14,6 +14,9 @@ module ExampleAppHooks
 
     def final_tasks
       copy_file 'spec/verify_active_record_spec.rb'
+      copy_file 'app/views/foo.html'
+      copy_file 'app/views/some_templates/bar.html'
+      copy_file 'spec/verify_custom_renderers_spec.rb'
       copy_file 'spec/verify_fixture_warning_spec.rb'
       run('bin/rake db:migrate')
       if ::Rails::VERSION::STRING.to_f < 4.1

--- a/example_app_generator/spec/verify_custom_renderers_spec.rb
+++ b/example_app_generator/spec/verify_custom_renderers_spec.rb
@@ -1,0 +1,159 @@
+require 'rails_helper'
+
+RSpec.describe "template rendering", :type => :controller do
+  context "without render_views" do
+    context "with the standard renderers" do
+      controller do
+        def index
+          render :template => 'foo', :layout => false
+        end
+      end
+
+      it "renders the 'foo' template" do
+        get :index
+
+        expect(response).to render_template(:foo)
+      end
+
+      it "renders an empty string" do
+        get :index
+
+        expect(response.body).to eq("")
+      end
+    end
+
+    context "with a String path prepended to the view path" do
+      controller do
+        def index
+          prepend_view_path('app/views/some_templates')
+
+          render :template => 'bar', :layout => false
+        end
+      end
+
+      it "renders the 'bar' template" do
+        get :index
+
+        expect(response).to render_template(:bar)
+      end
+
+      it "renders an empty string" do
+        get :index
+
+        expect(response.body).to eq("")
+      end
+    end
+
+    context "with a custom renderer prepended to the view path" do
+      controller do
+        def index
+          prepend_view_path(MyResolver.new)
+
+          render :template => 'baz', :layout => false
+        end
+      end
+
+      it "renders the 'baz' template" do
+        get :index
+
+        expect(response).to render_template(:baz)
+      end
+
+      it "renders an empty string" do
+        get :index
+
+        expect(response.body).to eq("")
+      end
+    end
+  end
+
+  context "with render_views enabled" do
+    render_views
+
+    context "with the standard renderers" do
+      controller do
+        def index
+          render :template => 'foo', :layout => false
+        end
+      end
+
+      it "renders the 'foo' template" do
+        get :index
+
+        expect(response).to render_template(:foo)
+      end
+
+      it "renders the contents of the template" do
+        get :index
+
+        expect(response.body).to include("Static template named 'foo.html'")
+      end
+    end
+
+    context "with a String path prepended to the view path" do
+      controller do
+        def index
+          prepend_view_path('app/views/some_templates')
+
+          render :template => 'bar', :layout => false
+        end
+      end
+
+      it "renders the 'bar' template" do
+        get :index
+
+        expect(response).to render_template(:bar)
+      end
+
+      it "renders the contents of the template" do
+        get :index
+
+        expect(response.body).to include("Static template named 'bar.html'")
+      end
+    end
+
+    context "with a custom renderer prepended to the view path" do
+      controller do
+        def index
+          prepend_view_path(MyResolver.new)
+
+          render :template => 'baz', :layout => false
+        end
+      end
+
+      it "renders the 'baz' template" do
+        get :index
+
+        expect(response).to render_template(:baz)
+      end
+
+      it "renders the contents of the template" do
+        get :index
+
+        expect(response.body).to eq("Dynamic template with path '/baz'")
+      end
+    end
+  end
+
+  class MyResolver < ActionView::Resolver
+  private
+
+    def find_templates(name, prefix = nil, partial = false, details = {}, key = nil, locals = [])
+      name.prepend("_") if partial
+      path = [prefix, name].join("/")
+      template = find_template(name, path)
+
+      [template]
+    end
+
+    def find_template(name, path)
+      ActionView::Template.new(
+        "",
+        name,
+        lambda { |_template| %("Dynamic template with path '#{_template.virtual_path}'") },
+        :virtual_path => path,
+        :format => :html
+      )
+    end
+  end
+end

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -139,6 +139,13 @@ module RSpec::Rails
         expect(controller.view_paths.map(&:to_s)).to match_paths 'app/views', 'app/legacy_views', 'app/others', 'app/more_views'
       end
 
+      it 'supports manipulating view paths with resolvers' do
+        expect {
+          controller.prepend_view_path ActionView::Resolver.new
+          controller.append_view_path ActionView::Resolver.new
+        }.to_not raise_error
+      end
+
       def match_paths(*paths)
         eq paths.map { |path| File.expand_path path }
       end


### PR DESCRIPTION
Let `EmptyTemplateResolver` create instances of either `EmptyTemplateResolver::ResolverDecorator` or `EmptyTemplateResolver::FileSystemResolver`, depending on whether the given path argument is an `ActionView::Resolver` instance or not.

The new `EmptyTemplateResolver::ResolverDecorator` class simply delegates all method calls to its given resolver, except for `#find_all` and `#find_all_anywhere` which it overrides to return templates that render with `EmptyTemplateHandler`.

Supersedes #1568 and hopefully also #1557.