### PR TITLE
split spec bootstapping into separate files

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --warnings
 --color
---require spec_helper

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --warnings
 --color
+--require spec_helper

--- a/spec/generator_helper.rb
+++ b/spec/generator_helper.rb
@@ -1,0 +1,3 @@
+require 'rails_helper'
+require 'ammeter/init'
+require 'support/generators'

--- a/spec/generators/rspec/controller/controller_generator_spec.rb
+++ b/spec/generators/rspec/controller/controller_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/controller/controller_generator'
 
-
 RSpec.describe Rspec::Generators::ControllerGenerator, :type => :generator do
   setup_default_destination
 

--- a/spec/generators/rspec/controller/controller_generator_spec.rb
+++ b/spec/generators/rspec/controller/controller_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/controller/controller_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::ControllerGenerator, :type => :generator do
   setup_default_destination

--- a/spec/generators/rspec/feature/feature_generator_spec.rb
+++ b/spec/generators/rspec/feature/feature_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by rails
 require 'generators/rspec/feature/feature_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::FeatureGenerator, :type => :generator do
   setup_default_destination

--- a/spec/generators/rspec/feature/feature_generator_spec.rb
+++ b/spec/generators/rspec/feature/feature_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by rails
 require 'generators/rspec/feature/feature_generator'
 
-
 RSpec.describe Rspec::Generators::FeatureGenerator, :type => :generator do
   setup_default_destination
 

--- a/spec/generators/rspec/helper/helper_generator_spec.rb
+++ b/spec/generators/rspec/helper/helper_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/helper/helper_generator'
 
-
 RSpec.describe Rspec::Generators::HelperGenerator, :type => :generator do
   setup_default_destination
 

--- a/spec/generators/rspec/helper/helper_generator_spec.rb
+++ b/spec/generators/rspec/helper/helper_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/helper/helper_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::HelperGenerator, :type => :generator do
   setup_default_destination

--- a/spec/generators/rspec/install/install_generator_spec.rb
+++ b/spec/generators/rspec/install/install_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/install/install_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::InstallGenerator, :type => :generator do
   def use_active_record_migration

--- a/spec/generators/rspec/install/install_generator_spec.rb
+++ b/spec/generators/rspec/install/install_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/install/install_generator'
 
-
 RSpec.describe Rspec::Generators::InstallGenerator, :type => :generator do
   def use_active_record_migration
     match(/ActiveRecord::Migration\./m)

--- a/spec/generators/rspec/integration/integration_generator_spec.rb
+++ b/spec/generators/rspec/integration/integration_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/integration/integration_generator'
 
-
 RSpec.describe Rspec::Generators::IntegrationGenerator, :type => :generator do
   setup_default_destination
   it_behaves_like "a request spec generator"

--- a/spec/generators/rspec/integration/integration_generator_spec.rb
+++ b/spec/generators/rspec/integration/integration_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/integration/integration_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::IntegrationGenerator, :type => :generator do
   setup_default_destination

--- a/spec/generators/rspec/job/job_generator_spec.rb
+++ b/spec/generators/rspec/job/job_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/job/job_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::JobGenerator, :type => :generator, :skip => !RSpec::Rails::FeatureCheck.has_active_job? do
   setup_default_destination

--- a/spec/generators/rspec/job/job_generator_spec.rb
+++ b/spec/generators/rspec/job/job_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/job/job_generator'
 
-
 RSpec.describe Rspec::Generators::JobGenerator, :type => :generator, :skip => !RSpec::Rails::FeatureCheck.has_active_job? do
   setup_default_destination
 
