### PR TITLE
Prevent "have_http_status" from using deprecated methods in Rails 5.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ matrix:
     - rvm: 2.4.2
       env: RAILS_VERSION='~> 3.1.12'
     - rvm: 2.4.2
-      env: RAILS_VERSION=5.2.0.beta2
+      env: RAILS_VERSION=5.2.0.rc1
   allow_failures:
     - rvm: 2.2.2
       env: RAILS_VERSION=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,8 @@ matrix:
       env: RAILS_VERSION=3-2-stable
     - rvm: 2.4.2
       env: RAILS_VERSION='~> 3.1.12'
+    - rvm: 2.4.2
+      env: RAILS_VERSION=5.2.0.beta2
   allow_failures:
     - rvm: 2.2.2
       env: RAILS_VERSION=master

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@ Enhancements:
 
 Bug Fixes:
 
-* Escape quotation characters when producing method names for system spec 
+* Escape quotation characters when producing method names for system spec
   screenshots. (Shane Cavanaugh, #1955)
 
 ### 3.7.2 / 2017-11-20

--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -289,8 +289,22 @@ module RSpec
 
         protected
 
-          def check_expected_status(test_response, expected)
-            test_response.send("#{expected}?")
+          if 5 < ::Rails::VERSION::MAJOR ||
+             (::Rails::VERSION::MAJOR == 5 && 2 <= ::Rails::VERSION::MINOR)
+            def check_expected_status(test_response, expected)
+              test_response.send("#{expected}?")
+            end
+          else
+            RESPONSE_METHODS = {
+              success: 'successful',
+              error: 'server_error',
+              missing: 'not_found'
+            }.freeze
+
+            def check_expected_status(test_response, expected)
+              test_response.send(
+                "{RESPONSE_METHODS.fetch(response_symbol, response_symbol)}?")
+            end
           end
 
         private

--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -292,15 +292,15 @@ module RSpec
           if 5 < ::Rails::VERSION::MAJOR ||
              (::Rails::VERSION::MAJOR == 5 && 2 <= ::Rails::VERSION::MINOR)
             RESPONSE_METHODS = {
-              success: 'successful',
-              error: 'server_error',
-              missing: 'not_found'
+              :success => 'successful',
+              :error => 'server_error',
+              :missing => 'not_found'
             }.freeze
           else
             RESPONSE_METHODS = {
-              successful: 'success',
-              server_error: 'error',
-              not_found: 'missing'
+              :successful => 'success',
+              :server_error => 'error',
+              :not_found => 'missing'
             }.freeze
           end
 

--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -342,11 +342,11 @@ module RSpec
             # @see https://github.com/rails/rails/blob/ca200378/actionpack/lib/action_dispatch/http/response.rb#L74
             # @see https://github.com/rack/rack/blob/ce4a3959/lib/rack/response.rb#L119-L122
             @type_codes ||= case expected
-                            when :error
+                            when :error, :server_error
                               "5xx"
-                            when :success
+                            when :success, :successful
                               "2xx"
-                            when :missing
+                            when :missing, :not_found
                               "404"
                             when :redirect
                               "3xx"

--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -259,7 +259,8 @@ module RSpec
             @invalid_response = nil
           end
 
-          # @return [Boolean] value of response status method
+          # @return [Boolean] `true` if Rack's associated numeric HTTP code matched
+          #   the `response` code or the named response status
           def matches?(response)
             test_response = as_test_response(response)
             @actual = test_response.response_code

--- a/spec/rspec/rails/matchers/have_http_status_spec.rb
+++ b/spec/rspec/rails/matchers/have_http_status_spec.rb
@@ -474,5 +474,26 @@ RSpec.describe "have_http_status" do
         let(:code) { 555 }
       end
     end
+
+    context 'http status :not_found' do
+      it_behaves_like "supports different response instances" do
+        subject(:matcher) { have_http_status(:not_found) }
+        let(:code) { 404 }
+      end
+    end
+
+    context 'http status :successful' do
+      it_behaves_like "supports different response instances" do
+        subject(:matcher) { have_http_status(:successful) }
+        let(:code) { 222 }
+      end
+    end
+
+    context 'http status :server_error' do
+      it_behaves_like "supports different response instances" do
+        subject(:matcher) { have_http_status(:server_error) }
+        let(:code) { 555 }
+      end
+    end
   end
 end

--- a/spec/rspec/rails/matchers/have_http_status_spec.rb
+++ b/spec/rspec/rails/matchers/have_http_status_spec.rb
@@ -434,4 +434,45 @@ RSpec.describe "have_http_status" do
       expect{ have_http_status(nil) }.to raise_error ArgumentError
     end
   end
+
+  if 5 < Rails::VERSION::MAJOR ||
+     (Rails::VERSION::MAJOR == 5 && 2 <= Rails::VERSION::MINOR)
+    shared_examples_for "does not use deprecated methods for Rails 5.2+" do
+      it "does not use deprecated method for Rails >= 5.2" do
+        previous_stderr = $stderr
+        begin
+          splitter = RSpec::Support::StdErrSplitter.new(previous_stderr)
+          $stderr = splitter
+          response = ::ActionDispatch::Response.new(code).tap {|x|
+            x.request = ActionDispatch::Request.new({})
+          }
+          expect( matcher.matches?(response) ).to be(true)
+          expect(splitter.has_output?).to be false
+        ensure
+          $stderr = previous_stderr
+        end
+      end
+    end
+
+    context 'http status :missing' do
+      it_behaves_like "does not use deprecated methods for Rails 5.2+" do
+        subject(:matcher) { have_http_status(:missing) }
+        let(:code) { 404 }
+      end
+    end
+
+    context 'http status :success' do
+      it_behaves_like "does not use deprecated methods for Rails 5.2+" do
+        subject(:matcher) { have_http_status(:success) }
+        let(:code) { 222 }
+      end
+    end
+
+    context 'http status :error' do
+      it_behaves_like "does not use deprecated methods for Rails 5.2+" do
+        subject(:matcher) { have_http_status(:error) }
+        let(:code) { 555 }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This alternative PR (to #1945) Provides a minimum change to solve the problem of response status methods deprecated in Rails 5.2, as raised by issue #1857

This does so without deprecating or changing any status matchers in RSpec, so a Rails 5.2 upgrade will be transparent, at least with respect to not causing deprecation warnings for the :success, :error, and :missing values of has_http_status.

A major or minor release that eliminates the version check will either require Rails 5.2 and map :success to the `successful` call, or require everyone to change their tests.