### PR TITLE
Adds keywords arguments in requests for controller specs

### DIFF
--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #index" do
     it "assigns all <%= table_name.pluralize %> as @<%= table_name.pluralize %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      get :index, {}, valid_session
+      get :index, params: {}, session: valid_session
       expect(assigns(:<%= table_name %>)).to eq([<%= file_name %>])
     end
   end
@@ -50,14 +50,14 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #show" do
     it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      get :show, {:id => <%= file_name %>.to_param}, valid_session
+      get :show, params: {:id => <%= file_name %>.to_param}, session: valid_session
       expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
     end
   end
 
   describe "GET #new" do
     it "assigns a new <%= ns_file_name %> as @<%= ns_file_name %>" do
-      get :new, {}, valid_session
+      get :new, params: {}, session: valid_session
       expect(assigns(:<%= ns_file_name %>)).to be_a_new(<%= class_name %>)
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #edit" do
     it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      get :edit, {:id => <%= file_name %>.to_param}, valid_session
+      get :edit, params: {:id => <%= file_name %>.to_param}, session: valid_session
       expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
     end
   end
@@ -74,30 +74,30 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with valid params" do
       it "creates a new <%= class_name %>" do
         expect {
-          post :create, {:<%= ns_file_name %> => valid_attributes}, valid_session
+          post :create, params: {:<%= ns_file_name %> => valid_attributes}, session: valid_session
         }.to change(<%= class_name %>, :count).by(1)
       end
 
       it "assigns a newly created <%= ns_file_name %> as @<%= ns_file_name %>" do
-        post :create, {:<%= ns_file_name %> => valid_attributes}, valid_session
+        post :create, params: {:<%= ns_file_name %> => valid_attributes}, session: valid_session
         expect(assigns(:<%= ns_file_name %>)).to be_a(<%= class_name %>)
         expect(assigns(:<%= ns_file_name %>)).to be_persisted
       end
 
       it "redirects to the created <%= ns_file_name %>" do
-        post :create, {:<%= ns_file_name %> => valid_attributes}, valid_session
+        post :create, params: {:<%= ns_file_name %> => valid_attributes}, session: valid_session
         expect(response).to redirect_to(<%= class_name %>.last)
       end
     end
 
     context "with invalid params" do
       it "assigns a newly created but unsaved <%= ns_file_name %> as @<%= ns_file_name %>" do
-        post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
+        post :create, params: {:<%= ns_file_name %> => invalid_attributes}, session: valid_session
         expect(assigns(:<%= ns_file_name %>)).to be_a_new(<%= class_name %>)
       end
 
       it "re-renders the 'new' template" do
-        post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
+        post :create, params: {:<%= ns_file_name %> => invalid_attributes}, session: valid_session
         expect(response).to render_template("new")
       end
     end
@@ -111,20 +111,20 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 
       it "updates the requested <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => new_attributes}, valid_session
+        put :update, params: {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => new_attributes}, session: valid_session
         <%= file_name %>.reload
         skip("Add assertions for updated state")
       end
 
       it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => valid_attributes}, valid_session
+        put :update, params: {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => valid_attributes}, session: valid_session
         expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
       end
 
       it "redirects to the <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => valid_attributes}, valid_session
+        put :update, params: {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => valid_attributes}, session: valid_session
         expect(response).to redirect_to(<%= file_name %>)
       end
     end
@@ -132,13 +132,13 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with invalid params" do
       it "assigns the <%= ns_file_name %> as @<%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, valid_session
