### PR TITLE
Add support for ActiveJob argument matchers

### DIFF
--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -209,6 +209,12 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to have_enqueued_job.with(global_id_object)
     end
 
+    it "passes with provided argument matchers" do
+      expect {
+        hello_job.perform_later(42, "David")
+      }.to have_enqueued_job.with(instance_of(Fixnum), instance_of(String))
+    end
+
     it "generates failure message with all provided options" do
       date = Date.tomorrow.noon
       message = "expected to enqueue exactly 2 jobs, with [42], on queue low, at #{date}, but enqueued 0" + \


### PR DESCRIPTION
Hi,

This PR adds support for argument list matcher when matching ActiveJob arguments. Not only it is convenient, but also provides consistency with RSpec's method arguments matcher. Here's an example:

```ruby
expect {
  hello_job.perform_later(42, "David")
}.to have_enqueued_job.with(instance_of(Fixnum), instance_of(String))
```