### PR TITLE
Make the have_rendered but was redirect error message clearer

### DIFF
--- a/lib/rspec/rails/matchers/have_rendered.rb
+++ b/lib/rspec/rails/matchers/have_rendered.rb
@@ -35,8 +35,8 @@ module RSpec
           # @api private
           def failure_message
             if @redirect_is
-              rescued_exception.message[/.* but /] +
-                "was a redirect to <#{@redirect_is}>"
+              rescued_exception.message[/(.*?)( but|$)/, 1] +
+                " but was a redirect to <#{@redirect_is}>"
             else
               rescued_exception.message
             end

--- a/spec/rspec/rails/matchers/have_rendered_spec.rb
+++ b/spec/rspec/rails/matchers/have_rendered_spec.rb
@@ -108,6 +108,19 @@ require "spec_helper"
             expect(response).to send(template_expectation, "template_name")
           end.to raise_exception("expecting <'template_name'> but was a redirect to <http://test.host/widgets/1>")
         end
+
+        context 'with a badly formatted error message' do
+          def assert_template(*)
+            message = 'expected [] to include "some/path"'
+            raise ActiveSupport::TestCase::Assertion.new(message)
+          end
+
+          it 'falls back to something informative' do
+            expect do
+              expect(response).to send(template_expectation, "template_name")
+            end.to raise_exception('expected [] to include "some/path" but was a redirect to <http://test.host/widgets/1>')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
In some circumstances (#1590), the error message for the `have_rendered` matcher produces unexpected results, and can cause a `NoMethodError`. This is a simple fix for that which attempts to keep the same style of message, it's not going to be perfect but it should at least not error.

Fixes #1590