### PR TITLE
Set RAILS_ENV=test early in rake execution

### DIFF
--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -2,6 +2,11 @@
 require 'rspec/core'
 require 'rspec/rails/feature_check'
 
+# Prevent problems with double loading between `development` and `test` environments
+if defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^(default$|spec(:|$))/).any?
+  ENV['RAILS_ENV'] ||= 'test'
+end
+
 # Namespace for all core RSpec projects.
 module RSpec
   # Namespace for rspec-rails code.


### PR DESCRIPTION
This hack mirrors a hack in Rails for test::unit.
(See https://github.com/rails/rails/blob/99873ca1ea98d73c73f8be60dfce0a54224f4ea8/railties/lib/rails/test_unit/railtie.rb)

In my particular situation (general issue for XING), this change
prevents a problem with the use of the dotenv gem where environment
variable values for development leak into the test environment.
(See https://github.com/bkeepers/dotenv/issues/219 and https://github.com/bkeepers/dotenv/pull/241)