### PR TITLE
Update bundler before travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ cache: bundler
 
 bundler_args: "--binstubs --without documentation --path ../bundle --retry=3 --jobs=3"
 
-before_install: "script/clone_all_rspec_repos"
+before_install:
+  - script/clone_all_rspec_repos
+  - gem update bundler
 
 before_script:
   # Rails 4.x complains with a bundler rails binstub in PROJECT_ROOT/bin/


### PR DESCRIPTION
Latest builds on travis are broken because of bundler is too old and contains some issues.

Refs: https://travis-ci.org/rspec/rspec-rails/jobs/273646937 https://github.com/travis-ci/travis-ci/issues/3531