### PR TITLE
Change ammeter dependency to use ammeter v1.1.3

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'cucumber', '~> 1.3.5'
   s.add_development_dependency 'aruba',    '~> 0.5.4'
-  s.add_development_dependency 'ammeter',  '1.1.2'
+  s.add_development_dependency 'ammeter',  '~> 1.1.2'
 end


### PR DESCRIPTION
Hi,
I am developing for Fedora rpm package.
I want to use ammeter v1.1.3 (latest version) as a development dependency of this module rspec-rails, as the ammeter is specified as v1.1.2 by gemspec file.

rspec test was passed for the latest version.
Could you merge my modification for that?

$ vi rspec-rails.gemspec
$ bundle update
$ rake spec
...
615 examples, 0 failures, 1 pending

Best,
Jun Aruga