### PR TITLE
Fix routing spec scaffold format

### DIFF
--- a/lib/generators/rspec/scaffold/templates/routing_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/routing_spec.rb
@@ -3,18 +3,17 @@ require "rails_helper"
 <% module_namespacing do -%>
 RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:routing) %> do
   describe "routing" do
-
 <% unless options[:singleton] -%>
     it "routes to #index" do
       expect(:get => "/<%= ns_table_name %>").to route_to("<%= ns_table_name %>#index")
     end
-    
+
 <% end -%>
 <% unless options[:api] -%>
     it "routes to #new" do
       expect(:get => "/<%= ns_table_name %>/new").to route_to("<%= ns_table_name %>#new")
     end
-  
+
 <% end -%>
     it "routes to #show" do
       expect(:get => "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#show", :id => "1")

--- a/lib/generators/rspec/scaffold/templates/routing_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/routing_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:routing
     it "routes to #index" do
       expect(:get => "/<%= ns_table_name %>").to route_to("<%= ns_table_name %>#index")
     end
-
+    
 <% end -%>
 <% unless options[:api] -%>
     it "routes to #new" do
       expect(:get => "/<%= ns_table_name %>/new").to route_to("<%= ns_table_name %>#new")
     end
+  
 <% end -%>
-
     it "routes to #show" do
       expect(:get => "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#show", :id => "1")
     end
@@ -24,6 +24,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:routing
     it "routes to #edit" do
       expect(:get => "/<%= ns_table_name %>/1/edit").to route_to("<%= ns_table_name %>#edit", :id => "1")
     end
+
 <% end -%>
 
     it "routes to #create" do
@@ -43,7 +44,6 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:routing
     it "routes to #destroy" do
       expect(:delete => "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#destroy", :id => "1")
     end
-
   end
 end
 <% end -%>


### PR DESCRIPTION
When I scaffold an User model in Rails 5 API application, I get this in `spec/routing/users_routing_spec.rb`:

```ruby
require "rails_helper"

RSpec.describe UsersController, type: :routing do
  describe "routing" do

    it "routes to #index" do
      expect(:get => "/users").to route_to("users#index")
    end


    it "routes to #show" do
      expect(:get => "/users/1").to route_to("users#show", :id => "1")
    end


    it "routes to #create" do
      expect(:post => "/users").to route_to("users#create")
    end

    it "routes to #update via PUT" do
      expect(:put => "/users/1").to route_to("users#update", :id => "1")
    end

    it "routes to #update via PATCH" do
      expect(:patch => "/users/1").to route_to("users#update", :id => "1")
    end

    it "routes to #destroy" do
      expect(:delete => "/users/1").to route_to("users#destroy", :id => "1")
    end

  end
end
```

Preferably, it should look like this:

```ruby
require "rails_helper"

RSpec.describe UsersController, type: :routing do
  describe "routing" do
    it "routes to #index" do
      expect(:get => "/users").to route_to("users#index")
    end

    it "routes to #show" do
      expect(:get => "/users/1").to route_to("users#show", :id => "1")
    end

    it "routes to #create" do
      expect(:post => "/users").to route_to("users#create")
    end

    it "routes to #update via PUT" do
      expect(:put => "/users/1").to route_to("users#update", :id => "1")
    end

    it "routes to #update via PATCH" do
      expect(:patch => "/users/1").to route_to("users#update", :id => "1")
    end

    it "routes to #destroy" do
      expect(:delete => "/users/1").to route_to("users#destroy", :id => "1")
    end
  end
end
```

This PR aims to solve this issue.