### PR TITLE
Delay loading system test integration

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -1,113 +1,96 @@
-can_load_system_tests = false
-begin
-  require 'puma'
-  require 'capybara'
-  if ActionPack::VERSION::STRING >= "5.1"
-    require 'action_dispatch/system_test_case'
-    can_load_system_tests = true
-  end
-# rubocop:disable Lint/HandleExceptions
-rescue LoadError
-  # rubocop:enable Lint/HandleExceptions
-end
+module RSpec
+  module Rails
+    # @api public
+    # Container class for system tests
+    module SystemExampleGroup
+      extend ActiveSupport::Concern
+      include RSpec::Rails::RailsExampleGroup
+      include RSpec::Rails::Matchers::RedirectTo
+      include RSpec::Rails::Matchers::RenderTemplate
+      include ActionDispatch::Integration::Runner
+      include ActionDispatch::Assertions
+      include ActionController::TemplateAssertions
 
-if !can_load_system_tests
-  module RSpec
-    module Rails
-      module SystemExampleGroup
-        extend ActiveSupport::Concern
-
-        included do
-          abort """
-            System test integration requires Rails >= 5.1 and has a hard
-            dependency on `puma` and `capybara`, please add these to your
-            Gemfile before attempting to use system tests.
-          """
+      # @private
+      module BlowAwayAfterTeardownHook
+        # @private
+        def after_teardown
         end
       end
-    end
-  end
-else
-  module RSpec
-    module Rails
-      # @api public
-      # Container class for system tests
-      module SystemExampleGroup
-        extend ActiveSupport::Concern
-        include RSpec::Rails::RailsExampleGroup
-        include ActionDispatch::Integration::Runner
-        include ActionDispatch::Assertions
-        include RSpec::Rails::Matchers::RedirectTo
-        include RSpec::Rails::Matchers::RenderTemplate
-        include ActionController::TemplateAssertions
 
-        include ActionDispatch::IntegrationTest::Behavior
+      # for the SystemTesting Screenshot situation
+      def passed?
+        RSpec.current_example.exception.nil?
+      end
 
-        # @private
-        module BlowAwayAfterTeardownHook
-          # @private
-          def after_teardown
-          end
+      # @private
+      def method_name
+        @method_name ||= [
+          self.class.name.underscore,
+          RSpec.current_example.description.underscore,
+          rand(1000)
+        ].join("_").gsub(/[\/\.:, ]/, "_")
+      end
+
+      # Delegates to `Rails.application`.
+      def app
+        ::Rails.application
+      end
+
+      included do |other|
+        begin
+          require 'capybara'
+          require 'action_dispatch/system_test_case'
+        # rubocop:disable Lint/HandleExceptions
+        rescue LoadError
+          # rubocop:enable Lint/HandleExceptions
+          abort """
+            System test integration requires Rails >= 5.1 and has a hard
+            dependency on a webserver and `capybara`, please add capybara to
+            your Gemfile and configure a webserver (e.g. `Capybara.server =
+            :webrick`) before attempting to use system tests.
+          """.gsub(/[\n\s]+/,' ').strip
         end
 
-        original_after_teardown = ::ActionDispatch::SystemTesting::TestHelpers::SetupAndTeardown.instance_method(:after_teardown)
+        original_after_teardown =
+          ::ActionDispatch::SystemTesting::TestHelpers::SetupAndTeardown.instance_method(:after_teardown)
 
-        include ::ActionDispatch::SystemTesting::TestHelpers::SetupAndTeardown
-        include ::ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper
-        include BlowAwayAfterTeardownHook
+        other.include ActionDispatch::IntegrationTest::Behavior
+        other.include ::ActionDispatch::SystemTesting::TestHelpers::SetupAndTeardown
+        other.include ::ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper
+        other.include BlowAwayAfterTeardownHook
 
-        # for the SystemTesting Screenshot situation
-        def passed?
-          RSpec.current_example.exception.nil?
+        attr_reader :driver
+
+        if ActionDispatch::SystemTesting::Server.respond_to?(:silence_puma=)
+          ActionDispatch::SystemTesting::Server.silence_puma = true
         end
 
-        # @private
-        def method_name
-          @method_name ||= [
-            self.class.name.underscore,
-            RSpec.current_example.description.underscore,
-            rand(1000)
-          ].join("_").gsub(/[\/\.:, ]/, "_")
+        def initialize(*args, &blk)
+          super(*args, &blk)
+          @driver = nil
         end
 
-        # Delegates to `Rails.application`.
-        def app
-          ::Rails.application
+        def driven_by(*args, &blk)
+          @driver = ::ActionDispatch::SystemTestCase.driven_by(*args, &blk).tap(&:use)
         end
 
-        included do
-          attr_reader :driver
+        before do
+          # A user may have already set the driver, so only default if driver
+          # is not set
+          driven_by(:selenium) unless @driver
+          @routes = ::Rails.application.routes
+        end
 
-          if ActionDispatch::SystemTesting::Server.respond_to?(:silence_puma=)
-            ActionDispatch::SystemTesting::Server.silence_puma = true
-          end
-
-          def initialize(*args, &blk)
-            super(*args, &blk)
-            @driver = nil
-          end
-
-          def driven_by(*args, &blk)
-            @driver = ::ActionDispatch::SystemTestCase.driven_by(*args, &blk).tap(&:use)
-          end
-
-          before do
-            # A user may have already set the driver, so only default if driver
-            # is not set
-            driven_by(:selenium) unless @driver
-            @routes = ::Rails.application.routes
-          end
-
-          after do
-            orig_stdout = $stdout
-            $stdout = StringIO.new
-            begin
-              original_after_teardown.bind(self).call
-            ensure
-              myio = $stdout
-              RSpec.current_example.metadata[:extra_failure_lines] = myio.string
-              $stdout = orig_stdout
-            end
+        after do
+          orig_stdout = $stdout
+          $stdout = StringIO.new
+          begin
+            original_after_teardown.bind(self).call
+          ensure
+            myio = $stdout
+            RSpec.current_example.metadata[:extra_failure_lines] = myio.string
+            $stdout = orig_stdout
           end
         end
       end


### PR DESCRIPTION
Delay loading system tests as late as possible in order to allow people who arent using them to not have to turn off puma or other such things. It also enables other webservers to be configured other
than puma which is needed in Rails as of https://github.com/rails/rails/commit/50f697664edf0d2deff22f3f1a1c8e01d54a74ca

This should help people who have issues with puma loading when they're not using system test integration. /cc @myronmarston @samphippen @sj26 