### PR TITLE
Remove non-Rails-5 features from controller spec scaffold

### DIFF
--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -39,16 +39,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 
 <% unless options[:singleton] -%>
   describe "GET #index" do
-    it "assigns all <%= table_name.pluralize %> as @<%= table_name.pluralize %>" do
-      <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
-      get :index, {}, valid_session
-<% else -%>
-      get :index, params: {}, session: valid_session
-<% end -%>
-      expect(assigns(:<%= table_name %>)).to eq([<%= file_name %>])
-    end
-
     it "returns a success response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
 <% if RUBY_VERSION < '1.9.3' -%>
@@ -62,16 +52,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 
 <% end -%>
   describe "GET #show" do
-    it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
-      <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
-      get :show, {:id => <%= file_name %>.to_param}, valid_session
-<% else -%>
-      get :show, params: {id: <%= file_name %>.to_param}, session: valid_session
-<% end -%>
-      expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
-    end
-
     it "returns a success response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
 <% if RUBY_VERSION < '1.9.3' -%>
@@ -84,15 +64,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   end
 
   describe "GET #new" do
-    it "assigns a new <%= ns_file_name %> as @<%= ns_file_name %>" do
-<% if RUBY_VERSION < '1.9.3' -%>
-      get :new, {}, valid_session
-<% else -%>
-      get :new, params: {}, session: valid_session
-<% end -%>
-      expect(assigns(:<%= ns_file_name %>)).to be_a_new(<%= class_name %>)
-    end
-
     it "returns a success response" do
 <% if RUBY_VERSION < '1.9.3' -%>
       get :new, {}, valid_session
@@ -104,16 +75,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   end
 
   describe "GET #edit" do
-    it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
-      <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
-      get :edit, {:id => <%= file_name %>.to_param}, valid_session
-<% else -%>
-      get :edit, params: {id: <%= file_name %>.to_param}, session: valid_session
-<% end -%>
-      expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
-    end
-
     it "returns a success response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
 <% if RUBY_VERSION < '1.9.3' -%>
@@ -137,16 +98,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
         }.to change(<%= class_name %>, :count).by(1)
       end
 
-      it "assigns a newly created <%= ns_file_name %> as @<%= ns_file_name %>" do
-<% if RUBY_VERSION < '1.9.3' -%>
-        post :create, {:<%= ns_file_name %> => valid_attributes}, valid_session
-<% else -%>
-        post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
-<% end -%>
-        expect(assigns(:<%= ns_file_name %>)).to be_a(<%= class_name %>)
-        expect(assigns(:<%= ns_file_name %>)).to be_persisted
-      end
-
       it "redirects to the created <%= ns_file_name %>" do
 <% if RUBY_VERSION < '1.9.3' -%>
         post :create, {:<%= ns_file_name %> => valid_attributes}, valid_session
@@ -158,15 +109,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     end
 
     context "with invalid params" do
-      it "assigns a newly created but unsaved <%= ns_file_name %> as @<%= ns_file_name %>" do
-<% if RUBY_VERSION < '1.9.3' -%>
-        post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
-<% else -%>
-        post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
-<% end -%>
-        expect(assigns(:<%= ns_file_name %>)).to be_a_new(<%= class_name %>)
-      end
-
       it "returns a success response (i.e. to display the 'new' template)" do
 <% if RUBY_VERSION < '1.9.3' -%>
         post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
@@ -174,15 +116,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
         post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
 <% end -%>
         expect(response).to be_success
-      end
-
-      it "re-renders the 'new' template" do
-<% if RUBY_VERSION < '1.9.3' -%>
-        post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
-<% else -%>
-        post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
-<% end -%>
-        expect(response).to render_template("new")
       end
     end
   end
@@ -204,16 +137,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
         skip("Add assertions for updated state")
       end
 
-      it "assigns the requested <%= ns_file_name %> as @<%= ns_file_name %>" do
-        <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => valid_attributes}, valid_session
-<% else -%>
-        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: valid_attributes}, session: valid_session
-<% end -%>
-        expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
-      end
-
       it "redirects to the <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
 <% if RUBY_VERSION < '1.9.3' -%>
