### PR TITLE
Respect long namespaces for rails g scaffold

### DIFF
--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -73,19 +73,29 @@ module Rspec
 
       # support for namespaced-resources
       def ns_file_name
-        ns_parts.empty? ? file_name : "#{ns_parts[0].underscore}_#{ns_parts[1].singularize.underscore}"
+        return file_name if ns_parts.empty?
+        "#{ns_prefix.map(&:underscore).join('/')}_#{ns_suffix.singularize.underscore}"
       end
 
       # support for namespaced-resources
       def ns_table_name
-        ns_parts.empty? ? table_name : "#{ns_parts[0].underscore}/#{ns_parts[1].tableize}"
+        return table_name if ns_parts.empty?
+        "#{ns_prefix.map(&:underscore).join('/')}/#{ns_suffix.tableize}"
       end
 
       def ns_parts
         @ns_parts ||= begin
-                        matches = generator_args[0].to_s.match(/\A(\w+)(?:\/|::)(\w+)/)
-                        matches ? [matches[1], matches[2]] : []
+                        parts = generator_args[0].split(/\/|::/)
+                        parts.size > 1 ? parts : []
                       end
+      end
+
+      def ns_prefix
+        @ns_prefix ||= ns_parts[0..-2]
+      end
+
+      def ns_suffix
+        @ns_suffix ||= ns_parts[-1]
       end
 
       def value_for(attribute)

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
       it { is_expected.to contain(/"renders a JSON response with errors for the \w+"/) }
 
       it { is_expected.not_to contain(/"redirects to the \w+ list"/) }
-
     end
   end
 
@@ -226,6 +225,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
       it { is_expected.to contain(/describe "routing"/) }
       it { is_expected.to contain(/routes to #new/) }
       it { is_expected.to contain(/routes to #edit/) }
+      it { is_expected.to contain('route_to("posts#new")') }
     end
 
     describe 'with --no-routing-specs' do
@@ -237,6 +237,16 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, :type => :generator do
       before { run_generator %w(posts --api) }
       it { is_expected.not_to contain(/routes to #new/) }
       it { is_expected.not_to contain(/routes to #edit/) }
+    end
+
+    context 'with a namespaced name' do
+      subject { file('spec/routing/api/v1/posts_routing_spec.rb') }
+
+      describe 'with default options' do
+        before { run_generator %w(api/v1/posts) }
+        it { is_expected.to contain(/^RSpec.describe Api::V1::PostsController, #{type_metatag(:routing)}/) }
+        it { is_expected.to contain('route_to("api/v1/posts#new")') }
+      end
     end
   end
 end


### PR DESCRIPTION
This PR changes the scaffold spec generator to take long namespaces
(longer than 2 elements) into consideration.

Fixes #1944