### PR TITLE
Force railties to be the same version as rails for maintenance branches

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -14,7 +14,12 @@ when /master/
   gem 'sprockets', :git => 'git://github.com/rails/sprockets.git', :branch => 'master'
   gem 'sprockets-rails', :git => 'git://github.com/rails/sprockets-rails.git', :branch => 'master'
 when /stable$/
-  gem "rails", :git => "git://github.com/rails/rails.git", :branch => version
+  gem_list = %w[rails railties actionmailer actionpack activerecord activesupport]
+  gem_list << 'activejob'  if version > '4-1-stable'
+  gem_list << 'actionview' if version > '4-0-stable'
+  gem_list.each do |rails_gem|
+    gem rails_gem, :git => "git://github.com/rails/rails.git", :branch => version
+  end
 when nil, false, ""
   if RUBY_VERSION < '1.9.3'
     # Rails 4+ requires 1.9.3+, so on earlier versions default to the last 3.x release.


### PR DESCRIPTION
This is an attempt to fix the build but forcing railties to be the same version as rails