@@ -226,16 +149,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     end
 
     context "with invalid params" do
-      it "assigns the <%= ns_file_name %> as @<%= ns_file_name %>" do
-        <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, valid_session
-<% else -%>
-        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
-<% end -%>
-        expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
-      end
-
       it "returns a success response (i.e. to display the 'edit' template)" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
 <% if RUBY_VERSION < '1.9.3' -%>
@@ -244,16 +157,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
         put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
 <% end -%>
         expect(response).to be_success
-      end
-
-      it "re-renders the 'edit' template" do
-        <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
-        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, valid_session
-<% else -%>
-        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
-<% end -%>
-        expect(response).to render_template("edit")
       end
     end
   end

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -17,6 +17,11 @@ require 'rails_helper'
 # is no simpler way to get a handle on the object needed for the example.
 # Message expectations are only used when there is no simpler way to specify
 # that an instance is receiving a specific message.
+#
+# Also compared to earlier versions of this generator, there are no longer any
+# expectations of assigns and templates rendered. These features have been
+# removed from Rails core in Rails 5, but can be added back in via the
+# `rails-controller-testing` gem.
 
 <% module_namespacing do -%>
 RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:controller) %> do

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% end -%>
       expect(assigns(:<%= table_name %>)).to eq([<%= file_name %>])
     end
+
+    it "returns a success response" do
+      <%= file_name %> = <%= class_name %>.create! valid_attributes
+<% if RUBY_VERSION < '1.9.3' -%>
+      get :index, {}, valid_session
+<% else -%>
+      get :index, params: {}, session: valid_session
+<% end -%>
+      expect(response).to be_success
+    end
   end
 
 <% end -%>
@@ -61,6 +71,16 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% end -%>
       expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
     end
+
+    it "returns a success response" do
+      <%= file_name %> = <%= class_name %>.create! valid_attributes
+<% if RUBY_VERSION < '1.9.3' -%>
+      get :show, {:id => <%= file_name %>.to_param}, valid_session
+<% else -%>
+      get :show, params: {id: <%= file_name %>.to_param}, session: valid_session
+<% end -%>
+      expect(response).to be_success
+    end
   end
 
   describe "GET #new" do
@@ -71,6 +91,15 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
       get :new, params: {}, session: valid_session
 <% end -%>
       expect(assigns(:<%= ns_file_name %>)).to be_a_new(<%= class_name %>)
+    end
+
+    it "returns a success response" do
+<% if RUBY_VERSION < '1.9.3' -%>
+      get :new, {}, valid_session
+<% else -%>
+      get :new, params: {}, session: valid_session
+<% end -%>
+      expect(response).to be_success
     end
   end
 
@@ -83,6 +112,16 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
       get :edit, params: {id: <%= file_name %>.to_param}, session: valid_session
 <% end -%>
       expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
+    end
+
+    it "returns a success response" do
+      <%= file_name %> = <%= class_name %>.create! valid_attributes
+<% if RUBY_VERSION < '1.9.3' -%>
+      get :edit, {:id => <%= file_name %>.to_param}, valid_session
+<% else -%>
+      get :edit, params: {id: <%= file_name %>.to_param}, session: valid_session
+<% end -%>
+      expect(response).to be_success
     end
   end
 
@@ -126,6 +165,15 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
         post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
 <% end -%>
         expect(assigns(:<%= ns_file_name %>)).to be_a_new(<%= class_name %>)
+      end
+
+      it "returns a success response (i.e. to display the 'new' template)" do
+<% if RUBY_VERSION < '1.9.3' -%>
+        post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
+<% else -%>
+        post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
+<% end -%>
+        expect(response).to be_success
       end
 
       it "re-renders the 'new' template" do
@@ -186,6 +234,16 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
         put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
 <% end -%>
         expect(assigns(:<%= ns_file_name %>)).to eq(<%= file_name %>)
+      end
+
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        <%= file_name %> = <%= class_name %>.create! valid_attributes
+<% if RUBY_VERSION < '1.9.3' -%>
+        put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, valid_session
+<% else -%>
+        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
+<% end -%>
+        expect(response).to be_success
       end
 
       it "re-renders the 'edit' template" do


