### PR TITLE
Improvements of ActiveJob matchers 

### DIFF
--- a/features/matchers/have_been_enqueued_matcher.feature
+++ b/features/matchers/have_been_enqueued_matcher.feature
@@ -1,0 +1,72 @@
+Feature: have_been_enqueued matcher
+
+  The `have_been_enqueued` matcher is used to check if given ActiveJob job was enqueued.
+
+  Background:
+    Given active job is available
+
+  Scenario: Checking job class name
+    Given a file named "spec/jobs/upload_backups_job_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe UploadBackupsJob do
+        it "matches with enqueued job" do
+          ActiveJob::Base.queue_adapter = :test
+          UploadBackupsJob.perform_later
+          expect(UploadBackupsJob).to have_been_enqueued
+        end
+      end
+      """
+    When I run `rspec spec/jobs/upload_backups_job_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Checking passed arguments to job
+    Given a file named "spec/jobs/upload_backups_job_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe UploadBackupsJob do
+        it "matches with enqueued job" do
+          ActiveJob::Base.queue_adapter = :test
+          UploadBackupsJob.perform_later("users-backup.txt", "products-backup.txt")
+          expect(UploadBackupsJob).to(
+            have_been_enqueued.with("users-backup.txt", "products-backup.txt")
+          )
+        end
+      end
+      """
+    When I run `rspec spec/jobs/upload_backups_job_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Checking job enqueued time
+    Given a file named "spec/jobs/upload_backups_job_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe UploadBackupsJob do
+        it "matches with enqueued job" do
+          ActiveJob::Base.queue_adapter = :test
+          UploadBackupsJob.set(:wait_until => Date.tomorrow.noon).perform_later
+          expect(UploadBackupsJob).to have_been_enqueued.at(Date.tomorrow.noon)
+        end
+      end
+      """
+    When I run `rspec spec/jobs/upload_backups_job_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Checking job queue name
+    Given a file named "spec/jobs/upload_backups_job_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe UploadBackupsJob do
+        it "matches with enqueued job" do
+          ActiveJob::Base.queue_adapter = :test
+          UploadBackupsJob.perform_later
+          expect(UploadBackupsJob).to have_been_enqueued.on_queue("default")
+        end
+      end
+      """
+    When I run `rspec spec/jobs/upload_backups_job_spec.rb`
+    Then the examples should all pass

--- a/features/matchers/have_enqueued_job_matcher.feature
+++ b/features/matchers/have_enqueued_job_matcher.feature
@@ -1,6 +1,6 @@
 Feature: have_enqueued_job matcher
 
-  The `have_enqueued_job` (also known as `enqueue_job`) matcher is used to check if given ActiveJob job was enqueued.
+  The `have_enqueued_job` (also aliased as `enqueue_job`) matcher is used to check if given ActiveJob job was enqueued.
 
   Background:
     Given active job is available

--- a/features/matchers/have_enqueued_job_matcher.feature
+++ b/features/matchers/have_enqueued_job_matcher.feature
@@ -1,6 +1,6 @@
 Feature: have_enqueued_job matcher
 
-  The `have_enqueued_job` matcher is used to check if given ActiveJob job was enqueued.
+  The `have_enqueued_job` (also known as `enqueue_job`) matcher is used to check if given ActiveJob job was enqueued.
 
   Background:
     Given active job is available
@@ -67,6 +67,23 @@ Feature: have_enqueued_job matcher
           expect {
             UploadBackupsJob.perform_later
           }.to have_enqueued_job.on_queue("default")
+        end
+      end
+      """
+    When I run `rspec spec/jobs/upload_backups_job_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Using alias method
+    Given a file named "spec/jobs/upload_backups_job_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe UploadBackupsJob do
+        it "matches with enqueued job" do
+          ActiveJob::Base.queue_adapter = :test
+          expect {
+            UploadBackupsJob.perform_later
+          }.to enqueue_job(UploadBackupsJob)
         end
       end
       """

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -147,7 +147,7 @@ module RSpec
           end
 
           def matches?(proc)
-            raise ArgumentError, "have_enqueued_job only support block expectations" unless Proc === proc
+            raise ArgumentError, "have_enqueued_job and enqueue_job only support block expectations" unless Proc === proc
 
             original_enqueued_jobs_count = queue_adapter.enqueued_jobs.count
             proc.call
@@ -173,6 +173,11 @@ module RSpec
       #     expect {
       #       HeavyLiftingJob.perform_later
       #     }.to have_enqueued_job
+      #
+      #     # Using alias
+      #     expect {
+      #       HeavyLiftingJob.perform_later
+      #     }.to enqueue_job
       #
       #     expect {
       #       HelloJob.perform_later
@@ -201,6 +206,7 @@ module RSpec
         check_active_job_adapter
         ActiveJob::HaveEnqueuedJob.new(job)
       end
+      alias_method :enqueue_job, :have_enqueued_job
 
       # @api public
       # Passess if `count` of jobs were enqueued

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -77,6 +77,18 @@ module RSpec
             self
           end
 
+          def once
+            exactly(:once)
+          end
+
+          def twice
+            exactly(:twice)
+          end
+
+          def thrice
+            exactly(:thrice)
+          end
+
           def failure_message
             "expected to enqueue #{base_message}"
           end

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -167,7 +167,7 @@ module RSpec
       end
 
       # @api public
-      # Passess if `count` of jobs were enqueued inside block
+      # Passes if a job has been enqueued inside block. May chain at_least, at_most or exactly to specify a number of times.
       #
       # @example
       #     expect {
@@ -185,9 +185,7 @@ module RSpec
       #     }.to have_enqueued_job(HelloJob).exactly(:once)
       #
       #     expect {
-      #       HelloJob.perform_later
-      #       HelloJob.perform_later
-      #       HelloJob.perform_later
+      #       3.times { HelloJob.perform_later }
       #     }.to have_enqueued_job(HelloJob).at_least(2).times
       #
       #     expect {
@@ -209,7 +207,7 @@ module RSpec
       alias_method :enqueue_job, :have_enqueued_job
 
       # @api public
-      # Passess if `count` of jobs were enqueued
+      # Passes if a job has been enqueued. May chain at_least, at_most or exactly to specify a number of times.
       #
       # @example
       #     before { ActiveJob::Base.queue_adapter.enqueued_jobs.clear }
@@ -221,9 +219,7 @@ module RSpec
       #     HeavyLiftingJob.perform_later
       #     expect(HeavyLiftingJob).to have_been_enqueued.exactly(:once)
       #
-      #     HelloJob.perform_later
-      #     HelloJob.perform_later
-      #     HelloJob.perform_later
+      #     3.times { HelloJob.perform_later }
       #     expect(HelloJob).to have_been_enqueued.at_least(2).times
       #
       #     HelloJob.perform_later

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to have_enqueued_job
     end
 
+    it "passess when using alias" do
+      expect {
+        heavy_lifting_job.perform_later
+      }.to enqueue_job
+    end
+
     it "counts only jobs enqueued in block" do
       heavy_lifting_job.perform_later
       expect {

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
 
       expect {
         expect { heavy_lifting_job.perform_later }.to have_enqueued_job
-      }.to raise_error("To use have_enqueued_job matcher set `ActiveJob::Base.queue_adapter = :test`")
+      }.to raise_error("To use ActiveJob matchers set `ActiveJob::Base.queue_adapter = :test`")
 
       ActiveJob::Base.queue_adapter = queue_adapter
     end
@@ -250,6 +250,31 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to have_enqueued_job(hello_job).at(noon).with { |arg|
         expect(arg).to eq("asdf")
       }
+    end
+  end
+
+  describe "have_been_enqueued" do
+    before { ActiveJob::Base.queue_adapter.enqueued_jobs.clear }
+
+    it "passess with default one number" do
+      heavy_lifting_job.perform_later
+      expect(heavy_lifting_job).to have_been_enqueued
+    end
+
+    it "counts all enqueued jobs" do
+      heavy_lifting_job.perform_later
+      heavy_lifting_job.perform_later
+      expect(heavy_lifting_job).to have_been_enqueued.exactly(2)
+    end
+
+    it "passess when negated" do
+      expect(heavy_lifting_job).not_to have_been_enqueued
+    end
+
+    it "fails when job is not enqueued" do
+      expect {
+        expect(heavy_lifting_job).to have_been_enqueued
+      }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
     end
   end
 end

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -61,13 +61,13 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to raise_error(ArgumentError)
     end
 
-    it "passess with default one number" do
+    it "passes with default jobs count (exactly one)" do
       expect {
         heavy_lifting_job.perform_later
       }.to have_enqueued_job
     end
 
-    it "passess when using alias" do
+    it "passes when using alias" do
       expect {
         heavy_lifting_job.perform_later
       }.to enqueue_job
@@ -80,7 +80,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to have_enqueued_job.exactly(1)
     end
 
-    it "passess when negated" do
+    it "passes when negated" do
       expect { }.not_to have_enqueued_job
     end
 
@@ -127,20 +127,20 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to have_enqueued_job(hello_job).and have_enqueued_job(logging_job)
     end
 
-    it "passess with :once count" do
+    it "passes with :once count" do
       expect {
         hello_job.perform_later
       }.to have_enqueued_job.exactly(:once)
     end
 
-    it "passess with :twice count" do
+    it "passes with :twice count" do
       expect {
         hello_job.perform_later
         hello_job.perform_later
       }.to have_enqueued_job.exactly(:twice)
     end
 
-    it "passess with :thrice count" do
+    it "passes with :thrice count" do
       expect {
         hello_job.perform_later
         hello_job.perform_later
@@ -148,14 +148,14 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to have_enqueued_job.exactly(:thrice)
     end
 
-    it "passess with at_least count when enqueued jobs are over limit" do
+    it "passes with at_least count when enqueued jobs are over limit" do
       expect {
         hello_job.perform_later
         hello_job.perform_later
       }.to have_enqueued_job.at_least(:once)
     end
 
-    it "passess with at_most count when enqueued jobs are under limit" do
+    it "passes with at_most count when enqueued jobs are under limit" do
       expect {
         hello_job.perform_later
       }.to have_enqueued_job.at_most(:once)
@@ -262,7 +262,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
   describe "have_been_enqueued" do
     before { ActiveJob::Base.queue_adapter.enqueued_jobs.clear }
 
-    it "passess with default one number" do
+    it "passes with default jobs count (exactly one)" do
       heavy_lifting_job.perform_later
       expect(heavy_lifting_job).to have_been_enqueued
     end
@@ -273,7 +273,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       expect(heavy_lifting_job).to have_been_enqueued.exactly(2)
     end
 
-    it "passess when negated" do
+    it "passes when negated" do
       expect(heavy_lifting_job).not_to have_been_enqueued
     end
 


### PR DESCRIPTION
There are some improvements of ActiveJob matchers. Sorry for packing all in one PR, I'm ready to remove some of them if needed.

1. __Rename have_enqueued_job to enqueue_job.__
  `expect(block).to enqueue_job` looks more correct grammatically, especially since we already have matchers like `expect(subject).to receive`, `expect(block).to change`, and so on.

2. __Add enqueue_job.once/twice/thrice.__
  This is just a syntax suggar. We have the same methods for `expect(subject).to receive`, and it would be right to have them here.

3. __Add have_been_enqueued matcher__
  This matcher looks over all enqueued jobs. It's very useful when you need to check many job into the one example.
  ```ruby
  UploadBackupsJob.perform_later
  expect(UploadBackupsJob).to have_been_enqueued
 ```