### PR TITLE
Fixed documentation for controller specs

### DIFF
--- a/features/controller_specs/controller_spec.feature
+++ b/features/controller_specs/controller_spec.feature
@@ -43,12 +43,12 @@ Feature: controller spec
       RSpec.describe WidgetsController, :type => :controller do
         describe "responds to" do
           it "responds to html by default" do
-            post :create, { :widget => { :name => "Any Name" } }
+            post :create, :params => { :widget => { :name => "Any Name" } }
             expect(response.content_type).to eq "text/html"
           end
 
           it "responds to custom formats when provided in the params" do
-            post :create, { :widget => { :name => "Any Name" }, :format => :json }
+            post :create, :params => { :widget => { :name => "Any Name" } }, :format => :json
             expect(response.content_type).to eq "application/json"
           end
         end


### PR DESCRIPTION
Now it's mandatory to explicitly send `params` in the keyword arguments.