### PR TITLE
include general matchers in all contexts when rspec-rails is present

### DIFF
--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -47,6 +47,7 @@ module RSpec
       config.include RSpec::Rails::RoutingExampleGroup,    :type => :routing
       config.include RSpec::Rails::ViewExampleGroup,       :type => :view
       config.include RSpec::Rails::FeatureExampleGroup,    :type => :feature
+      config.include RSpec::Rails::Matchers
     end
 
     # @private


### PR DESCRIPTION
Because the matcher methods are public, and the module is public, we can't extract matchers easily without duplication. Given the original problem was simply that certain matchers (active job) weren't available outside Rails specific contexts, it seems safe just to included the matchers module generally without worrying about it. 

/cc @samphippen 

