### PR TITLE
Correct return value of `path_for`

### DIFF
--- a/lib/rspec/rails/view_path_builder.rb
+++ b/lib/rspec/rails/view_path_builder.rb
@@ -18,7 +18,7 @@ module RSpec
       # @example
       #     # path cannot be built because the params are missing a required element (:id)
       #     view_path_builder.path_for({ :controller => 'posts', :action => 'delete' })
-      #     # => nil
+      #     # => ActionController::UrlGenerationError: No route matches {:action=>"delete", :controller=>"posts"}
       def path_for(path_params)
         url_for(path_params.merge(:only_path => true))
       rescue => e


### PR DESCRIPTION
Method `ViewPathBuilder#path_for` is actually returning correct url or exception error message.

It's `nil` in the documentation, guess people forgot this when working on #1402. Correcting now.
