### PR TITLE
Clarify spec_helper vs rails_helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ details.
 **NOTE:** Generators run in RSpec 3.x will now require `rails_helper` instead
 of `spec_helper`.
 
+### `rails_helper` vs `spec_helper`
+As described [in this stackoverflow answer](http://stackoverflow.com/a/24145760/495637), `spec_helper.rb` is for specs which don't depend on Rails (such as specs for classes in the lib directory). `rails_helper.rb` is for specs which do depend on Rails (in a Rails project, most or all of them).
+
+If you want your non-Rails-dependent specs to enforce that they're non-Rails-dependent, and to run as fast as possible when you run them by themselves, you could require `spec_helper.rb` rather than `rails_helper.rb` in those.
+
+The generated `.rspec` file requires `spec_helper`.
+
 ### Generators
 
 Once installed, RSpec will generate spec files instead of Test::Unit test files

--- a/README.md
+++ b/README.md
@@ -98,12 +98,9 @@ details.
 **NOTE:** Generators run in RSpec 3.x will now require `rails_helper` instead
 of `spec_helper`.
 
-### `rails_helper` vs `spec_helper`
-As described [in this stackoverflow answer](http://stackoverflow.com/a/24145760/495637), `spec_helper.rb` is for specs which don't depend on Rails (such as specs for classes in the lib directory). `rails_helper.rb` is for specs which do depend on Rails (in a Rails project, most or all of them).
-
-If you want your non-Rails-dependent specs to enforce that they're non-Rails-dependent, and to run as fast as possible when you run them by themselves, you could require `spec_helper.rb` rather than `rails_helper.rb` in those.
-
-The generated `.rspec` file requires `spec_helper`.
+#### `rails_helper` vs `spec_helper`
+`spec_helper.rb` is for configuration and extensions you use in every spec, however it does not load Rails. The generated `.rspec` file requires `spec_helper` by default.
+`rails_helper.rb` is for specs which do depend on Rails (in a Rails project, most or all of them). You should explicitly require `rails_helper` at the top of specs that require Rails, or you may adjust your `.rspec` file to require `rails_helper` by default.
 
 ### Generators
 


### PR DESCRIPTION
When greenfielding a new app & coming from older versions of rspec, the out-of-box experience was confusing for me. Since `.rspec` required `spec_helper` I figured I'd be able to simply write specs & run them.  So I was confounded when my first attempt yielded undefined constant `Rails`.

Searching for answers showed I wasn't the only one. Might as well add a short explanation here, as it's not exactly self-explanatory and even the comments in the files don't really spell it out.