### PR TITLE
Use keyword args for HTTP methods in controller specs only on Rails 5

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@ Enhancements:
 
 * Add compatibility for Rails 5.1. (Sam Phippen, Yuichiro Kaneko, #1790)
 
+Bug Fixes:
+
+* Fix scaffold generator so that it does not generate broken controller specs
+  on Rails 3.x and 4.x. (Yuji Nakayama, #1710)
+
 ### 3.6.0.beta2 / 2016-12-12
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.6.0.beta1...v3.6.0.beta2)
 

--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -134,4 +134,9 @@ gsub_file 'spec/spec_helper.rb',
           'config.warnings = false'
 gsub_file '.rspec', '--warnings', ''
 
+# Remove skips so we can test controller specs work
+gsub_file 'spec/controllers/gadgets_controller_spec.rb',
+          'skip("Add a hash of attributes valid for your model")',
+          '{}'
+
 final_tasks

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #index" do
     it "returns a success response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
       get :index, {}, valid_session
 <% else -%>
       get :index, params: {}, session: valid_session
@@ -59,7 +59,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #show" do
     it "returns a success response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
       get :show, {:id => <%= file_name %>.to_param}, valid_session
 <% else -%>
       get :show, params: {id: <%= file_name %>.to_param}, session: valid_session
@@ -70,7 +70,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 
   describe "GET #new" do
     it "returns a success response" do
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
       get :new, {}, valid_session
 <% else -%>
       get :new, params: {}, session: valid_session
@@ -82,7 +82,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #edit" do
     it "returns a success response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
       get :edit, {:id => <%= file_name %>.to_param}, valid_session
 <% else -%>
       get :edit, params: {id: <%= file_name %>.to_param}, session: valid_session
@@ -95,7 +95,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with valid params" do
       it "creates a new <%= class_name %>" do
         expect {
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
           post :create, {:<%= ns_file_name %> => valid_attributes}, valid_session
 <% else -%>
           post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
@@ -104,7 +104,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
       end
 
       it "redirects to the created <%= ns_file_name %>" do
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
         post :create, {:<%= ns_file_name %> => valid_attributes}, valid_session
 <% else -%>
         post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
@@ -115,7 +115,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'new' template)" do
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
         post :create, {:<%= ns_file_name %> => invalid_attributes}, valid_session
 <% else -%>
         post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
@@ -133,7 +133,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 
       it "updates the requested <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
         put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => new_attributes}, valid_session
 <% else -%>
         put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: new_attributes}, session: valid_session
@@ -144,7 +144,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 
       it "redirects to the <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
         put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => valid_attributes}, valid_session
 <% else -%>
         put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: valid_attributes}, session: valid_session
@@ -156,7 +156,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'edit' template)" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
         put :update, {:id => <%= file_name %>.to_param, :<%= ns_file_name %> => invalid_attributes}, valid_session
 <% else -%>
         put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
@@ -170,7 +170,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     it "destroys the requested <%= ns_file_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       expect {
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
         delete :destroy, {:id => <%= file_name %>.to_param}, valid_session
 <% else -%>
         delete :destroy, params: {id: <%= file_name %>.to_param}, session: valid_session
@@ -180,7 +180,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 
     it "redirects to the <%= table_name %> list" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if RUBY_VERSION < '1.9.3' -%>
+<% if Rails::VERSION::STRING < '5.0' -%>
       delete :destroy, {:id => <%= file_name %>.to_param}, valid_session
 <% else -%>
       delete :destroy, params: {id: <%= file_name %>.to_param}, session: valid_session


### PR DESCRIPTION
This closes #1669.
