### PR TITLE
Update rails_helper.rb template

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 <% if RSpec::Rails::FeatureCheck.can_maintain_test_schema? -%>
 # Checks for pending migrations and applies them before tests are run.


### PR DESCRIPTION
The following change follows best practices of Rails.root.join and avoids linting errors when uncommented. See also http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/FilePath