### PR TITLE
Set RAILS_ENV to test in rails_helper

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
This is a solution to tests running in development environment as stated in issues #70 and #586.
Before Rails 3.2.7, `ENV['RAILS_ENV'] ||= 'test'` ran tests without issues in test env as discussed in https://github.com/rails/rails/issues/7175#issue-5869126.