### PR TITLE
Remove useless ivar assign in controller spec

### DIFF
--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% unless options[:singleton] -%>
   describe "GET #index" do
     it "returns a success response" do
-      <%= file_name %> = <%= class_name %>.create! valid_attributes
+      <%= class_name %>.create! valid_attributes
 <% if Rails::VERSION::STRING < '5.0' -%>
       get :index, {}, valid_session
 <% else -%>


### PR DESCRIPTION
This assignment is not necessary here.
It maybe need to be someone, but there is no reason to assign in generated code at least ;)

before rspec-rails generates(model: Person, Rails > 5):

```ruby
describe "GET #index" do
  it "returns a success response" do
    person = Person.create! valid_attributes
    get :index, params: {}, session: valid_session
    expect(response).to be_success
  end
end
```

after:

```ruby
describe "GET #index" do
  it "returns a success response" do
    Person.create! valid_attributes
    get :index, params: {}, session: valid_session
    expect(response).to be_success
  end
end
```

How do you think?