### PR TITLE
Fix #1600: Update gemspec to handle dependencies that only exist in beta state

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -31,14 +31,23 @@ Gem::Specification.new do |s|
     version_string << '!= 3.2.22.1'
   end
 
+  # Remove 'pre' designation from version tag.
+  rspec_rails_version = RSpec::Rails::Version::STRING \
+    .split('.')[0..1] \
+    .concat(['0']) \
+    .join('.')
+
   s.add_runtime_dependency %q<activesupport>, version_string
   s.add_runtime_dependency %q<actionpack>,    version_string
   s.add_runtime_dependency %q<railties>,      version_string
-  %w[core expectations mocks support].each do |name|
+
+  # Handle dependencies that only exist in beta state.
+  %w[core mocks expectations support].each do |name|
     if RSpec::Rails::Version::STRING =~ /[a-zA-Z]+/ # prerelease builds
-      s.add_runtime_dependency "rspec-#{name}", "= #{RSpec::Rails::Version::STRING}"
+      rspec_rails_version << '.beta'
+      s.add_runtime_dependency "rspec-#{name}", "~> #{rspec_rails_version}"
     else
-      s.add_runtime_dependency "rspec-#{name}", "~> #{RSpec::Rails::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
+      s.add_runtime_dependency "rspec-#{name}", "~> #{rspec_rails_version}"
     end
   end
 


### PR DESCRIPTION
This accounts for dependencies that are still in their `~> .beta` state and fixes https://github.com/rspec/rspec-rails/issues/1600