### PR TITLE
Fixed AJ job name in generated error message

### DIFF
--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -129,7 +129,7 @@ module RSpec
             msg_parts << "on queue #{job[:queue]}" if job[:queue]
             msg_parts << "at #{Time.at(job[:at])}" if job[:at]
 
-            "#{job[:job].class.name} job".tap do |msg|
+            "#{job[:job].name} job".tap do |msg|
               msg << " #{msg_parts.join(', ')}" if msg_parts.any?
             end
           end

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
   let(:heavy_lifting_job) do
     Class.new(ActiveJob::Base) do
       def perform; end
+      def self.name; "HeavyLiftingJob"; end
     end
   end
 
@@ -45,12 +46,14 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
     Class.new(ActiveJob::Base) do
       def perform(*)
       end
+      def self.name; "HelloJob"; end
     end
   end
 
   let(:logging_job) do
     Class.new(ActiveJob::Base) do
       def perform; end
+      def self.name; "LoggingJob"; end
     end
   end
 
@@ -217,7 +220,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       date = Date.tomorrow.noon
       message = "expected to enqueue exactly 2 jobs, with [42], on queue low, at #{date}, but enqueued 0" + \
                 "\nQueued jobs:" + \
-                "\n  Class job with [1], on queue default"
+                "\n  HelloJob job with [1], on queue default"
 
       expect {
         expect {


### PR DESCRIPTION
It was not caught before because of no class name for the anonymous class.