### PR TITLE
add example for single spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ bundle exec rspec spec/models
 
 # Run only specs for AccountsController
 bundle exec rspec spec/controllers/accounts_controller_spec.rb
+
+# Run only spec on line 8 of AccountsController
+bundle exec rspec spec/controllers/accounts_controller_spec.rb:8
 ```
 
 Specs can also be run via `rake spec`, though this command may be slower to


### PR DESCRIPTION
Add example for running a single spec, in the README.md. I think it fits in well there, and is something I didn't realize you could do, until doing a fair bit of digging. 