### PR TITLE
delegate find_all directly

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -71,6 +71,11 @@ module RSpec
             @resolver = resolver
           end
 
+          def find_all(*args, &block)
+            result = @resolver.find_all(*args, &block)
+            nullify_templates(result)
+          end
+
           def method_missing(name, *args, &block)
             result = @resolver.send(name, *args, &block)
             nullify_templates(result)


### PR DESCRIPTION
this will allow ruby to delegate find_all method more effectively