+        put :update, params: {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, session: valid_session
         expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
       end
 
       it "re-renders the 'edit' template" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, valid_session
+        put :update, params: {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, session: valid_session
         expect(response).to render_template("edit")
       end
     end
@@ -148,13 +148,13 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     it "destroys the requested <%= ns_file_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       expect {
-        delete :destroy, {:id => <%= file_name %>.to_param}, valid_session
+        delete :destroy, params: {:id => <%= file_name %>.to_param}, session: valid_session
       }.to change(<%= class_name %>, :count).by(-1)
     end
 
     it "redirects to the <%= table_name %> list" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      delete :destroy, {:id => <%= file_name %>.to_param}, valid_session
+      delete :destroy, params: {:id => <%= file_name %>.to_param}, session: valid_session
       expect(response).to redirect_to(<%= index_helper %>_url)
     end
   end

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -41,7 +41,11 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #index" do
     it "assigns all <%= table_name.pluralize %> as @<%= table_name.pluralize %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
+    <% if RUBY_VERSION < '1.9.3' -%>
+      get :index, {}, valid_session
+    <% else -%>
       get :index, params: {}, session: valid_session
+    <% end -%>
       expect(assigns(:<%= table_name %>)).to eq([<%= file_name %>])
     end
   end
@@ -50,14 +54,22 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #show" do
     it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      get :show, params: {:id => <%= file_name %>.to_param}, session: valid_session
+    <% if RUBY_VERSION < '1.9.3' -%>
+      get :show, {:id => <%= file_name %>.to_param}, valid_session
+    <% else -%>
+      get :show, params: {id: <%= file_name %>.to_param}, session: valid_session
+    <% end -%>
       expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
     end
   end
 
   describe "GET #new" do
     it "assigns a new <%= ns_file_name %> as @<%= ns_file_name %>" do
+    <% if RUBY_VERSION < '1.9.3' -%>
+      get :new, {}, valid_session
+    <% else -%>
       get :new, params: {}, session: valid_session
+    <% end -%>
       expect(assigns(:<%= ns_file_name %>)).to be_a_new(<%= class_name %>)
     end
   end
@@ -65,7 +77,11 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #edit" do
     it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      get :edit, params: {:id => <%= file_name %>.to_param}, session: valid_session
+    <% if RUBY_VERSION < '1.9.3' -%>
+      get :edit, {:id => <%= file_name %>.to_param}, valid_session
+    <% else -%>
+      get :edit, params: {id: <%= file_name %>.to_param}, session: valid_session
+    <% end -%>
       expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
     end
   end
@@ -74,30 +90,50 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with valid params" do
       it "creates a new <%= class_name %>" do
         expect {
-          post :create, params: {:<%= ns_file_name %> => valid_attributes}, session: valid_session
+        <% if RUBY_VERSION < '1.9.3' -%>
+          post :create, {:<%= ns_file_name %> => valid_attributes}, valid_session
+        <% else -%>
+          post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
+        <% end -%>
         }.to change(<%= class_name %>, :count).by(1)
       end
 
       it "assigns a newly created <%= ns_file_name %> as @<%= ns_file_name %>" do
-        post :create, params: {:<%= ns_file_name %> => valid_attributes}, session: valid_session
+      <% if RUBY_VERSION < '1.9.3' -%>
+        post :create, {:<%= ns_file_name %> => valid_attributes}, valid_session
+      <% else -%>
+        post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
+      <% end -%>
         expect(assigns(:<%= ns_file_name %>)).to be_a(<%= class_name %>)
         expect(assigns(:<%= ns_file_name %>)).to be_persisted
       end
 
       it "redirects to the created <%= ns_file_name %>" do
-        post :create, params: {:<%= ns_file_name %> => valid_attributes}, session: valid_session
+      <% if RUBY_VERSION < '1.9.3' -%>
+        post :create, {:<%= ns_file_name %> => valid_attributes}, valid_session
+      <% else -%>
+        post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
+      <% end -%>
         expect(response).to redirect_to(<%= class_name %>.last)
       end
     end
 
     context "with invalid params" do
       it "assigns a newly created but unsaved <%= ns_file_name %> as @<%= ns_file_name %>" do
-        post :create, params: {:<%= ns_file_name %> => invalid_attributes}, session: valid_session
+      <% if RUBY_VERSION < '1.9.3' -%>
+        post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
+      <% else -%>
+        post :create, params: {<%= ns_file_name %>: => invalid_attributes}, session: valid_session
+      <% end -%>
         expect(assigns(:<%= ns_file_name %>)).to be_a_new(<%= class_name %>)
       end
 
       it "re-renders the 'new' template" do
-        post :create, params: {:<%= ns_file_name %> => invalid_attributes}, session: valid_session
+      <% if RUBY_VERSION < '1.9.3' -%>
+        post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
+      <% else -%>
+        post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
+      <% end -%>
         expect(response).to render_template("new")
       end
     end
@@ -111,20 +147,32 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 
       it "updates the requested <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => new_attributes}, session: valid_session
+      <% if RUBY_VERSION < '1.9.3' -%>
+        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => new_attributes}, valid_session
+      <% else -%>
+        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: new_attributes}, session: valid_session
+      <% end -%>
         <%= file_name %>.reload
         skip("Add assertions for updated state")
       end
 
       it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => valid_attributes}, session: valid_session
