### PR TITLE
Cache ActionView::FixtureResolvers created by stub_template

### DIFF
--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -14,6 +14,14 @@ module RSpec
       include RSpec::Rails::Matchers::RenderTemplate
 
       # @private
+      module StubResolverCache
+        def self.resolver_for(hash)
+          @resolvers ||= {}
+          @resolvers[hash] ||= ActionView::FixtureResolver.new(hash)
+        end
+      end
+
+      # @private
       module ClassMethods
         def _default_helper
           base = metadata[:description].split('/')[0..-2].join('/')
@@ -84,7 +92,7 @@ module RSpec
         #
         #     stub_template("widgets/_widget.html.erb" => "This content.")
         def stub_template(hash)
-          view.view_paths.unshift(ActionView::FixtureResolver.new(hash))
+          view.view_paths.unshift(StubResolverCache.resolver_for(hash))
         end
 
         # Provides access to the params hash that will be available within the

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -254,5 +254,25 @@ module RSpec::Rails
         view_spec.template
       end
     end
+
+    describe '#stub_template' do
+      let(:view_spec) do
+        Class.new do
+          include ViewExampleGroup::ExampleMethods
+          def _view
+            @_view ||= Struct.new(:view_paths).new(['some-path'])
+          end
+        end.new
+      end
+
+      it 'prepends an ActionView::FixtureResolver to the view path' do
+        view_spec.stub_template('some_path/some_template' => 'stubbed-contents')
+
+        result = view_spec.view.view_paths.first
+
+        expect(result).to be_instance_of(ActionView::FixtureResolver)
+        expect(result.hash).to eq('some_path/some_template' => 'stubbed-contents')
+      end
+    end
   end
 end

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -256,22 +256,33 @@ module RSpec::Rails
     end
 
     describe '#stub_template' do
-      let(:view_spec) do
+      let(:view_spec_group) do
         Class.new do
           include ViewExampleGroup::ExampleMethods
           def _view
             @_view ||= Struct.new(:view_paths).new(['some-path'])
           end
-        end.new
+        end
       end
 
       it 'prepends an ActionView::FixtureResolver to the view path' do
+        view_spec = view_spec_group.new
         view_spec.stub_template('some_path/some_template' => 'stubbed-contents')
 
         result = view_spec.view.view_paths.first
 
         expect(result).to be_instance_of(ActionView::FixtureResolver)
         expect(result.hash).to eq('some_path/some_template' => 'stubbed-contents')
+      end
+
+      it 'caches FixtureResolver instances between example groups' do
+        view_spec_one = view_spec_group.new
+        view_spec_two = view_spec_group.new
+
+        view_spec_one.stub_template('some_path/some_template' => 'stubbed-contents')
+        view_spec_two.stub_template('some_path/some_template' => 'stubbed-contents')
+
+        expect(view_spec_one.view.view_paths.first).to eq(view_spec_two.view.view_paths.first)
       end
     end
   end


### PR DESCRIPTION
The `#stub_template` view spec helper works by prepending an [`ActionView::FixtureResolver`](https://github.com/rails/rails/blob/9f65d2a08bc80a94bbb2c0b6e00957c7059aed25/actionview/lib/action_view/testing/resolvers.rb#L6-L9) to the view instance's `view_paths`. This intercepts queries for specific template files, providing a canned response that's used to instantiate a dummy `ActionView::Template`.

These canned responses still require compilation and [finalization](https://github.com/rails/rails/blob/9f65d2a08bc80a94bbb2c0b6e00957c7059aed25/actionview/lib/action_view/template.rb#L118-L126), however. As the resolver holds all the references to `ActionView::Template` instances, and a new resolver is created for each stub in every example, this means that a single `stub_template` call in a `before` block covering 20 examples will result in the same template being compiled and finalized 20 times.

Both compilation and finalization can be expensive. To avoid this expense where possible, this change adds a global resolver cache for stubbed templates.

By way of anecdote ('cos everyone loves those), this dropped our ~4k example view spec suite with ~500 `stub_template` calls from 6 min to 2 min total runtime.

If there's anything you'd like done differently, or if there are any negative consequences of this change I haven't thought of, just let me know; I'll be happy to update the PR accordingly.

Cheers,
Simon

edit: ugh, the [only build job that failed](https://travis-ci.org/rspec/rspec-rails/jobs/360415431) looks transient...