### PR TITLE
Add ruby 2.3.1 in Travis-CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script: "script/run_build 2>&1"
 rvm:
   - 1.8.7
   - 2.3.0
+  - 2.3.1
   - 2.2
   - 2.1
   - 2.0.0
@@ -63,6 +64,10 @@ matrix:
       env: RAILS_VERSION=master
     - rvm: 2.3.0
       env: RAILS_VERSION=5.0.0
+    - rvm: 2.3.1
+      env: RAILS_VERSION=master
+    - rvm: 2.3.1
+      env: RAILS_VERSION=5.0.0
   exclude:
     # 3.0.x is not supported on MRI 2.0+
     - rvm: 2.0.0
@@ -72,6 +77,8 @@ matrix:
     - rvm: 2.2
       env: RAILS_VERSION='~> 3.0.20'
     - rvm: 2.3.0
+      env: RAILS_VERSION='~> 3.0.20'
+    - rvm: 2.3.1
       env: RAILS_VERSION='~> 3.0.20'
     # 4.x is not supported on MRI ruby-1.8.7 or 1.9.2
     - rvm: 1.8.7
@@ -103,10 +110,14 @@ matrix:
       env: RAILS_VERSION='~> 3.1.12'
     - rvm: 2.3.0
       env: RAILS_VERSION='~> 3.1.12'
+    - rvm: 2.3.1
+      env: RAILS_VERSION='~> 3.1.12'
   allow_failures:
     - rvm: 2.2.2
       env: RAILS_VERSION=master
     - rvm: 2.3.0
+      env: RAILS_VERSION=master
+    - rvm: 2.3.1
       env: RAILS_VERSION=master
   fast_finish: true
 


### PR DESCRIPTION
Hey folks, 

Since the latest stable version of Ruby is 2.3.1, I would love to have them tested against, too. 😃 

Thanks for doing an awesome job on this project. <3

Cheers