### PR TITLE
Revert "Ensure rspec core is loaded if rspec-rails is."

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,10 +5,15 @@ Enhancements:
 
 * Add support for `rake notes` in Rails `>= 5.1`. (John Meehan, #1661)
 
+Bug Fixes:
+
+* Stop unnecessarily loading `rspec/core` from `rspec/rails` to avoid
+  IRB context warning. (Myron Marston, #1678)
+
 ### 3.5.1 / 2016-07-08
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.5.0...v3.5.1)
 
-Bugfixes:
+Bug Fixes:
 
 * Only attempt to load `ActionDispatch::IntegrationTest::Behavior` on Rails 5,
   and above; Prevents possible `TypeError` when an existing `Behaviour` class

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -1,5 +1,3 @@
-# Explicitly require rspec-core for weird spring issue, see #1558
-require 'rspec/core'
 require 'rspec/rails/feature_check'
 
 # Namespace for all core RSpec projects.


### PR DESCRIPTION
This reverts commit 994cb7afa8919c5f4560c8b765867b2aac15c192.

The original fix was never shown to have fixed anything, and looks
to have triggered rspec/rspec-rails#1645 and rspec/rspec-core#2301.

Fixes #1645.

@xaviershay and @samphippen are you OK with this?