### PR TITLE
Contributing updates v2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,28 @@ If you'd like to help make RSpec better, here are some ways you can contribute:
 If you need help getting started, check out the [DEVELOPMENT](DEVELOPMENT.md) file for steps that will get you up and running.
 
 Thanks for helping us make RSpec better!
+
+## `Small` issues
+
+Small issues are the ones that we be believe are best suited for new
+contributors to get started on. They represent a meaningful contribution to the
+project that can be made that should not be too hard to pull off.
+
+## `Triage` issues
+
+Triage issues are ones that have been labelled by the maintainers that we
+believe do not currently have enough information for them to be reproduced by
+us. You can help us move triage issues into `ready to go` or `has reproduction
+case` (for feature requests or bugs) as a seriously meaningful contribution.
+
+## `Has reproduction case` issues
+
+Issues that have reproduction cases have a repository that we can clone that
+enable us to quickly determine the issue is valid and then start debugging
+within RSpec. These issues are good ones to tackle to help us actively fix bugs.
+
+## Maintenance branches
+
+Maintenance branches are how we manage the different supported point releases
+of RSpec. As such, while they might look like good candidates to merge into
+master, please do not open pull requests to merge them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ contribution to the project that should not be too hard to pull off.
 These issues are ones that have been labelled by the maintainers that we
 believe do not currently have enough information to be reproduced the RSpec
 team. While not directly counted by the GitHub contribution graph, we consider
-helping us to reproduced the issue with a repro case as an extremely meaningful
+helping us to reproduce the issue with a repro case as an extremely meaningful
 contribution.
 
 ### `Has reproduction case` issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,8 @@ contribution.
 
 ### `Has reproduction case` issues
 
-Issues that have reproduction cases have a repository that we can clone that
-enable us to quickly determine the issue is valid and then start debugging
-within RSpec. These issues are good ones to tackle to help us actively fix bugs.
+These issues are the ones that have reproduction cases, able to start working on
+immediately. These are good ones to tackle to help us actively fix bugs.
 
 ## Dev environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,7 @@ contribution.
 These issues are the ones that have reproduction cases, able to start working on
 immediately. These are good ones to tackle to help us actively fix bugs.
 
-## Dev environment
-
-### Maintenance branches
+## Maintenance branches
 
 Maintenance branches are how we manage the different supported point releases
 of RSpec. As such, while they might look like good candidates to merge into

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,15 +26,14 @@ Thanks for helping us make RSpec better!
 
 ## `Small` issues
 
-Small issues are the ones that we be believe are best suited for new
-contributors to get started on. They represent a meaningful contribution to the
-project that can be made that should not be too hard to pull off.
-
+These issues are the ones that we be believe are best suited for new
+contributors to get started on. They represent a potential meaningful
+contribution to the project that should not be too hard to pull off.
 ## `Triage` issues
 
