### PR TITLE
Skip mocks callback when AR improperly defined.

### DIFF
--- a/lib/rspec/rails/active_record.rb
+++ b/lib/rspec/rails/active_record.rb
@@ -7,7 +7,7 @@ module RSpec
       def self.initialize_activerecord_configuration(config)
         config.before :suite do
           # This allows dynamic columns etc to be used on ActiveRecord models when creating instance_doubles
-          if defined?(ActiveRecord) && defined?(::RSpec::Mocks)
+          if defined?(ActiveRecord) && defined?(ActiveRecord::Base) && defined?(::RSpec::Mocks)
             ::RSpec::Mocks.configuration.when_declaring_verifying_double do |possible_model|
               target = possible_model.target
 


### PR DESCRIPTION
In the case ActiveRecord has been improperly defined skip the call back for defining methods on mocks.

Fixes #1611 