### PR TITLE
Don't load ActionPack and ActionView examples, when they are not available

### DIFF
--- a/lib/rspec/rails/example.rb
+++ b/lib/rspec/rails/example.rb
@@ -1,13 +1,16 @@
 require 'rspec/rails/example/rails_example_group'
-require 'rspec/rails/example/controller_example_group'
-require 'rspec/rails/example/request_example_group'
-require 'rspec/rails/example/helper_example_group'
-require 'rspec/rails/example/view_example_group'
-require 'rspec/rails/example/mailer_example_group'
-require 'rspec/rails/example/routing_example_group'
 require 'rspec/rails/example/model_example_group'
-require 'rspec/rails/example/job_example_group'
 require 'rspec/rails/example/feature_example_group'
-require 'rspec/rails/example/system_example_group'
 require 'rspec/rails/example/channel_example_group'
 require 'rspec/rails/example/mailbox_example_group'
+require 'rspec/rails/example/mailer_example_group' if defined?(ActionMailer)
+require 'rspec/rails/example/job_example_group' if defined?(ActiveJob)
+require 'rspec/rails/example/view_example_group' if defined?(ActionView)
+
+if defined?(ActionPack)
+  require 'rspec/rails/example/controller_example_group'
+  require 'rspec/rails/example/helper_example_group'
+  require 'rspec/rails/example/request_example_group'
+  require 'rspec/rails/example/routing_example_group'
+  require 'rspec/rails/example/system_example_group'
+end

--- a/lib/rspec/rails/example/job_example_group.rb
+++ b/lib/rspec/rails/example/job_example_group.rb
@@ -1,23 +1,9 @@
 module RSpec
   module Rails
-    # @api public
-    # Container module for job spec functionality. It is only available if
-    # ActiveJob has been loaded before it.
+    # Container module for job spec functionality.
     module JobExampleGroup
-      # This blank module is only necessary for YARD processing. It doesn't
-      # handle the conditional `defined?` check below very well.
-    end
-  end
-end
-
-if defined?(ActiveJob)
-  module RSpec
-    module Rails
-      # Container module for job spec functionality.
-      module JobExampleGroup
-        extend ActiveSupport::Concern
-        include RSpec::Rails::RailsExampleGroup
-      end
+      extend ActiveSupport::Concern
+      include RSpec::Rails::RailsExampleGroup
     end
   end
 end

--- a/lib/rspec/rails/example/mailer_example_group.rb
+++ b/lib/rspec/rails/example/mailer_example_group.rb
@@ -1,36 +1,22 @@
 module RSpec
   module Rails
-    # @api public
-    # Container module for mailer spec functionality. It is only available if
-    # ActionMailer has been loaded before it.
+    # Container module for mailer spec functionality.
     module MailerExampleGroup
-      # This blank module is only necessary for YARD processing. It doesn't
-      # handle the conditional `defined?` check below very well.
-    end
-  end
-end
+      extend ActiveSupport::Concern
+      include RSpec::Rails::RailsExampleGroup
+      include ActionMailer::TestCase::Behavior
 
-if defined?(ActionMailer)
-  module RSpec
-    module Rails
-      # Container module for mailer spec functionality.
-      module MailerExampleGroup
-        extend ActiveSupport::Concern
-        include RSpec::Rails::RailsExampleGroup
-        include ActionMailer::TestCase::Behavior
+      included do
+        include ::Rails.application.routes.url_helpers
+        options = ::Rails.configuration.action_mailer.default_url_options
+        options&.each { |key, value| default_url_options[key] = value }
+      end
 
-        included do
-          include ::Rails.application.routes.url_helpers
-          options = ::Rails.configuration.action_mailer.default_url_options
-          options&.each { |key, value| default_url_options[key] = value }
-        end
-
-        # Class-level DSL for mailer specs.
-        module ClassMethods
-          # Alias for `described_class`.
-          def mailer_class
-            described_class
-          end
+      # Class-level DSL for mailer specs.
+      module ClassMethods
+        # Alias for `described_class`.
+        def mailer_class
+          described_class
         end
       end
     end

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -248,14 +248,12 @@ RSpec.describe "Configuration" do
     expect(example).to be_a(RSpec::Rails::FeatureExampleGroup)
   end
 
-  if defined?(ActionMailer)
-    it "metadata `type: :mailer` sets up mailer example groups" do
-      a_mailer_class = Class.new
-      stub_const "SomeMailer", a_mailer_class
-      group = RSpec.describe(SomeMailer, type: :mailer)
-      expect(group.mailer_class).to be(a_mailer_class)
-      expect(group.new).to be_a(RSpec::Rails::MailerExampleGroup)
-    end
+  it "metadata `type: :mailer` sets up mailer example groups" do
+    a_mailer_class = Class.new
+    stub_const "SomeMailer", a_mailer_class
+    group = RSpec.describe(SomeMailer, type: :mailer)
+    expect(group.mailer_class).to be(a_mailer_class)
+    expect(group.new).to be_a(RSpec::Rails::MailerExampleGroup)
   end
 
   it "has a default #file_fixture_path of 'spec/fixtures/files'" do


### PR DESCRIPTION
When I use rails without `action_pack` or `action_view`, `rspec-rails` still  expects them to be both loaded and available. This PR fixes the issue, similar way it's handled for `ActiveJob` or `ActionMailer`

Better to ignore whitespaces when looking on code changes here https://github.com/rspec/rspec-rails/pull/1911/files?w=1 :)