### PR TITLE
Rake notes compatibility in Rails 5.1.0

### DIFF
--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -8,12 +8,10 @@ module RSpec
   module Rails
     # Railtie to hook into Rails.
     class Railtie < ::Rails::Railtie
-
       # As of Rails 5.1.0 you can register directories to work with `rake notes`
-      if Gem::Requirement.new(">= 5.1.0").satisfied_by?(Gem::Version.new(::Rails.version))
+      if ::Rails::VERSION::STRING > '5.1'
         SourceAnnotationExtractor::Annotation.register_directories("spec")
       end
-      
       # Rails-3.0.1 requires config.app_generators instead of 3.0.0's config.generators
       generators = config.respond_to?(:app_generators) ? config.app_generators : config.generators
       generators.integration_tool :rspec
@@ -73,7 +71,6 @@ module RSpec
         # always return `true`.
         config.respond_to?(:action_mailer) && ::Rails::VERSION::STRING > '4.1'
       end
-
     end
   end
 end

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -28,6 +28,13 @@ module RSpec
         setup_preview_path(app)
       end
 
+      # As of Rails 5.1.0 you can register directories to work with `rake notes`
+      if Gem::Requirement.new(">= 5.1.0").satisfied_by?(Gem::Version.new(::Rails.version))
+        initializer "register_spec_folder_with_rake_notes" do
+          SourceAnnotationExtractor::Annotation.register_directories("spec")
+        end
+      end
+
     private
 
       def setup_preview_path(app)
@@ -66,6 +73,12 @@ module RSpec
         # `config.action_mailer.respond_to?(:preview_path)` here as it will
         # always return `true`.
         config.respond_to?(:action_mailer) && ::Rails::VERSION::STRING > '4.1'
+      end
+
+      def register_spec_folder_with_rake_notes
+        # This tells rails source_annotation_extractor about the spec folder.
+        # Now `rake notes` will work with rspec.
+        config.annotations.register_directories("spec")
       end
     end
   end

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -9,7 +9,7 @@ module RSpec
     # Railtie to hook into Rails.
     class Railtie < ::Rails::Railtie
       # As of Rails 5.1.0 you can register directories to work with `rake notes`
-      if ::Rails::VERSION::STRING > '5.1'
+      if ::Rails::VERSION::STRING >= '5.1'
         SourceAnnotationExtractor::Annotation.register_directories("spec")
       end
       # Rails-3.0.1 requires config.app_generators instead of 3.0.0's config.generators

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -8,6 +8,12 @@ module RSpec
   module Rails
     # Railtie to hook into Rails.
     class Railtie < ::Rails::Railtie
+
+      # As of Rails 5.1.0 you can register directories to work with `rake notes`
+      if Gem::Requirement.new(">= 5.1.0").satisfied_by?(Gem::Version.new(::Rails.version))
+        SourceAnnotationExtractor::Annotation.register_directories("spec")
+      end
+      
       # Rails-3.0.1 requires config.app_generators instead of 3.0.0's config.generators
       generators = config.respond_to?(:app_generators) ? config.app_generators : config.generators
       generators.integration_tool :rspec
@@ -26,13 +32,6 @@ module RSpec
       initializer "rspec_rails.action_mailer",
                   :before => "action_mailer.set_configs" do |app|
         setup_preview_path(app)
-      end
-
-      # As of Rails 5.1.0 you can register directories to work with `rake notes`
-      if Gem::Requirement.new(">= 5.1.0").satisfied_by?(Gem::Version.new(::Rails.version))
-        initializer "register_spec_folder_with_rake_notes" do
-          SourceAnnotationExtractor::Annotation.register_directories("spec")
-        end
       end
 
     private
@@ -75,11 +74,6 @@ module RSpec
         config.respond_to?(:action_mailer) && ::Rails::VERSION::STRING > '4.1'
       end
 
-      def register_spec_folder_with_rake_notes
-        # This tells rails source_annotation_extractor about the spec folder.
-        # Now `rake notes` will work with rspec.
-        config.annotations.register_directories("spec")
-      end
     end
   end
 end


### PR DESCRIPTION
As of Rails 5.1.0 gems can register a directories to work with `rake notes`

in this case we can tell Rails it to now look in the `/spec` folder when searching for annotations like `# TODO:` `# FIXME` etc.

This was added in this PR:
rails/rails#25692

Resulting in:

```bash

$ rake notes
app/spec/models/article_spec.rb:
  * [2] [TODO] add more specs
  * [3] [FIXME] Spec A is broken
  * [4] [OPTIMIZE] improve this test

```

Thats one less daily annoyance. 

John