### PR TITLE
Fix failing sanity check spec under Bundler 1.16.0

### DIFF
--- a/spec/sanity_check_spec.rb
+++ b/spec/sanity_check_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Verify required rspec dependencies" do
 
     Bundler.with_clean_env do
       expect(`bundle exec #{script} 2>&1`).
-        to match(/uninitialized constant RSpec::Support \(NameError\)/).
+        to match(/uninitialized constant RSpec::Support/).
         or match(/undefined method `require_rspec_core' for RSpec::Support:Module/)
 
       expect($?.exitstatus).to eq(1)


### PR DESCRIPTION
When I run specs in the master branch, `spec/sanity_check_spec.rb` passes with Bundler 1.15.4 but fails with 1.16.0.

This PR fixes this failure by relaxing the regex expectation to work with both versions of Bundler.

<details>

```
Failures:

  1) Verify required rspec dependencies fails when libraries are not required
     Failure/Error:
       expect(`bundle exec #{script} 2>&1`).
         to match(/uninitialized constant RSpec::Support \(NameError\)/).
         or match(/undefined method `require_rspec_core' for RSpec::Support:Module/)
     
          expected "bundler: failed to load command: /Users/mbrictson/Code/rspec-rails/tmp/fail_sanity_check (/Users/mbr...RSpec::Support\n  /Users/mbrictson/Code/rspec-rails/tmp/fail_sanity_check:2:in `<top (required)>'\n" to match /uninitialized constant RSpec::Support \(NameError\)/
     
       ...or:
     
          expected "bundler: failed to load command: /Users/mbrictson/Code/rspec-rails/tmp/fail_sanity_check (/Users/mbr...RSpec::Support\n  /Users/mbrictson/Code/rspec-rails/tmp/fail_sanity_check:2:in `<top (required)>'\n" to match /undefined method `require_rspec_core' for RSpec::Support:Module/
       Diff for (match /uninitialized constant RSpec::Support \(NameError\)/):
       @@ -1,2 +1,4 @@
       -/uninitialized constant RSpec::Support \(NameError\)/
       +bundler: failed to load command: /Users/mbrictson/Code/rspec-rails/tmp/fail_sanity_check (/Users/mbrictson/Code/rspec-rails/tmp/fail_sanity_check)
       +NameError: uninitialized constant RSpec::Support
       +  /Users/mbrictson/Code/rspec-rails/tmp/fail_sanity_check:2:in `<top (required)>'
       
       Diff for (match /undefined method `require_rspec_core' for RSpec::Suppor...):
       @@ -1,2 +1,4 @@
       -/undefined method `require_rspec_core' for RSpec::Support:Module/
       +bundler: failed to load command: /Users/mbrictson/Code/rspec-rails/tmp/fail_sanity_check (/Users/mbrictson/Code/rspec-rails/tmp/fail_sanity_check)
       +NameError: uninitialized constant RSpec::Support
       +  /Users/mbrictson/Code/rspec-rails/tmp/fail_sanity_check:2:in `<top (required)>'
       
     # ./spec/sanity_check_spec.rb:21:in `block (3 levels) in <top (required)>'
     # ./spec/sanity_check_spec.rb:20:in `block (2 levels) in <top (required)>'

Finished in 3.29 seconds (files took 1.43 seconds to load)
669 examples, 1 failure, 1 pending

Failed examples:

rspec ./spec/sanity_check_spec.rb:10 # Verify required rspec dependencies fails when libraries are not required
```

</details>
