### PR TITLE
Ensure that system test screenshots work for specs that have :aggregate_failures enabled

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -20,7 +20,13 @@ module RSpec
 
       # for the SystemTesting Screenshot situation
       def passed?
-        RSpec.current_example.exception.nil?
+        return false if RSpec.current_example.exception
+        return true unless defined?(::RSpec::Expectations::FailureAggregator)
+
+        failure_notifier = ::RSpec::Support.failure_notifier
+        return true unless failure_notifier.is_a?(::RSpec::Expectations::FailureAggregator)
+
+        failure_notifier.failures.empty? && failure_notifier.other_errors.empty?
       end
 
       # @private


### PR DESCRIPTION
Prior to this PR, if RSpec's `:aggregate_failures` is enabled, a system spec with a failed expectation would not automatically trigger a screenshot as expected.

This is because aggregated failures are not exposed via the typical `RSpec.current_example.exception`. To correctly detect failures when aggregation is enabled, we have to do more work.

This PR works around this problem by using some behind-the-scenes knowledge of how rspec-expectations does the aggregation. Now we reach into the thread-local storage (`RSpec::Support.failure_notifier`) and discover whether there are in fact failures "queued up". If so, we will consider the example to have failed and take a screenshot.

This is the same workaround as used by capybara-screenshot:
https://github.com/mattheworiordan/capybara-screenshot/pull/213