### PR TITLE
Remove redundant expectation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,8 @@ require "rails_helper"
 
 RSpec.describe PostsController, :type => :controller do
   describe "GET #index" do
-    it "responds successfully with an HTTP 200 status code" do
+    it "responds with an HTTP 200 status code" do
       get :index
-      expect(response).to be_success
       expect(response).to have_http_status(200)
     end
 


### PR DESCRIPTION
The `be_success` checks that the HTTP status is between 200 and 299, but
the next line already checks that it is 200.