### PR TITLE
Log a message when view rendering is intercepted

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -61,6 +61,20 @@ module RSpec
           end
         end
 
+        # @private
+        class LogSubscriber < ::ActiveSupport::LogSubscriber
+          def current_example_group
+            RSpec.current_example.example_group
+          end
+
+          def render_template(_event)
+            return if current_example_group.render_views?
+            info("  Template rendering was prevented by rspec-rails. Use `render_views` to verify rendered view contents if necessary.")
+          end
+        end
+
+        LogSubscriber.attach_to(:action_view)
+
         # Delegates all methods to the submitted resolver and for all methods
         # that return a collection of `ActionView::Template` instances, return
         # templates with modified source

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -47,6 +47,14 @@ module RSpec::Rails
           group.render_views true
           expect(group.new.render_views?).to be_truthy
         end
+
+        it "does not log a message that rendering was prevented" do
+          subscriber = RSpec::Rails::ViewRendering::EmptyTemplateResolver::LogSubscriber.new
+          allow(subscriber).to receive(:current_example_group).and_return group
+          expect(subscriber).to_not receive(:info)
+          group.render_views true
+          subscriber.render_template(nil)
+        end
       end
 
       context "with false" do
@@ -59,6 +67,14 @@ module RSpec::Rails
           allow(RSpec.configuration).to receive(:render_views?).and_return true
           group.render_views false
           expect(group.new.render_views?).to be_falsey
+        end
+
+        it "logs a message that rendering was prevented" do
+          subscriber = RSpec::Rails::ViewRendering::EmptyTemplateResolver::LogSubscriber.new
+          allow(subscriber).to receive(:current_example_group).and_return group
+          expect(subscriber).to receive(:info).with /render_views/
+          group.render_views false
+          subscriber.render_template(nil)
         end
       end
 


### PR DESCRIPTION
This is an attempt at #1332, to clarify test logs when view rendering is prevented. Without calling `render_views`, logs currently look something like:

```
I, [2016-10-29T00:26:15.783195 #47754]  INFO -- : Processing by FoosController#show as HTML
I, [2016-10-29T00:26:15.803927 #47754]  INFO -- :   Rendered foos/show.html.haml within layouts/bar (6.3ms)
```

...even though the template was not actually rendered. With this change the logs look like:

```
I, [2016-10-29T00:27:02.543168 #47770]  INFO -- : Processing by FoosController#show as HTML
I, [2016-10-29T00:27:02.551786 #47770]  INFO -- :   Rendered foos/show.html.haml within layouts/bar (0.2ms)
I, [2016-10-29T00:27:02.551891 #47770]  INFO -- :   Template rendering was prevented by rspec-rails. Use `render_views` to verify rendered view contents if necessary.
```

I struggled a little bit with how to write the specs for this. The LogSubscriber is attached and created independent of any examples/groups, but still needs to know the current example group's `render_views?` to decide whether or not to log the message, though when `rspec-rails` specs are running the current example is in the `rspec-rails` suite and not a controller spec. I'd be happy to take a different approach if someone points me in the right direction.
