### PR TITLE
Allow use of composable matchers inside be_a_new#with

### DIFF
--- a/lib/rspec/rails/matchers/be_a_new.rb
+++ b/lib/rspec/rails/matchers/be_a_new.rb
@@ -49,7 +49,7 @@ module RSpec
 
         def attributes_match?(actual)
           attributes.stringify_keys.all? do |key, value|
-            actual.attributes[key].eql?(value)
+            actual.attributes[key].eql?(value) || (value.respond_to?(:expected, true) && actual.attributes[key].include?(value.expected))
           end
         end
 

--- a/lib/rspec/rails/matchers/be_a_new.rb
+++ b/lib/rspec/rails/matchers/be_a_new.rb
@@ -32,10 +32,11 @@ module RSpec
               message << "expected #{actual.inspect} to be a new #{expected.inspect}"
             end
             unless attributes_match?(actual)
+              describe_unmatched_attributes = surface_descriptions_in(unmatched_attributes)
               if unmatched_attributes.size > 1
-                message << "attributes #{unmatched_attributes.inspect} were not set on #{actual.inspect}"
+                message << "attributes #{describe_unmatched_attributes.inspect} were not set on #{actual.inspect}"
               else
-                message << "attribute #{unmatched_attributes.inspect} was not set on #{actual.inspect}"
+                message << "attribute #{describe_unmatched_attributes.inspect} was not set on #{actual.inspect}"
               end
             end
           end.join(' and ')

--- a/lib/rspec/rails/matchers/be_a_new.rb
+++ b/lib/rspec/rails/matchers/be_a_new.rb
@@ -49,13 +49,13 @@ module RSpec
 
         def attributes_match?(actual)
           attributes.stringify_keys.all? do |key, value|
-            actual.attributes[key].eql?(value) || (value.respond_to?(:expected, true) && actual.attributes[key].include?(value.expected))
+            values_match?(value, actual.attributes[key])
           end
         end
 
         def unmatched_attributes
           attributes.stringify_keys.reject do |key, value|
-            actual.attributes[key].eql?(value)
+            values_match?(value, actual.attributes[key])
           end
         end
       end

--- a/spec/rspec/rails/matchers/be_a_new_spec.rb
+++ b/spec/rspec/rails/matchers/be_a_new_spec.rb
@@ -69,7 +69,7 @@ describe "be_a_new matcher" do
         context "one attribute is a composable matcher" do
           it "passes" do
             expect(record).to be_a_new(record.class).with(
-              :foo => a_string_matching("foo"))
+              :foo => a_string_including("foo"))
           end
 
           it "fails" do
@@ -111,8 +111,7 @@ describe "be_a_new matcher" do
                   :bar => a_string_matching("barn")
                 )
               }.to raise_error {|e|
-                expect(e.message).to match(/attributes \{.*\} were not set on #{Regexp.escape record.inspect}/)
-                expect(e.message).to match(/@expected="foo"/)
+                expect(e.message).to match(/attribute \{.*\} was not set on #{Regexp.escape record.inspect}/)
                 expect(e.message).to match(/@expected="barn"/)
               }
             end

--- a/spec/rspec/rails/matchers/be_a_new_spec.rb
+++ b/spec/rspec/rails/matchers/be_a_new_spec.rb
@@ -65,6 +65,61 @@ describe "be_a_new matcher" do
         end
       end
 
+      context "with composable matchers" do
+        context "one attribute is a composable matcher" do
+          it "passes" do
+            expect(record).to be_a_new(record.class).with(
+              :foo => a_string_matching("foo"))
+          end
+
+          it "fails" do
+            expect {
+              expect(record).to be_a_new(record.class).with(
+                :foo => a_string_matching("bar"))
+            }.to raise_error{|e|
+              expect(e.message).to match(/attribute \{.*\} was not set on #{Regexp.escape record.inspect}/)
+              expect(e.message).to match(/@expected="bar"/)
+            }
+          end
+          context "matcher is wrong type" do
+            it "fails" do
+              expect {
+                expect(record).to be_a_new(record.class).with(
+                  :foo => a_hash_including({:no_foo => "foo"}))
+              }.to raise_error {|e|
+                  expect(e.message).to eq("no implicit conversion of Hash into String").or eq("can't convert Hash into String")
+              }
+            end
+          end
+        end
+
+        context "two attributes are composable matchers" do
+          context "both matchers present in actual" do
+            it "passes" do
+              expect(record).to be_a_new(record.class).with(
+                :foo => a_string_matching("foo"),
+                :bar => a_string_matching("bar")
+              )
+            end
+          end
+
+          context "only one matcher present in actual" do
+            it "fails" do
+              expect {
+                expect(record).to be_a_new(record.class).with(
+                  :foo => a_string_matching("foo"),
+                  :bar => a_string_matching("barn")
+                )
+              }.to raise_error {|e|
+                expect(e.message).to match(/attributes \{.*\} were not set on #{Regexp.escape record.inspect}/)
+                expect(e.message).to match(/@expected="foo"/)
+                expect(e.message).to match(/@expected="barn"/)
+              }
+            end
+          end
+        end
+      end
+
       context "no attributes same" do
         it "fails" do
           expect {

--- a/spec/rspec/rails/matchers/be_a_new_spec.rb
+++ b/spec/rspec/rails/matchers/be_a_new_spec.rb
@@ -76,11 +76,9 @@ describe "be_a_new matcher" do
             expect {
               expect(record).to be_a_new(record.class).with(
                 :foo => a_string_matching("bar"))
-            }.to raise_error{|e|
-              expect(e.message).to match(/attribute \{.*\} was not set on #{Regexp.escape record.inspect}/)
-              expect(e.message).to match(/@expected="bar"/)
-            }
+            }.to raise_error("attribute {\"foo\"=>(a string matching \"bar\")} was not set on #{record.inspect}")
           end
+
           context "matcher is wrong type" do
             it "fails" do
               expect {
@@ -110,10 +108,7 @@ describe "be_a_new matcher" do
                   :foo => a_string_matching("foo"),
                   :bar => a_string_matching("barn")
                 )
-              }.to raise_error {|e|
-                expect(e.message).to match(/attribute \{.*\} was not set on #{Regexp.escape record.inspect}/)
-                expect(e.message).to match(/@expected="barn"/)
-              }
+              }.to raise_error("attribute {\"bar\"=>(a string matching \"barn\")} was not set on #{record.inspect}")
             end
           end
         end


### PR DESCRIPTION
The be_a_new(model_class).with(attributes) did not allow the use of composable matchers inside the with method.

Fixes the third and final item in issue [#1801](https://github.com/rspec/rspec-rails/issues/1801).

This appears to be working as expected per my discussion with @myronmarston in the issue thread but I am, of course, open to feedback.