### PR DESCRIPTION
Fixes #1605 by removing all expectations for assigns and templates rendered from the controller specs generated for scaffolds. Sample generated spec below.

They feel a big lethargic because all that’s being specified for a lot of the methods now is only that they return HTTP success—but I believe that’s all there is to specify for them in a vanilla Rails 5 install.

A few other things we could consider:

- Generating commented out “assigns” and “template rendered” expectations, along with a comment explaining the `rails-controller-testing` gem.
- Detecting whether “assigns” and “template rendered” expectations are available (i.e. a Rails 4 app, or a Rails 5 app with the `rails-controller-testing` gem), and generating the appropriate expectations then. That would significantly increase the complexity of the controller spec template.

Happy to take this PR any direction y’all would like—let me know how I can help!

Here’s a sample of the generated spec, which passes once I take care of the skips:

```
require 'rails_helper'

# (header comments trimmed)

RSpec.describe PostsController, type: :controller do

  # This should return the minimal set of attributes required to create a valid
  # Post. As you add validations to Post, be sure to
  # adjust the attributes here as well.
  let(:valid_attributes) {
    skip("Add a hash of attributes valid for your model")
  }

  let(:invalid_attributes) {
    skip("Add a hash of attributes invalid for your model")
  }

  # This should return the minimal set of values that should be in the session
  # in order to pass any filters (e.g. authentication) defined in
  # PostsController. Be sure to keep this updated too.
  let(:valid_session) { {} }

  describe "GET #index" do
    it "returns a success response" do
      post = Post.create! valid_attributes
      get :index, params: {}, session: valid_session
      expect(response).to be_success
    end
  end

  describe "GET #show" do
    it "returns a success response" do
      post = Post.create! valid_attributes
      get :show, params: {id: post.to_param}, session: valid_session
      expect(response).to be_success
    end
  end

  describe "GET #new" do
    it "returns a success response" do
      get :new, params: {}, session: valid_session
      expect(response).to be_success
    end
  end

  describe "GET #edit" do
    it "returns a success response" do
      post = Post.create! valid_attributes
      get :edit, params: {id: post.to_param}, session: valid_session
      expect(response).to be_success
    end
  end

  describe "POST #create" do
    context "with valid params" do
      it "creates a new Post" do
        expect {
          post :create, params: {post: valid_attributes}, session: valid_session
        }.to change(Post, :count).by(1)
      end

      it "redirects to the created post" do
        post :create, params: {post: valid_attributes}, session: valid_session
        expect(response).to redirect_to(Post.last)
      end
    end

    context "with invalid params" do
      it "returns a success response (i.e. to display the 'new' template)" do
        post :create, params: {post: invalid_attributes}, session: valid_session
        expect(response).to be_success
      end
    end
  end

  describe "PUT #update" do
    context "with valid params" do
      let(:new_attributes) {
        skip("Add a hash of attributes valid for your model")
      }

      it "updates the requested post" do
        post = Post.create! valid_attributes
        put :update, params: {id: post.to_param, post: new_attributes}, session: valid_session
        post.reload
        skip("Add assertions for updated state")
      end

      it "redirects to the post" do
        post = Post.create! valid_attributes
        put :update, params: {id: post.to_param, post: valid_attributes}, session: valid_session
        expect(response).to redirect_to(post)
      end
    end

    context "with invalid params" do
      it "returns a success response (i.e. to display the 'edit' template)" do
        post = Post.create! valid_attributes
        put :update, params: {id: post.to_param, post: invalid_attributes}, session: valid_session
        expect(response).to be_success
      end
    end
  end

  describe "DELETE #destroy" do
    it "destroys the requested post" do
      post = Post.create! valid_attributes
      expect {
        delete :destroy, params: {id: post.to_param}, session: valid_session
      }.to change(Post, :count).by(-1)
    end

    it "redirects to the posts list" do
      post = Post.create! valid_attributes
      delete :destroy, params: {id: post.to_param}, session: valid_session
      expect(response).to redirect_to(posts_url)
    end
  end

end
```
