### PR TITLE
Fix undefined method `example_group' for nil & NoMethodError: render_views? for feature specs

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -77,8 +77,6 @@ module RSpec
           end
         end
 
-        LogSubscriber.attach_to(:action_view)
-
         # Delegates all methods to the submitted resolver and for all methods
         # that return a collection of `ActionView::Template` instances, return
         # templates with modified source
@@ -150,6 +148,9 @@ module RSpec
       end
 
       included do
+        # Make sure to log when template rendering was prevented by rspec-rails
+        EmptyTemplateResolver::LogSubscriber.attach_to(:action_view)
+
         before do
           unless render_views?
             @_original_path_set = controller.class.view_paths

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -64,12 +64,16 @@ module RSpec
         # @private
         class LogSubscriber < ::ActiveSupport::LogSubscriber
           def current_example_group
-            RSpec.current_example.example_group
+            # When running feature specs current_example can be nil if the subscriber runs in a different context
+            # than the specs themselves. E.g. in a capybara thread.
+            RSpec.current_example.try!(:example_group)
           end
 
           def render_template(_event)
-            return if current_example_group.render_views?
-            info("  Template rendering was prevented by rspec-rails. Use `render_views` to verify rendered view contents if necessary.")
+            example_group = current_example_group
+            if example_group.respond_to?(:render_views?) && !example_group.render_views?
+              info("  Template rendering was prevented by rspec-rails. Use `render_views` to verify rendered view contents if necessary.")
+            end
           end
         end
 

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -183,7 +183,7 @@ module RSpec::Rails
         ActiveSupport::LogSubscriber.logger
       end
 
-      pending 'does not cause an error' do
+      it 'does not cause an error' do
         expect(logger).not_to receive(:error).with(a_string_starting_with('Could not log "render_template.action_view" event.'))
         view.render(body: 'foo')
       end


### PR DESCRIPTION
This is my stab at issue #1800.

In my case the `ViewRenderer` code that was added with PR #1732 was triggered via the capybara webdriver and `RSpec.current_example` is nil then causing the error in the title. @yujinakayama's spec repro in #1818 points to the cause being that `FeatureExampleGroup` doesn't include `RSpec::Rails::ViewRendering` while `ControllerExampleGroup` does.

This commit makes the tests in PR #1818 pass (via the `respond_to?`) and running the whole rspec-rails suite only caused bundler errors for me (I tweaked the gemspec for local gem development). Using this local commit also got rid of loads of errors (those from the title) when running feature specs in my own project.

I have to say that this is my very first experience with RSpec code and that I just deemed the `included` block to be a good place to do this. Bear with me, if I forgot something.