### PR TITLE
Only configure RSpec::Mocks if it is fully loaded

### DIFF
--- a/lib/rspec/rails/active_record.rb
+++ b/lib/rspec/rails/active_record.rb
@@ -7,7 +7,7 @@ module RSpec
       def self.initialize_activerecord_configuration(config)
         config.before :suite do
           # This allows dynamic columns etc to be used on ActiveRecord models when creating instance_doubles
-          if defined?(ActiveRecord) && defined?(ActiveRecord::Base) && defined?(::RSpec::Mocks)
+          if defined?(ActiveRecord) && defined?(ActiveRecord::Base) && defined?(::RSpec::Mocks) && (::RSpec::Mocks.respond_to?(:configuration))
             ::RSpec::Mocks.configuration.when_declaring_verifying_double do |possible_model|
               target = possible_model.target
 


### PR DESCRIPTION
It's possible for the `::RSpec::Mocks` constant to exist, but for it not to have the `configuration` method present. This can happen if another library has required some files from _within_ the `rspec/mocks` library, but nothing else has fully loaded it.

For a concrete example, see https://github.com/krisleech/wisper-rspec/issues/21

While allowing external libraries to use parts of this one might not be something that's explicitly supported, we can avoid some unexpected exceptions by adding a little extra check to our detection of whether or not the mocking library is loaded.

I couldn't see anywhere appropriate to add a new spec for this, but the change is fairly minor so hopefully that's OK. If not, I'd be happy to add a new spec if you have some pointers about where it should it.