### PR TITLE
Add relish to gemfile to publish to relish

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'yard', '~> 0.8.7', :require => false
 group :documentation do
   gem 'redcarpet',     '2.3.0'
   gem 'github-markup', '1.0.0'
+  gem 'relish'
 end
 
 platforms :jruby do


### PR DESCRIPTION
The rake task for publishing to relish doesn't work for me without this (as the install is isolated I guess?) /cc @myronmarston 