### PR TITLE
Add fscenario alias to focus example

### DIFF
--- a/lib/rspec/rails/example/feature_example_group.rb
+++ b/lib/rspec/rails/example/feature_example_group.rb
@@ -64,6 +64,7 @@ unless RSpec.respond_to?(:feature)
     c.alias_example_group_to :feature, opts
     c.alias_example_to :scenario
     c.alias_example_to :xscenario, :skip => 'Temporarily skipped with xscenario'
+    c.alias_example_to :fscenario, :focus => true
   end
 
   # Due to load order issues and `config.expose_dsl_globally?` defaulting to


### PR DESCRIPTION
This alias adds the focus: true metadata to scenarios. Most users
receive get this functionality via the Capybara gem; however, this
patch makes it available to all rspec-rails users.

I'm not sure how to test this change. Capybara uses [this scenario](https://github.com/teamcapybara/capybara/blob/e6e132ca636f1e81b944066250aa302348cfdf50/spec/rspec/scenarios_spec.rb#L10). However, because rspec-rails has [filter_run: :focus](https://github.com/rspec/rspec-rails/blob/1d2935861c89246236b46f77de753cda5ea67d61/spec/spec_helper.rb#L23) that won't work.