@@ -14,6 +13,5 @@ RSpec.describe Rspec::Generators::JobGenerator, :type => :generator, :skip => !R
     it { is_expected.to exist }
     it { is_expected.to contain(/require 'rails_helper'/) }
     it { is_expected.to contain(/describe UserJob, #{type_metatag(:job)}/) }
-
   end
 end

--- a/spec/generators/rspec/mailer/mailer_generator_spec.rb
+++ b/spec/generators/rspec/mailer/mailer_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/mailer/mailer_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::MailerGenerator, :type => :generator do
   setup_default_destination

--- a/spec/generators/rspec/mailer/mailer_generator_spec.rb
+++ b/spec/generators/rspec/mailer/mailer_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/mailer/mailer_generator'
 
-
 RSpec.describe Rspec::Generators::MailerGenerator, :type => :generator do
   setup_default_destination
 

--- a/spec/generators/rspec/model/model_generator_spec.rb
+++ b/spec/generators/rspec/model/model_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/model/model_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::ModelGenerator, :type => :generator do
   setup_default_destination

--- a/spec/generators/rspec/model/model_generator_spec.rb
+++ b/spec/generators/rspec/model/model_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/model/model_generator'
 
-
 RSpec.describe Rspec::Generators::ModelGenerator, :type => :generator do
   setup_default_destination
 

--- a/spec/generators/rspec/observer/observer_generator_spec.rb
+++ b/spec/generators/rspec/observer/observer_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/observer/observer_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::ObserverGenerator, :type => :generator do
   setup_default_destination

--- a/spec/generators/rspec/observer/observer_generator_spec.rb
+++ b/spec/generators/rspec/observer/observer_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/observer/observer_generator'
 
-
 RSpec.describe Rspec::Generators::ObserverGenerator, :type => :generator do
   setup_default_destination
 

--- a/spec/generators/rspec/request/request_generator_spec.rb
+++ b/spec/generators/rspec/request/request_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/request/request_generator'
 
-
 RSpec.describe Rspec::Generators::RequestGenerator, :type => :generator do
   setup_default_destination
   it_behaves_like "a request spec generator"

--- a/spec/generators/rspec/request/request_generator_spec.rb
+++ b/spec/generators/rspec/request/request_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/request/request_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::RequestGenerator, :type => :generator do
   setup_default_destination

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/scaffold/scaffold_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
   setup_default_destination

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/scaffold/scaffold_generator'
 
-
 RSpec.describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
   setup_default_destination
 

--- a/spec/generators/rspec/view/view_generator_spec.rb
+++ b/spec/generators/rspec/view/view_generator_spec.rb
@@ -2,7 +2,6 @@ require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/view/view_generator'
 
-
 RSpec.describe Rspec::Generators::ViewGenerator, :type => :generator do
   setup_default_destination
 

--- a/spec/generators/rspec/view/view_generator_spec.rb
+++ b/spec/generators/rspec/view/view_generator_spec.rb
@@ -1,6 +1,7 @@
+require 'generator_helper'
 # Generators are not automatically loaded by Rails
 require 'generators/rspec/view/view_generator'
-require 'support/generators'
+
 
 RSpec.describe Rspec::Generators::ViewGenerator, :type => :generator do
   setup_default_destination

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,13 @@
+require 'rails/all'
+
+module RSpecRails
+  class Application < ::Rails::Application
+    self.config.secret_key_base = 'ASecretString' if config.respond_to? :secret_key_base
+  end
+end
+I18n.enforce_available_locales = true if I18n.respond_to?(:enforce_available_locales)
+
+require 'rspec/support/spec'
+require 'rspec/rails'
+
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}

--- a/spec/rspec/rails/active_model_spec.rb
+++ b/spec/rspec/rails/active_model_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 RSpec.describe "ActiveModel support" do
   around do |ex|
     old_value = RSpec::Mocks.configuration.verify_partial_doubles?

--- a/spec/rspec/rails/active_record_spec.rb
+++ b/spec/rspec/rails/active_record_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 RSpec.describe "ActiveRecord support" do
   around do |ex|
     old_value = RSpec::Mocks.configuration.verify_partial_doubles?

--- a/spec/rspec/rails/assertion_adapter_spec.rb
+++ b/spec/rspec/rails/assertion_adapter_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 
 describe RSpec::Rails::MinitestAssertionAdapter do
   include RSpec::Rails::MinitestAssertionAdapter

--- a/spec/rspec/rails/assertion_delegator_spec.rb
+++ b/spec/rspec/rails/assertion_delegator_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe RSpec::Rails::AssertionDelegator do
   it "provides a module that delegates assertion methods to an isolated class" do

--- a/spec/rspec/rails/assertion_delegator_spec.rb
+++ b/spec/rspec/rails/assertion_delegator_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RSpec::Rails::AssertionDelegator do
   it "provides a module that delegates assertion methods to an isolated class" do

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 require 'rspec/support/spec/in_sub_process'
 
 RSpec.describe "Configuration" do

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 
 class ::ApplicationController
   def self.abstract?; false; end

--- a/spec/rspec/rails/example/feature_example_group_spec.rb
+++ b/spec/rspec/rails/example/feature_example_group_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module RSpec::Rails
   describe FeatureExampleGroup do

--- a/spec/rspec/rails/example/feature_example_group_spec.rb
+++ b/spec/rspec/rails/example/feature_example_group_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 
 module RSpec::Rails
   describe FeatureExampleGroup do

--- a/spec/rspec/rails/example/feature_example_group_spec.rb
+++ b/spec/rspec/rails/example/feature_example_group_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 module RSpec::Rails
   describe FeatureExampleGroup do

--- a/spec/rspec/rails/example/helper_example_group_spec.rb
+++ b/spec/rspec/rails/example/helper_example_group_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 module RSpec::Rails
   describe HelperExampleGroup do

--- a/spec/rspec/rails/example/helper_example_group_spec.rb
+++ b/spec/rspec/rails/example/helper_example_group_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module RSpec::Rails
   describe HelperExampleGroup do

--- a/spec/rspec/rails/example/job_example_group_spec.rb
+++ b/spec/rspec/rails/example/job_example_group_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 
 module RSpec::Rails
   describe JobExampleGroup do

--- a/spec/rspec/rails/example/mailer_example_group_spec.rb
+++ b/spec/rspec/rails/example/mailer_example_group_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 module RSpec::Rails
   describe MailerExampleGroup do

--- a/spec/rspec/rails/example/mailer_example_group_spec.rb
+++ b/spec/rspec/rails/example/mailer_example_group_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module RSpec::Rails
   describe MailerExampleGroup do

--- a/spec/rspec/rails/example/model_example_group_spec.rb
+++ b/spec/rspec/rails/example/model_example_group_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 module RSpec::Rails
   describe ModelExampleGroup do

--- a/spec/rspec/rails/example/model_example_group_spec.rb
+++ b/spec/rspec/rails/example/model_example_group_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module RSpec::Rails
   describe ModelExampleGroup do

--- a/spec/rspec/rails/example/request_example_group_spec.rb
+++ b/spec/rspec/rails/example/request_example_group_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module RSpec::Rails
   describe RequestExampleGroup do

--- a/spec/rspec/rails/example/request_example_group_spec.rb
+++ b/spec/rspec/rails/example/request_example_group_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 module RSpec::Rails
   describe RequestExampleGroup do

--- a/spec/rspec/rails/example/routing_example_group_spec.rb
+++ b/spec/rspec/rails/example/routing_example_group_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module RSpec::Rails
   describe RoutingExampleGroup do

--- a/spec/rspec/rails/example/routing_example_group_spec.rb
+++ b/spec/rspec/rails/example/routing_example_group_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 module RSpec::Rails
   describe RoutingExampleGroup do

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module RSpec::Rails
   describe ViewExampleGroup do

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module RSpec::Rails
   describe ViewExampleGroup do
     it_behaves_like "an rspec-rails example group mixin", :view,

--- a/spec/rspec/rails/fixture_support_spec.rb
+++ b/spec/rspec/rails/fixture_support_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 
 module RSpec::Rails
   describe FixtureSupport do

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 require "rspec/rails/feature_check"
 
 if RSpec::Rails::FeatureCheck.has_active_job?

--- a/spec/rspec/rails/matchers/be_a_new_spec.rb
+++ b/spec/rspec/rails/matchers/be_a_new_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe "be_a_new matcher" do
   include RSpec::Rails::Matchers

--- a/spec/rspec/rails/matchers/be_a_new_spec.rb
+++ b/spec/rspec/rails/matchers/be_a_new_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe "be_a_new matcher" do
   include RSpec::Rails::Matchers

--- a/spec/rspec/rails/matchers/be_new_record_spec.rb
+++ b/spec/rspec/rails/matchers/be_new_record_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe "be_new_record" do
   include RSpec::Rails::Matchers

--- a/spec/rspec/rails/matchers/be_new_record_spec.rb
+++ b/spec/rspec/rails/matchers/be_new_record_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe "be_new_record" do
   include RSpec::Rails::Matchers

--- a/spec/rspec/rails/matchers/be_routable_spec.rb
+++ b/spec/rspec/rails/matchers/be_routable_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 
 describe "be_routable" do
   include RSpec::Rails::Matchers::RoutingMatchers

--- a/spec/rspec/rails/matchers/be_valid_spec.rb
+++ b/spec/rspec/rails/matchers/be_valid_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 require 'rspec/rails/matchers/be_valid'
 
 describe "be_valid matcher" do

--- a/spec/rspec/rails/matchers/has_spec.rb
+++ b/spec/rspec/rails/matchers/has_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 class CollectionOwner < ActiveRecord::Base
   connection.execute <<-SQL

--- a/spec/rspec/rails/matchers/have_http_status_spec.rb
+++ b/spec/rspec/rails/matchers/have_http_status_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe "have_http_status" do
   include RSpec::Rails::Matchers

--- a/spec/rspec/rails/matchers/have_rendered_spec.rb
+++ b/spec/rspec/rails/matchers/have_rendered_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 
 %w[have_rendered render_template].each do |template_expectation|
   describe template_expectation do

--- a/spec/rspec/rails/matchers/redirect_to_spec.rb
+++ b/spec/rspec/rails/matchers/redirect_to_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 require "active_support"
 require "active_support/test_case"
 

--- a/spec/rspec/rails/matchers/relation_match_array_spec.rb
+++ b/spec/rspec/rails/matchers/relation_match_array_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 
 describe "ActiveSupport::Relation match_array matcher" do
   before { MockableModel.delete_all }

--- a/spec/rspec/rails/matchers/route_to_spec.rb
+++ b/spec/rspec/rails/matchers/route_to_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 
 describe "route_to" do
   include RSpec::Rails::Matchers::RoutingMatchers

--- a/spec/rspec/rails/minitest_lifecycle_adapter_spec.rb
+++ b/spec/rspec/rails/minitest_lifecycle_adapter_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RSpec::Rails::MinitestLifecycleAdapter do
   it "invokes minitest lifecycle hooks at the appropriate times" do

--- a/spec/rspec/rails/minitest_lifecycle_adapter_spec.rb
+++ b/spec/rspec/rails/minitest_lifecycle_adapter_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe RSpec::Rails::MinitestLifecycleAdapter do
   it "invokes minitest lifecycle hooks at the appropriate times" do

--- a/spec/rspec/rails/setup_and_teardown_adapter_spec.rb
+++ b/spec/rspec/rails/setup_and_teardown_adapter_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe RSpec::Rails::SetupAndTeardownAdapter do
   describe "::setup" do

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'rails_helper'
 
 module RSpec::Rails
   describe ViewRendering do

--- a/spec/rspec/rails/view_spec_methods_spec.rb
+++ b/spec/rspec/rails/view_spec_methods_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 module RSpec::Rails
   RSpec.describe ViewSpecMethods do
     before do

--- a/spec/rspec/rails_spec.rb
+++ b/spec/rspec/rails_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 require 'rspec/support/spec/library_wide_checks'
 
 RSpec.describe "RSpec::Rails" do

--- a/spec/sanity_check_spec.rb
+++ b/spec/sanity_check_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'pathname'
 
 RSpec.describe "Verify required rspec dependencies" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-
+# This file should only contain the bare minimum required to configure the spec suite
 require 'rspec/support/spec'
 
 class RSpec::Core::ExampleGroup

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,5 @@
-require 'rails/all'
-
-module RSpecRails
-  class Application < ::Rails::Application
-    self.config.secret_key_base = 'ASecretString' if config.respond_to? :secret_key_base
-  end
-end
-I18n.enforce_available_locales = true if I18n.respond_to?(:enforce_available_locales)
-
-require 'rspec/support/spec'
 require 'rspec/rails'
-require 'ammeter/init'
-
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
+require 'rspec/support/spec'
 
 class RSpec::Core::ExampleGroup
   def self.run_all(reporter=nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'rspec/rails'
+
 require 'rspec/support/spec'
 
 class RSpec::Core::ExampleGroup


### PR DESCRIPTION
This splits the spec bootstrapping process into  spec_helper.rb, rails_helper.rb and generator_helper.rb to avoid loading the entire rails stack when not needed.

I mostly picked the low hanging fruit - further optimizations could likely be gained by only loading the needed parts of the rails stack with `config.include_context` and loading files explicitly from spec/support.
