### PR TITLE
Consistently use `record.new_record?`.

### DIFF
--- a/lib/rspec/rails/matchers/be_a_new.rb
+++ b/lib/rspec/rails/matchers/be_a_new.rb
@@ -61,8 +61,8 @@ module RSpec
       end
 
       # @api public
-      # Passes if actual is an instance of `model_class` and returns `false` for
-      # `persisted?`. Typically used to specify instance variables assigned to
+      # Passes if actual is an instance of `model_class` and returns `true` for
+      # `new_record?`. Typically used to specify instance variables assigned to
       # views by controller actions
       #
       # Use the `with` method to specify the specific attributes to match on the

--- a/lib/rspec/rails/matchers/be_new_record.rb
+++ b/lib/rspec/rails/matchers/be_new_record.rb
@@ -4,7 +4,7 @@ module RSpec
       # @private
       class BeANewRecord < RSpec::Matchers::BuiltIn::BaseMatcher
         def matches?(actual)
-          !actual.persisted?
+          actual.new_record?
         end
 
         def failure_message
@@ -17,7 +17,7 @@ module RSpec
       end
 
       # @api public
-      # Passes if actual returns `false` for `persisted?`.
+      # Passes if actual returns `true` for `new_record?`.
       #
       # @example
       #     get :new

--- a/spec/rspec/rails/matchers/be_new_record_spec.rb
+++ b/spec/rspec/rails/matchers/be_new_record_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 describe "be_new_record" do
-  context "un-persisted record" do
-    let(:record) { double('record', :persisted? => false) }
+  context "a new record" do
+    let(:record) { double('record', :new_record? => true) }
 
     it "passes" do
       expect(record).to be_new_record
@@ -15,8 +15,8 @@ describe "be_new_record" do
     end
   end
 
-  context "persisted record" do
-    let(:record) { double('record', :persisted? => true) }
+  context "a persisted record" do
+    let(:record) { double('record', :new_record? => false) }
 
     it "fails" do
       expect(record).not_to be_new_record


### PR DESCRIPTION
`be_a_new(model_class)` and `be_new_record` were
inconsistent in that one of them checked `!persisted?`
and one checked `new_record?`. The docs also said that
both checked `!persisted?` even only one did.

This changes both to use `new_record?` and to be documented
as such.

Fixes #1801.

Note that I'm not sure this is the right fix but I figured I'd offer to get the conversation on #1801 rolling.  [My book](https://pragprog.com/book/rspec3/effective-testing-with-rspec-3) has an rspec-rails cheat sheet and documents the current inconsistency which is confusing some readers, so I'd like to get this fixed by publication if possible.

/cc @rspec/rspec