### PR TITLE
Check for puma and capybara when defining system tests

### DIFF
--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -49,17 +49,7 @@ module RSpec
       config.include RSpec::Rails::ViewExampleGroup,       :type => :view
       config.include RSpec::Rails::FeatureExampleGroup,    :type => :feature
       config.include RSpec::Rails::Matchers
-
-      if ActionPack::VERSION::STRING >= "5.1"
-        begin
-          require 'puma'
-          require 'capybara'
-          config.include RSpec::Rails::SystemExampleGroup, :type => :system
-        # rubocop:disable Lint/HandleExceptions
-        rescue LoadError
-          # rubocop:enable Lint/HandleExceptions
-        end
-      end
+      config.include RSpec::Rails::SystemExampleGroup, :type => :system
     end
 
     # @private

--- a/lib/rspec/rails/example.rb
+++ b/lib/rspec/rails/example.rb
@@ -8,13 +8,4 @@ require 'rspec/rails/example/routing_example_group'
 require 'rspec/rails/example/model_example_group'
 require 'rspec/rails/example/job_example_group'
 require 'rspec/rails/example/feature_example_group'
-if ActionPack::VERSION::STRING >= "5.1"
-  begin
-    require 'puma'
-    require 'capybara'
-    require 'rspec/rails/example/system_example_group'
-  # rubocop:disable Lint/HandleExceptions
-  rescue LoadError
-    # rubocop:enable Lint/HandleExceptions
-  end
-end
+require 'rspec/rails/example/system_example_group'

--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -1,4 +1,30 @@
-if ActionPack::VERSION::STRING >= "5.1"
+can_load_system_tests = false
+begin
+  require 'puma'
+  require 'capybara'
+  can_load_system_tests = ActionPack::VERSION::STRING >= "5.1"
+# rubocop:disable Lint/HandleExceptions
+rescue LoadError
+  # rubocop:enable Lint/HandleExceptions
+end
+
+if !can_load_system_tests
+  module RSpec
+    module Rails
+      module SystemExampleGroup
+        extend ActiveSupport::Concern
+
+        included do
+          abort """
+            System test integration requires Rails >= 5.1 and has a hard
+            dependency on `puma` and `capybara`, please add these to your
+            Gemfile before attempting to use system tests.
+          """
+        end
+      end
+    end
+  end
+else
   require 'action_dispatch/system_test_case'
   module RSpec
     module Rails

--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -2,7 +2,10 @@ can_load_system_tests = false
 begin
   require 'puma'
   require 'capybara'
-  can_load_system_tests = ActionPack::VERSION::STRING >= "5.1"
+  if ActionPack::VERSION::STRING >= "5.1"
+    require 'action_dispatch/system_test_case'
+    can_load_system_tests = true
+  end
 # rubocop:disable Lint/HandleExceptions
 rescue LoadError
   # rubocop:enable Lint/HandleExceptions
@@ -25,7 +28,6 @@ if !can_load_system_tests
     end
   end
 else
-  require 'action_dispatch/system_test_case'
   module RSpec
     module Rails
       # @api public

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 module RSpec::Rails
-  if defined?(SystemExampleGroup)
+  if ActionPack::VERSION::STRING >= "5.1"
     RSpec.describe SystemExampleGroup do
       it_behaves_like "an rspec-rails example group mixin", :system,
         './spec/system/', '.\\spec\\system\\'


### PR DESCRIPTION
Rather than skipping the definition altogether define a fake module that
warns about the dependencies.