### PR TITLE
Make sure that negative matcher fails on multiple enqueues of the same kind

### DIFF
--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -106,6 +106,34 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 2/)
     end
 
+
+    it "shows correct fail message when negated with at_least matcher" do
+      expect {
+        expect {
+          heavy_lifting_job.perform_later
+          heavy_lifting_job.perform_later
+        }.not_to have_enqueued_job.at_least(2)
+      }.to raise_error(/expected not to enqueue at least 2 jobs, but enqueued 2/)
+    end
+
+    it "shows correct fail message when negated with at_most matcher" do
+      expect {
+        expect {
+          heavy_lifting_job.perform_later
+          heavy_lifting_job.perform_later
+        }.not_to have_enqueued_job.at_most(2)
+      }.to raise_error(/expected not to enqueue at most 2 jobs, but enqueued 2/)
+    end
+
+    it "fails when too many jobs enqueued in negated form" do
+      expect {
+        expect {
+          heavy_lifting_job.perform_later
+          heavy_lifting_job.perform_later
+        }.not_to have_enqueued_job.exactly(2)
+      }.to raise_error(/expected not to enqueue exactly 2 jobs, but enqueued 2/)
+    end
+
     it "reports correct number in fail error message" do
       heavy_lifting_job.perform_later
       expect {

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
     it "fails when negated and job is enqueued" do
       expect {
         expect { heavy_lifting_job.perform_later }.not_to have_enqueued_job
-      }.to raise_error(/expected not to enqueue exactly 1 jobs, but enqueued 1/)
+      }.to raise_error(/expected not to enqueue job, but enqueued 1/)
     end
 
     it "passes with job name" do
@@ -132,6 +132,22 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
         logging_job.perform_later
         heavy_lifting_job.perform_later
       }.to have_enqueued_job(hello_job).and have_enqueued_job(logging_job)
+    end
+
+    it "passes with multiple jobs of the same kind and different expected count when negated" do
+      expect {
+        hello_job.perform_later
+        hello_job.perform_later
+      }.not_to have_enqueued_job.once
+    end
+
+    it "fails with multiple same type jobs when negated" do
+      expect {
+        expect {
+          hello_job.perform_later
+          hello_job.perform_later
+        }.not_to have_enqueued_job
+      }.to raise_error(/expected not to enqueue job, but enqueued 2/)
     end
 
     it "passes with :once count" do


### PR DESCRIPTION
Fix for #1870. 

Without this fix test passes for given example
```
expect {
  job.perform_later
  job.perform_later
}.not_to have_enqueued_job
```

This happens because by default we check using options `:exactly, 1`. That is, under the hood 
`}.not_to have_enqueued_job`
is same as
`.not_to have_enqueued_job.exactly(:once)`. 

In negative examples this is incorrect - we should use `:exaclty, 0` instead. 
Negative example 
`.not_to have_enqueued_job`
 should be equal to positive example with conditions
`.to have_enqueued_job.exactly(0)`