### PR TITLE
Remove the version check in have_http_status

### DIFF
--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -289,20 +289,11 @@ module RSpec
 
         protected
 
-          if 5 < ::Rails::VERSION::MAJOR ||
-             (::Rails::VERSION::MAJOR == 5 && 2 <= ::Rails::VERSION::MINOR)
-            RESPONSE_METHODS = {
-              :success => 'successful',
-              :error => 'server_error',
-              :missing => 'not_found'
-            }.freeze
-          else
-            RESPONSE_METHODS = {
-              :successful => 'success',
-              :server_error => 'error',
-              :not_found => 'missing'
-            }.freeze
-          end
+          RESPONSE_METHODS = {
+            :success => 'successful',
+            :error => 'server_error',
+            :missing => 'not_found'
+          }.freeze
 
           def check_expected_status(test_response, expected)
             test_response.send(

--- a/spec/rspec/rails/matchers/have_http_status_spec.rb
+++ b/spec/rspec/rails/matchers/have_http_status_spec.rb
@@ -435,65 +435,62 @@ RSpec.describe "have_http_status" do
     end
   end
 
-  if 5 < Rails::VERSION::MAJOR ||
-     (Rails::VERSION::MAJOR == 5 && 2 <= Rails::VERSION::MINOR)
-    shared_examples_for "does not use deprecated methods for Rails 5.2+" do
-      it "does not use deprecated method for Rails >= 5.2" do
-        previous_stderr = $stderr
-        begin
-          splitter = RSpec::Support::StdErrSplitter.new(previous_stderr)
-          $stderr = splitter
-          response = ::ActionDispatch::Response.new(code).tap {|x|
-            x.request = ActionDispatch::Request.new({})
-          }
-          expect( matcher.matches?(response) ).to be(true)
-          expect(splitter.has_output?).to be false
-        ensure
-          $stderr = previous_stderr
-        end
+  shared_examples_for "does not use deprecated methods for Rails 5.2+" do
+    it "does not use deprecated method for Rails >= 5.2" do
+      previous_stderr = $stderr
+      begin
+        splitter = RSpec::Support::StdErrSplitter.new(previous_stderr)
+        $stderr = splitter
+        response = ::ActionDispatch::Response.new(code).tap {|x|
+          x.request = ActionDispatch::Request.new({})
+        }
+        expect( matcher.matches?(response) ).to be(true)
+        expect(splitter.has_output?).to be false
+      ensure
+        $stderr = previous_stderr
       end
     end
+  end
 
-    context 'http status :missing' do
-      it_behaves_like "does not use deprecated methods for Rails 5.2+" do
-        subject(:matcher) { have_http_status(:missing) }
-        let(:code) { 404 }
-      end
+  context 'http status :missing' do
+    it_behaves_like "does not use deprecated methods for Rails 5.2+" do
+      subject(:matcher) { have_http_status(:missing) }
+      let(:code) { 404 }
     end
+  end
 
-    context 'http status :success' do
-      it_behaves_like "does not use deprecated methods for Rails 5.2+" do
-        subject(:matcher) { have_http_status(:success) }
-        let(:code) { 222 }
-      end
+  context 'http status :success' do
+    it_behaves_like "does not use deprecated methods for Rails 5.2+" do
+      subject(:matcher) { have_http_status(:success) }
+      let(:code) { 222 }
     end
+  end
 
-    context 'http status :error' do
-      it_behaves_like "does not use deprecated methods for Rails 5.2+" do
-        subject(:matcher) { have_http_status(:error) }
-        let(:code) { 555 }
-      end
+  context 'http status :error' do
+    it_behaves_like "does not use deprecated methods for Rails 5.2+" do
+      subject(:matcher) { have_http_status(:error) }
+      let(:code) { 555 }
     end
+  end
 
-    context 'http status :not_found' do
-      it_behaves_like "supports different response instances" do
-        subject(:matcher) { have_http_status(:not_found) }
-        let(:code) { 404 }
-      end
+  context 'http status :not_found' do
+    it_behaves_like "supports different response instances" do
+      subject(:matcher) { have_http_status(:not_found) }
+      let(:code) { 404 }
     end
+  end
 
-    context 'http status :successful' do
-      it_behaves_like "supports different response instances" do
-        subject(:matcher) { have_http_status(:successful) }
-        let(:code) { 222 }
-      end
+  context 'http status :successful' do
+    it_behaves_like "supports different response instances" do
+      subject(:matcher) { have_http_status(:successful) }
+      let(:code) { 222 }
     end
+  end
 
-    context 'http status :server_error' do
-      it_behaves_like "supports different response instances" do
-        subject(:matcher) { have_http_status(:server_error) }
-        let(:code) { 555 }
-      end
+  context 'http status :server_error' do
+    it_behaves_like "supports different response instances" do
+      subject(:matcher) { have_http_status(:server_error) }
+      let(:code) { 555 }
     end
   end
 end


### PR DESCRIPTION
The successful?, server_error?, and not_found? methods for ActionDispatch::TestResponse have existed in Rails for a very long time. It isn't necessary to check for Rails 5.2 or greater in order to use them.

This is an improvement on https://github.com/rspec/rspec-rails/pull/1951 which has been merged.