### PR TITLE
Pin byebug to '~> 9.0.6' for ruby 2.0.

### DIFF
--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -20,6 +20,7 @@ in_root do
   gsub_file 'Gemfile', /^.*\bgem 'rails.*$/, ''
   gsub_file "Gemfile", /.*web-console.*/, ''
   gsub_file "Gemfile", /.*debugger.*/, ''
+  gsub_file "Gemfile", /.*byebug.*/, "gem 'byebug', '~> 9.0.6'"
 
   if Rails::VERSION::STRING >= '5.0.0'
     append_to_file('Gemfile', "gem 'rails-controller-testing', :git => 'https://github.com/rails/rails-controller-testing'\n")


### PR DESCRIPTION
Byebug `9.1.0` released pinned to ruby 2.2. We need to support ruby 2.0,
so here we add a gsub to pin to byebug versions that support 2.0.