### PR TITLE
improve documentation - add common example

### DIFF
--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -233,6 +233,7 @@ module RSpec
         #   expect(response).to have_http_status(:error)
         #   expect(response).to have_http_status(:missing)
         #   expect(response).to have_http_status(:redirect)
+        #   expect(response).to have_http_status(:unauthorized)   
         #
         # @see RSpec::Rails::Matchers.have_http_status
         # @see ActionDispatch::TestResponse


### PR DESCRIPTION
* it's too common for 401 not be added hence its inclusion

* This documentation renders as intended. It is also tested against my rspec code.