### PR TITLE
Add to render_template docs: specify that a request renders a given layout

### DIFF
--- a/features/matchers/render_template_matcher.feature
+++ b/features/matchers/render_template_matcher.feature
@@ -1,7 +1,7 @@
 Feature: render_template matcher
 
   The `render_template` matcher is used to specify that a request renders a
-  given template.  It delegates to
+  given template or layout.  It delegates to
   [`assert_template`](http://api.rubyonrails.org/classes/ActionController/TemplateAssertions.html#method-i-assert_template)
 
   It is available in controller specs (spec/controllers) and request
@@ -26,6 +26,28 @@ Feature: render_template matcher
 
           it "does not render a different template" do
             expect(subject).to_not render_template("gadgets/show")
+          end
+        end
+      end
+      """
+    When I run `rspec spec/controllers/gadgets_spec.rb`
+    Then the examples should all pass
+
+  Scenario: specify that a request renders a given layout
+    Given a file named "spec/controllers/gadgets_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe GadgetsController do
+        describe "GET #index" do
+          subject { get :index }
+
+          it "renders the guest layout" do
+            expect(subject).to render_template("layouts/guest")
+          end
+
+          it "does not render a different layout" do
+            expect(subject).to_not render_template("layouts/admin")
           end
         end
       end


### PR DESCRIPTION
Given that render_template can be used to assert that a specific layout was rendered, as in `expect(subject).to render_template("layouts/guest")`, this PR adds that to the docs. 

This closes #1836.