### PR TITLE
Rescue TypeError if a top-level class named Behavior exists

### DIFF
--- a/lib/rspec/rails/example/request_example_group.rb
+++ b/lib/rspec/rails/example/request_example_group.rb
@@ -13,7 +13,7 @@ module RSpec
 
       begin
         include ActionDispatch::IntegrationTest::Behavior
-      rescue NameError # rubocop:disable Lint/HandleExceptions
+      rescue NameError, TypeError # rubocop:disable Lint/HandleExceptions
         # rails is too old to provide integration test helpers
       end
 


### PR DESCRIPTION
If your application defines a top-level class named Behavior, loading
rspec/rails/example/request_example_group.rb with Rails 3.2.22.1
results in a compiler warning:

`warning: toplevel constant Behavior referenced by ActionDispatch::IntegrationTest::Behavior`

This warning is the result of the situation descibed in https://github.com/rails/rails/issues/6931,
i.e. Rails auto-load magic concludes that the constant named Behavior is already
defined, and tries to use it instead of attempting to auto-load a properly namespaced one.

The result is a TypeError, which can safely be swallowed.