### PR TITLE
Upgrade rubocop, motivated by CVE.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
-inherit_from: .rubocop_rspec_base.yml
+inherit_from:
+  - .rubocop_rspec_base.yml
 
 # Over time we'd like to get this down, but this is what we're at now.
 LineLength:
@@ -8,6 +9,15 @@ LineLength:
 MethodLength:
   Max: 50
 
+
+Metrics/AbcSize:
+  Max: 34
+
+Metrics/BlockLength:
+  Max: 43
+
+Metrics/PerceivedComplexity:
+  Max: 11
 # We use spaces, so it's less of a change to stick with that.
 SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: space
@@ -43,3 +53,10 @@ PerlBackrefs:
     # We probably can refactor the backref out, but for now excluding it since
     # we can't use named matches in 1.8.7
     - lib/generators/rspec/scaffold/scaffold_generator.rb
+
+Lint/AssignmentInCondition:
+  # Could possibly refactor these to avoid but wanting to avoid the churn while
+  # upgrading.
+  Exclude:
+    - 'lib/rspec/rails/adapters.rb'
+    - 'lib/rspec/rails/tasks/rspec.rake'

--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -1,11 +1,8 @@
-# This file was generated on 2017-11-21T14:21:55+11:00 from the rspec-dev repo.
-# DO NOT modify it by hand as your changes will get lost the next time it is generated.
-
 # This file contains defaults for RSpec projects. Individual projects
 # can customize by inheriting this file and overriding particular settings.
 
 AccessModifierIndentation:
-  EnforcedStyle: outdent
+  Enabled: false
 
 # "Use alias_method instead of alias"
 # We're fine with `alias`.
@@ -50,9 +47,6 @@ DoubleNegation:
 EachWithObject:
   Enabled: false
 
-Encoding:
-  EnforcedStyle: when_needed
-
 FormatString:
   EnforcedStyle: percent
 
@@ -73,7 +67,7 @@ MethodLength:
   Max: 15
 
 # Who cares what we call the argument for binary operator methods?
-OpMethod:
+BinaryOperatorParameterName:
   Enabled: false
 
 PercentLiteralDelimiters:
@@ -98,9 +92,6 @@ PredicateName:
 Proc:
   Enabled: false
 
-RedundantReturn:
-  AllowMultipleReturnValues: true
-
 # Exceptions should be rescued with `Support::AllExceptionsExceptOnesWeMustNotRescue`
 RescueException:
   Enabled: true
@@ -121,10 +112,196 @@ StringLiterals:
 Style/SpecialGlobalVars:
   Enabled: false
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
   Enabled: false
 
 TrivialAccessors:
   AllowDSLWriters: true
   AllowPredicates: true
   ExactNameMatch: true
+
+Style/ParallelAssignment:
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+
+Layout/FirstParameterIndentation:
+  Enabled: false
+
+Naming/ConstantName:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: false
+
+Style/MethodMissing:
+  Enabled: false
+
+Style/MixinUsage:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/NestedModifier:
+  Enabled: false
+
+Style/NestedParenthesizedCalls:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/RedundantParentheses:
+  Enabled: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/SymbolProc:
+  Enabled: false
+
+Style/YodaCondition:
+  Enabled: false
+
+Style/ZeroLengthPredicate:
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Layout/SpaceAroundBlockParameters:
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Enabled: false
+
+Layout/SpaceBeforeComma:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/EmptyCaseCondition:
+  Enabled: false
+
+Style/MultilineIfModifier:
+  Enabled: false
+
+Style/RescueStandardError:
+  Enabled: false
+
+Style/StderrPuts:
+  Enabled: false
+
+Style/TernaryParentheses:
+  Enabled: false
+
+# This could likely be enabled, but it had a false positive on rspec-mocks
+# (suggested change was not behaviour preserving) so I don't trust it.
+Performance/HashEachMethods:
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Layout/IndentArray:
+  Enabled: false
+
+Layout/IndentAssignment:
+  Enabled: false
+
+Layout/IndentHeredoc:
+  Enabled: false
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: false
+
+Style/EmptyElse:
+  Enabled: false
+
+Style/IfInsideElse:
+  Enabled: false
+
+Style/RedundantReturn:
+  Enabled: false
+
+Style/StructInheritance:
+  Enabled: false
+
+Naming/VariableNumber:
+  Enabled: false
+
+Layout/SpaceInsideStringInterpolation:
+  Enabled: false
+
+Style/DateTime:
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Lint/ImplicitStringConcatenation:
+  Enabled: false
+
+Lint/NestedMethodDefinition:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: false
+

