### PR TITLE
Negative matcher should failed if have_enqueued_job have more than 1 Jobs

### DIFF
--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -16,7 +16,7 @@ module RSpec
             @queue = nil
             @at = nil
             @block = Proc.new {}
-            set_expected_number(:exactly, 1)
+            set_expected_number(:at_least, 1)
           end
 
           def with(*args, &block)

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
     it "fails when job is not enqueued" do
       expect {
         expect { }.to have_enqueued_job
-      }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
+      }.to raise_error(/expected to enqueue at least 1 jobs, but enqueued 0/)
     end
 
     it "fails when too many jobs enqueued" do
@@ -116,7 +116,16 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
     it "fails when negated and job is enqueued" do
       expect {
         expect { heavy_lifting_job.perform_later }.not_to have_enqueued_job
-      }.to raise_error(/expected not to enqueue exactly 1 jobs, but enqueued 1/)
+      }.to raise_error(/expected not to enqueue at least 1 jobs, but enqueued 1/)
+    end
+
+    it "fails when negated and job is enqueued more than one time" do
+      expect {
+        expect {
+          heavy_lifting_job.perform_later
+          heavy_lifting_job.perform_later
+        }.not_to have_enqueued_job
+      }.to raise_error(/expected not to enqueue at least 1 jobs, but enqueued 2/)
     end
 
     it "passes with job name" do
@@ -306,7 +315,7 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
     it "fails when job is not enqueued" do
       expect {
         expect(heavy_lifting_job).to have_been_enqueued
-      }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
+      }.to raise_error(/expected to enqueue at least 1 jobs, but enqueued 0/)
     end
   end
 end


### PR DESCRIPTION
Fixing issue #1870

We should use `at_least` instead of `exactly`.

Examples:

```ruby
ExampleJobs.perform_later
ExampleJobs.perform_later

expect(ExampleJobs).not_to have_enqueued_jobs(ExampleJobs)
```
Current negative matcher above will be passed because we have more than one jobs and in our current code is checking for exactly one jobs. It should be failed.

We can hack current state without changing any code with:

`expect{ my_job.perform }.to have_enqueued_job(OtherJob).exactly(0).times`

but it's wierd.