### PR TITLE
Change `rails_helper.rb` template to friendly error log

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -24,14 +24,22 @@ require 'rspec/rails'
 
 <% if RSpec::Rails::FeatureCheck.can_maintain_test_schema? -%>
 # Checks for pending migrations and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.maintain_test_schema!
-
+# If you are not using ActiveRecord, you can remove these lines.
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
 <% elsif RSpec::Rails::FeatureCheck.can_check_pending_migrations? -%>
 # Checks for pending migrations before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.check_pending!
-
+# If you are not using ActiveRecord, you can remove these lines.
+begin
+  ActiveRecord::Migration.check_pending!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
 <% end -%>
 RSpec.configure do |config|
 <% if RSpec::Rails::FeatureCheck.has_active_record? -%>


### PR DESCRIPTION
This commit will change `rails_helper.rb` template to the following pending migration error log.

## Before

```console
% bin/rspec spec/models/foo_spec.rb
/Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/bundler/gems/rails-0f8568f58d36/activerecord/lib/active_record/migration.rb:578:in
 `check_pending!':  (ActiveRecord::PendingMigrationError)

Migrations are pending. To resolve this issue, run:

        bin/rails db:migrate RAILS_ENV=test

        from /Users/koic/src/ (snip) /spec/spec_helper.rb:27:in `<top (required)>'
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `require'
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in
        `block in requires='
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `each'
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `requires='
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:112:in
        `block in process_options_into'
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:111:in `each'
        from
        /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:111:in
        `process_options_into'
        from
        /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:21:in
        `configure'
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:99:in `setup'
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:86:in `run'
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:71:in `run'
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:45:in `invoke'
        from /Users/koic/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rspec-core-3.7.0/exe/rspec:4:in `<top (required)>'
        from bin/rspec:9:in `load'
        from bin/rspec:9:in `<main>'
```

## After

```console
% bin/rspec spec/models/foo_spec.rb
Migrations are pending. To resolve this issue, run:

        bin/rails db:migrate RAILS_ENV=test
```

This PR got an idea from rails/rails#28939.