### PR TITLE
Fix noisy log error

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -63,12 +63,15 @@ module RSpec
 
         # @private
         class LogSubscriber < ::ActiveSupport::LogSubscriber
-          def current_example_group
-            RSpec.current_example.example_group
+          def prevent_view_rendering?
+            RSpec.current_example &&
+              RSpec.current_example.example_group &&
+              RSpec.current_example.example_group.respond_to?(:render_views?) &&
+              !RSpec.current_example.example_group.render_views?
           end
 
           def render_template(_event)
-            return if current_example_group.render_views?
+            return unless prevent_view_rendering?
             info("  Template rendering was prevented by rspec-rails. Use `render_views` to verify rendered view contents if necessary.")
           end
         end

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -61,23 +61,6 @@ module RSpec
           end
         end
 
-        # @private
-        class LogSubscriber < ::ActiveSupport::LogSubscriber
-          def prevent_view_rendering?
-            RSpec.current_example &&
-              RSpec.current_example.example_group &&
-              RSpec.current_example.example_group.respond_to?(:render_views?) &&
-              !RSpec.current_example.example_group.render_views?
-          end
-
-          def render_template(_event)
-            return unless prevent_view_rendering?
-            info("  Template rendering was prevented by rspec-rails. Use `render_views` to verify rendered view contents if necessary.")
-          end
-        end
-
-        LogSubscriber.attach_to(:action_view)
-
         # Delegates all methods to the submitted resolver and for all methods
         # that return a collection of `ActionView::Template` instances, return
         # templates with modified source
@@ -120,6 +103,8 @@ module RSpec
       # @private
       class EmptyTemplateHandler
         def self.call(_template)
+          ::Rails.logger.info("  Template rendering was prevented by rspec-rails. Use `render_views` to verify rendered view contents if necessary.")
+
           %("")
         end
       end

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -47,14 +47,6 @@ module RSpec::Rails
           group.render_views true
           expect(group.new.render_views?).to be_truthy
         end
-
-        it "does not log a message that rendering was prevented" do
-          subscriber = RSpec::Rails::ViewRendering::EmptyTemplateResolver::LogSubscriber.new
-          allow(subscriber).to receive(:current_example_group).and_return group
-          expect(subscriber).to_not receive(:info)
-          group.render_views true
-          subscriber.render_template(nil)
-        end
       end
 
       context "with false" do
@@ -67,14 +59,6 @@ module RSpec::Rails
           allow(RSpec.configuration).to receive(:render_views?).and_return true
           group.render_views false
           expect(group.new.render_views?).to be_falsey
-        end
-
-        it "logs a message that rendering was prevented" do
-          subscriber = RSpec::Rails::ViewRendering::EmptyTemplateResolver::LogSubscriber.new
-          allow(subscriber).to receive(:prevent_view_rendering?).and_return(true)
-          expect(subscriber).to receive(:info).with(/render_views/)
-          group.render_views false
-          subscriber.render_template(nil)
         end
       end
 

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -71,8 +71,8 @@ module RSpec::Rails
 
         it "logs a message that rendering was prevented" do
           subscriber = RSpec::Rails::ViewRendering::EmptyTemplateResolver::LogSubscriber.new
-          allow(subscriber).to receive(:current_example_group).and_return group
-          expect(subscriber).to receive(:info).with /render_views/
+          allow(subscriber).to receive(:prevent_view_rendering?).and_return(true)
+          expect(subscriber).to receive(:info).with(/render_views/)
           group.render_views false
           subscriber.render_template(nil)
         end


### PR DESCRIPTION
We've been seeing this error in our test logs:

    Could not log "render_template.action_view" event.
    NoMethodError: undefined method `example_group' for nil:NilClass
    .../rspec-rails-3.6.0/lib/rspec/rails/view_rendering.rb:67:in `current_example_group'
    .../rspec-rails-3.6.0/lib/rspec/rails/view_rendering.rb:71:in `render_template'
    ...

This is while running an rspec rails feature spec using capybara, so this is a separate thread running webrick. This was also during a before block. In any case, this should probably fail gracefully when there is no example.

While updating this code I got an "ExampleGroup doesn't respond to render_views?", so built in that case too.