### PR TITLE
Make requiring order of `spec/support/**/*.rb` to be fixed

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+# Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 <% if RSpec::Rails::FeatureCheck.can_maintain_test_schema? -%>
 # Checks for pending migrations and applies them before tests are run.


### PR DESCRIPTION
Dir.glob is not guaranteed order.

This change may help who faced the problem about test success and failure across some environments.