### PR TITLE
Fix #1865 by memoizing generated method name.

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -35,7 +35,7 @@ if ActionPack::VERSION::STRING >= "5.1"
 
         # @private
         def method_name
-          [
+          @method_name ||= [
             self.class.name.underscore,
             RSpec.current_example.description.underscore,
             rand(1000)


### PR DESCRIPTION
The problem here is that rails calls `#method_name` on the example a
number of times in order to correctly generate the screenshot and then
manipulate it. Given that we were randomising the integer that was
generated on every call, this didn't work.

This patch solves the problem by memoizing the generated method name so
that the screenshot path is generated once per example and then
correctly accessed on subsequent method calls.