### PR TITLE
Fix Ruby warning: character class has duplicated range

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -49,7 +49,7 @@ module RSpec
             dependency on a webserver and `capybara`, please add capybara to
             your Gemfile and configure a webserver (e.g. `Capybara.server =
             :webrick`) before attempting to use system tests.
-          """.gsub(/[\n\s]+/,' ').strip
+          """.gsub(/\s+/,' ').strip
         end
 
         original_after_teardown =


### PR DESCRIPTION
When running the specs in master, I see the following warning printed:

```
lib/rspec/rails/example/system_example_group.rb:52: warning: character class has duplicated range: /[\n\s]+/
```

This PR fixes the warning by simplifying the offending regex to remove the redundant `\n`.