### PR TITLE
Get rspec-rails running on Rails 5-0-stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,11 +58,11 @@ matrix:
     - rvm: 2.2.2
       env: RAILS_VERSION=master
     - rvm: 2.2.2
-      env: RAILS_VERSION=5.0.0
+      env: RAILS_VERSION=5-0-stable
     - rvm: 2.3.1
       env: RAILS_VERSION=master
     - rvm: 2.3.1
-      env: RAILS_VERSION=5.0.0
+      env: RAILS_VERSION=5-0-stable
   exclude:
     # 3.0.x is not supported on MRI 2.0+
     - rvm: 2.0.0

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -8,6 +8,7 @@ module RSpec
     class Railtie < ::Rails::Railtie
       # As of Rails 5.1.0 you can register directories to work with `rake notes`
       if ::Rails::VERSION::STRING >= '5.1'
+        require 'rails/source_annotation_extractor'
         SourceAnnotationExtractor::Annotation.register_directories("spec")
       end
       # Rails-3.0.1 requires config.app_generators instead of 3.0.0's config.generators


### PR DESCRIPTION
- Added missing require
- Change Travis CI configuration to use `5-0-stable` instead of `5.0.0`, since new `5.0.x` versions (for example, 5.0.1) will be landing soon

cc @samphippen 