### PR TITLE
Default rails install to the latest version

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -25,7 +25,7 @@ when nil, false, ""
     # Rails 4+ requires 1.9.3+, so on earlier versions default to the last 3.x release.
     gem "rails", "~> 3.2.17"
   else
-    gem "rails", "~> 4.2.0"
+    gem "rails", "~> 5.0.0"
   end
 else
   gem "rails", version


### PR DESCRIPTION
This will fix the remaining rspec-rails failures for 2.4.0 on the other repos, but doesn't actually affect the travis build for rspec-rails (as we always specify a version). /cc @samphippen @myronmarston 