+      <% if RUBY_VERSION < '1.9.3' -%>
+        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => valid_attributes}, valid_session
+      <% else -%>
+        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: valid_attributes}, session: valid_session
+      <% end -%>
         expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
       end
 
       it "redirects to the <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => valid_attributes}, session: valid_session
+      <% if RUBY_VERSION < '1.9.3' -%>
+        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => valid_attributes}, valid_session
+      <% else -%>
+        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: valid_attributes}, session: valid_session
+      <% end -%>
         expect(response).to redirect_to(<%= file_name %>)
       end
     end
@@ -132,13 +180,21 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with invalid params" do
       it "assigns the <%= ns_file_name %> as @<%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, session: valid_session
+      <% if RUBY_VERSION < '1.9.3' -%>
+        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, valid_session
+      <% else -%>
+        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
+      <% end -%>
         expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
       end
 
       it "re-renders the 'edit' template" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, session: valid_session
+      <% if RUBY_VERSION < '1.9.3' -%>
+        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, valid_session
+      <% else -%>
+        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
+      <% end -%>
         expect(response).to render_template("edit")
       end
     end
@@ -148,13 +204,21 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     it "destroys the requested <%= ns_file_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       expect {
-        delete :destroy, params: {:id => <%= file_name %>.to_param}, session: valid_session
+      <% if RUBY_VERSION < '1.9.3' -%>
+        delete :destroy, {:id => <%= file_name %>.to_param}, valid_session
+      <% else -%>
+        delete :destroy, params: {id: <%= file_name %>.to_param}, session: valid_session
+      <% end -%>
       }.to change(<%= class_name %>, :count).by(-1)
     end
 
     it "redirects to the <%= table_name %> list" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      delete :destroy, params: {:id => <%= file_name %>.to_param}, session: valid_session
+    <% if RUBY_VERSION < '1.9.3' -%>
+      delete :destroy, {:id => <%= file_name %>.to_param}, valid_session
+    <% else -%>
+      delete :destroy, params: {id: <%= file_name %>.to_param}, session: valid_session
+    <% end -%>
       expect(response).to redirect_to(<%= index_helper %>_url)
     end
   end

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
       <% if RUBY_VERSION < '1.9.3' -%>
         post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
       <% else -%>
-        post :create, params: {<%= ns_file_name %>: => invalid_attributes}, session: valid_session
+        post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
       <% end -%>
         expect(assigns(:<%= ns_file_name %>)).to be_a_new(<%= class_name %>)
       end


### PR DESCRIPTION
Making a request without keywords arguments in specs will cause Rails to print this warning:

```
DEPRECATION WARNING: ActionController::TestCase HTTP request methods will accept only
keyword arguments in future Rails versions.

examples:

get :show, params: { id: 1 }, session: { user_id: 1 }
process :update, method: :post, params: { id: 1 }
```