### PR TITLE
Indent example in the request spec docs

### DIFF
--- a/features/request_specs/request_spec.feature
+++ b/features/request_specs/request_spec.feature
@@ -162,8 +162,8 @@ Feature: request spec
     RSpec.describe "Widget management", :type => :request do
 
       it "creates a Widget and redirects to the Widget's page" do
-      headers = { "CONTENT_TYPE" => "application/json" }
-      post "/widgets", :params => '{ "widget": { "name":"My Widget" } }', :headers => headers
+        headers = { "CONTENT_TYPE" => "application/json" }
+        post "/widgets", :params => '{ "widget": { "name":"My Widget" } }', :headers => headers
         expect(response).to redirect_to(assigns(:widget))
       end
 


### PR DESCRIPTION
Just a super minor thing that I noticed when I was perusing the docs at https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec#providing-json-data.