### PR TITLE
Substitute quotes with underscores for method name

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -35,7 +35,7 @@ module RSpec
           self.class.name.underscore,
           RSpec.current_example.description.underscore,
           rand(1000)
-        ].join("_").gsub(/[\/\.:,'" ]/, "_")
+        ].join("_").tr('/.:,\'" ', "_")
       end
 
       # Delegates to `Rails.application`.

--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -35,7 +35,7 @@ module RSpec
           self.class.name.underscore,
           RSpec.current_example.description.underscore,
           rand(1000)
-        ].join("_").gsub(/[\/\.:, ]/, "_")
+        ].join("_").gsub(/[\/\.:,'" ]/, "_")
       end
 
       # Delegates to `Rails.application`.

--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -11,6 +11,9 @@ module RSpec
       include ActionDispatch::Assertions
       include ActionController::TemplateAssertions
 
+      # Special characters to translate into underscores for #method_name
+      CHARS_TO_TRANSLATE = ['/', '.', ':', ',', "'", '"', " "].freeze
+
       # @private
       module BlowAwayAfterTeardownHook
         # @private
@@ -35,7 +38,7 @@ module RSpec
           self.class.name.underscore,
           RSpec.current_example.description.underscore,
           rand(1000)
-        ].join("_").tr('/.:,\'" ', "_")
+        ].join("_").tr(CHARS_TO_TRANSLATE.join, "_")
       end
 
       # Delegates to `Rails.application`.

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -10,7 +10,7 @@ module RSpec::Rails
           group = RSpec::Core::ExampleGroup.describe ActionPack do
             include SystemExampleGroup
           end
-          ['/', '.', ':', ',', "'", '"', ' '].each do |char|
+          SystemExampleGroup::CHARS_TO_TRANSLATE.each do |char|
             example = group.new
             example_class_mock = double('name' => "method#{char}name")
             allow(example).to receive(:class).and_return(example_class_mock)

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -4,6 +4,20 @@ module RSpec::Rails
     RSpec.describe SystemExampleGroup do
       it_behaves_like "an rspec-rails example group mixin", :system,
         './spec/system/', '.\\spec\\system\\'
+
+      describe '#method_name' do
+        it 'converts special characters to underscores' do
+          group = RSpec::Core::ExampleGroup.describe ActionPack do
+            include SystemExampleGroup
+          end
+          ['/', '.', ':', ',', "'", '"', ' '].each do |char|
+            example = group.new
+            example_class_mock = double('name' => "method#{char}name")
+            allow(example).to receive(:class).and_return(example_class_mock)
+            expect(example.send(:method_name)).to start_with('method_name')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Rails' SystemTestCase uses `method_name` to generate a filename for a screenshot, which is output along with the failure message. The filename for examples with single or double quotation marks retain the marks, making it tedious to copy-and-past the generated filename then manually escape it to use in a shell command.