--- a/Gemfile
+++ b/Gemfile
@@ -66,10 +66,8 @@ if RUBY_VERSION <= '1.8.7'
   gem 'rubyzip', '< 1.0'
 end
 
-if RUBY_VERSION >= '2.0.0' && RUBY_VERSION < '2.2.0'
-  # our current rubocop version doesn't support the json version required by Ruby 2.4
-  # our rails rubocop setup only supports 2.0 and 2.1
-  gem 'rubocop', "~> 0.23.0"
+if RUBY_VERSION >= '2.0.0'
+  gem 'rubocop', "~> 0.52.1"
 end
 
 custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)

--- a/Gemfile
+++ b/Gemfile
@@ -66,8 +66,9 @@ if RUBY_VERSION <= '1.8.7'
   gem 'rubyzip', '< 1.0'
 end
 
-if RUBY_VERSION >= '2.0.0'
-  gem 'rubocop', "~> 0.52.1"
+# No need to run rubocop on earlier versions
+if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
+  gem "rubocop", "~> 0.52.1"
 end
 
 custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)

--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -11,9 +11,9 @@ module RSpec
       # gem in version 2.4.9. Previous to this version `Test::Unit.run=` was
       # used. The implementation of test-unit included with Ruby has neither
       # method.
-      if defined?(Test::Unit::AutoRunner.need_auto_run = ())
+      if defined?(Test::Unit::AutoRunner.need_auto_run = nil)
         Test::Unit::AutoRunner.need_auto_run = false
-      elsif defined?(Test::Unit.run = ())
+      elsif defined?(Test::Unit.run = nil)
         Test::Unit.run = false
       end
     end

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -53,7 +53,7 @@ module RSpec
     end
 
     # @private
-    # rubocop:disable Style/MethodLength
+    # rubocop:disable Metrics/MethodLength
     def self.initialize_configuration(config)
       config.backtrace_exclusion_patterns << /vendor\//
       config.backtrace_exclusion_patterns << %r{lib/rspec/rails}
@@ -141,7 +141,7 @@ module RSpec
         config.include RSpec::Rails::JobExampleGroup, :type => :job
       end
     end
-    # rubocop:enable Style/MethodLength
+    # rubocop:enable Metrics/MethodLength
 
     initialize_configuration RSpec.configuration
   end

--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -47,9 +47,7 @@ module RSpec
         begin
           require 'capybara'
           require 'action_dispatch/system_test_case'
-        # rubocop:disable Lint/HandleExceptions
         rescue LoadError
-          # rubocop:enable Lint/HandleExceptions
           abort """
             System test integration requires Rails >= 5.1 and has a hard
             dependency on a webserver and `capybara`, please add capybara to

--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -2,11 +2,8 @@ module RSpec
   module Rails
     # @private
     # Disable some cops until https://github.com/bbatsov/rubocop/issues/1310
-    # rubocop:disable Style/IndentationConsistency
     module FeatureCheck
-    # rubocop:disable Style/IndentationWidth
-    module_function
-      # rubocop:enable Style/IndentationWidth
+      module_function
 
       def can_check_pending_migrations?
         has_active_record_migration? &&
@@ -59,6 +56,5 @@ module RSpec
         end
       end
     end
-    # rubocop:enable Style/IndentationConsistency
   end
 end

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -8,7 +8,7 @@ module RSpec
       #
       # @api private
       module ActiveJob
-        # rubocop: disable Style/ClassLength
+        # rubocop: disable Metrics/ClassLength
         # @private
         class Base < RSpec::Matchers::BuiltIn::BaseMatcher
           def initialize
@@ -169,7 +169,7 @@ module RSpec
             ::ActiveJob::Base.queue_adapter
           end
         end
-        # rubocop: enable Style/ClassLength
+        # rubocop: enable Metrics/ClassLength
 
         # @private
         class HaveEnqueuedJob < Base


### PR DESCRIPTION
Defaulted most new things to off, though tried to keep performance and linters.

Note that `.rubocop_rspec_base` doesn't 100% match up with `rspec-dev` because I was adding to it as we went along. Once these are all merged I'm planning to ensure they're all consistent.