-Triage issues are ones that have been labelled by the maintainers that we
-believe do not currently have enough information for them to be reproduced by
-us. You can help us move triage issues into `ready to go` or `has reproduction
+These issues are ones that have been labelled by the maintainers that we
+believe do not currently have enough information to be reproduced the RSpec
+team. You can help us move triage issues into `ready to go` or `has reproduction
 case` (for feature requests or bugs) as a seriously meaningful contribution.
 
 ## `Has reproduction case` issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,14 @@ Thanks for helping us make RSpec better!
 These issues are the ones that we be believe are best suited for new
 contributors to get started on. They represent a potential meaningful
 contribution to the project that should not be too hard to pull off.
+
 ## `Triage` issues
 
 These issues are ones that have been labelled by the maintainers that we
 believe do not currently have enough information to be reproduced the RSpec
-team. You can help us move triage issues into `ready to go` or `has reproduction
-case` (for feature requests or bugs) as a seriously meaningful contribution.
+team. While not directly counted by the GitHub contribution graph, we consider
+helping us triage issues to the point where they can be reproduced as an
+extremely meaningful contribution.
 
 ## `Has reproduction case` issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,27 +24,31 @@ If you need help getting started, check out the [DEVELOPMENT](DEVELOPMENT.md) fi
 
 Thanks for helping us make RSpec better!
 
-## `Small` issues
+## Rspec issues labels definition
+
+### `Your first PR` issues
 
 These issues are the ones that we be believe are best suited for new
 contributors to get started on. They represent a potential meaningful
 contribution to the project that should not be too hard to pull off.
 
-## `Triage` issues
+### `Needs reproduction case` issues
 
 These issues are ones that have been labelled by the maintainers that we
 believe do not currently have enough information to be reproduced the RSpec
 team. While not directly counted by the GitHub contribution graph, we consider
-helping us triage issues to the point where they can be reproduced as an
-extremely meaningful contribution.
+helping us to reproduced the issue with a repro case as an extremely meaningful
+contribution.
 
-## `Has reproduction case` issues
+### `Has reproduction case` issues
 
 Issues that have reproduction cases have a repository that we can clone that
 enable us to quickly determine the issue is valid and then start debugging
 within RSpec. These issues are good ones to tackle to help us actively fix bugs.
 
-## Maintenance branches
+## Dev environment
+
+### Maintenance branches
 
 Maintenance branches are how we manage the different supported point releases
 of RSpec. As such, while they might look like good candidates to merge into

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -14,11 +14,18 @@ resolve your bug faster!
 
 -->
 
-## Description of issue
+## Observed behaviour
 
 <!--
-please provide a high level description of the problem that you are having,
-including details like rails version and so on
+please provide a concise description of the behaviour you are observing with
+RSpec and Rails
+-->
+
+## Expected behaviour
+
+<!--
+Please provide a description of what you expect to be happening, and how that
+differs from the current behaviour.
 -->
 
 ## Can you provide an example app?

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -62,9 +62,3 @@ your issue, and we typically ask that you follow these steps:
 4. Commit
 5. Provide a link to a github repo, a description of the app and what you're expecting here
 -->
-
-
-## Did this problem exist before you upgraded to Rails 5?
-
-<!-- We're still tracking down a few edge cases since Rails 5 came out, so if
-it's new for you since Rails 5, that'll help us find it faster -->

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -14,6 +14,24 @@ resolve your bug faster!
 
 -->
 
+## What Ruby, Rails and RSpec versions are you using?
+
+Ruby version:
+Rails version:
+Rspec version:
+
+<!--
+
+You can run
+
+```
+bundle exec ruby --version
+bundle exec rails --version
+bundle exec rspec --version
+```
+
+-->
+
 ## Observed behaviour
 
 <!--
@@ -45,21 +63,6 @@ your issue, and we typically ask that you follow these steps:
 5. Provide a link to a github repo, a description of the app and what you're expecting here
 -->
 
-## What Ruby, Rails and RSpec versions are you using?
-
-<!--
-
-You can run
-
-```
-bundle exec ruby --version
-bundle exec rails --version
-bundle exec rspec --version
-```
-
-and paste the output below
-
--->
 
 ## Did this problem exist before you upgraded to Rails 5?
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,60 @@
+<!--
+
+Hi there! Here's a few pointers to help us help you with your issue as quickly
+as possible.
+
+We prefer that the RSpec Rails issue tracker be mainly used for bug reports.
+Feature requests or general requests for help should go to our google group:
+rspec@googlegroups.com. We use that as our primary location for higher level
+RSpec discussions.
+
+If you are filing a bug report, there's a few steps it'd be super if you could
+follow. If you can't do all of these, don't worry, but if you can it'll help us
+resolve your bug faster!
+
+-->
+
+## Description of issue
+
+<!--
+please provide a high level description of the problem that you are having,
+including details like rails version and so on
+-->
+
+## Can you provide an example app?
+
+<!--
+This step is probably the most important in allowing us to quickly debug
+your issue, and we typically ask that you follow these steps:
+
+1. `rails new` an app at the specific version of ruby and rails that you are
+   using
+2. commit that app, so that we have the rails skeleton in a separate commit
+3. Make all the changes necessary (adding RSpec, models, specs, controllers,
+   etc) to reproduce the issue. There should be a failing test or tests that you
+   expect to pass. We'll run `bundle exec rspec`, but if you can provide a
+   readme with more detailed instructions that'd be amazing :)
+4. Commit
+5. Provide a link to a github repo, a description of the app and what you're expecting here
+-->
+
+## What Ruby, Rails and RSpec versions are you using?
+
+<!--
+
+You can run
+
+```
+bundle exec ruby --version
+bundle exec rails --version
+bundle exec rspec --version
+```
+
+and paste the output below
+
+-->
+
+## Did this problem exist before you upgraded to Rails 5?
+
+<!-- We're still tracking down a few edge cases since Rails 5 came out, so if
+it's new for you since Rails 5, that'll help us find it faster -->


### PR DESCRIPTION
Hello

This PR is meant [to continue the work](https://twitter.com/samphippen/status/938746864123498496) done by @samphippen on #1705. I answered to few of the comments of @ashleygwilliams and @myronmarston. 

My english is not that good. So feel free to make any comments.

Their is a related PR on rspec-core https://github.com/rspec/rspec-core/pull/2485 that could be added into `CONTRIBUTING.md` and referenced from the issue template.

On the top of `CONTRIBUTING.md` their is this text:
```
<!---
 This file was generated on 2015-12-07T22:01:06+11:00 from the rspec-dev repo.
 DO NOT modify it by hand as your changes will get lost the next time it is generated.
 -->
```
Is it still the case? Should I make this PR against : https://github.com/rspec/rspec-dev/blob/master/common_markdown_files/CONTRIBUTING.md.erb ?

Thanks in advance for the review.