### PR TITLE
Update ruby versions for RSpec Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ cache: bundler
 bundler_args: "--binstubs --path ../bundle --retry=3 --jobs=3"
 
 before_install:
+  - gem update --system
+  - gem install bundler
   - script/clone_all_rspec_repos
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ bundler_args: "--binstubs --path ../bundle --retry=3 --jobs=3"
 
 before_install:
   - script/clone_all_rspec_repos
-  # Note this doesn't work on JRUBY 2.0.0 mode so we don't do it, the excluded versions are broken on Ruby 2.3
-  - if [ "jruby" != "$TRAVIS_RUBY_VERSION"  ]; then gem install bundler --version "1.15.4"; fi
-  - alias bundle="bundle _1.15.4_"
 
 before_script:
   # Rails 4.x complains with a bundler rails binstub in PROJECT_ROOT/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ script: "script/run_build 2>&1"
 
 rvm:
   - 1.8.7
-  - 2.4.2
-  - 2.3.5
+  - 2.4.4
+  - 2.3.7
   - 2.2
   - 2.1
   - 2.0.0
@@ -65,17 +65,23 @@ matrix:
       env: RAILS_VERSION=5-0-stable
     - rvm: 2.2.2
       env: RAILS_VERSION=5.1.0
-    - rvm: 2.3.5
+    - rvm: 2.3.7
       env: RAILS_VERSION=master
-    - rvm: 2.3.5
+    - rvm: 2.3.7
       env: RAILS_VERSION=5-0-stable
-    - rvm: 2.3.5
+    - rvm: 2.3.7
       env: RAILS_VERSION=5.1.0
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION=master
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION=5-0-stable
-    - rvm: 2.4.2
+    - rvm: 2.4.4
+      env: RAILS_VERSION=5.1.0
+    - rvm: 2.5.1
+      env: RAILS_VERSION=master
+    - rvm: 2.5.1
+      env: RAILS_VERSION=5-0-stable
+    - rvm: 2.5.1
       env: RAILS_VERSION=5.1.0
   exclude:
     # 3.0.x is not supported on MRI 2.0+
@@ -85,9 +91,9 @@ matrix:
       env: RAILS_VERSION='~> 3.0.20'
     - rvm: 2.2
       env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.3.5
+    - rvm: 2.3.7
       env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION='~> 3.0.20'
     # 4.x is not supported on MRI ruby-1.8.7 or 1.9.2
     - rvm: 1.8.7
@@ -117,36 +123,34 @@ matrix:
     # MRI 2.2+ is not supported on a few versions
     - rvm: 2.2
       env: RAILS_VERSION='~> 3.1.12'
-    - rvm: 2.3.5
+    - rvm: 2.3.7
       env: RAILS_VERSION='~> 3.1.12'
     # MRI 2.4+ is not supported on a few versions
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION='~> 4.1.0'
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION=4-1-stable
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION='~> 4.0.4'
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION=4-0-stable
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION='~> 3.2.17'
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION=3-2-stable
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION='~> 3.1.12'
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION=5.2.0.rc1
   allow_failures:
     - rvm: 2.2.2
       env: RAILS_VERSION=master
-    - rvm: 2.3.5
+    - rvm: 2.3.7
       env: RAILS_VERSION=master
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       env: RAILS_VERSION=master
-    - rvm: 2.4.2
-      env: RAILS_VERSION='~> 4.2.0'
-    - rvm: 2.4.2
-      env: RAILS_VERSION=4-2-stable
+    - rvm: 2.5.1
+      env: RAILS_VERSION=master
   fast_finish: true
 
 branches:

--- a/example_app_generator/travis_retry_bundle_install.sh
+++ b/example_app_generator/travis_retry_bundle_install.sh
@@ -5,7 +5,7 @@ source FUNCTIONS_SCRIPT_FILE
 
 echo "Starting bundle install using shared bundle path"
 if is_mri_192_plus; then
-  travis_retry eval "RUBYOPT=$RUBYOPT:'--enable rubygems' bundle install --gemfile ./Gemfile --path REPLACE_BUNDLE_PATH --retry=3 --jobs=3"
+  travis_retry eval "RUBYOPT=$RUBYOPT:' --enable rubygems' bundle install --gemfile ./Gemfile --path REPLACE_BUNDLE_PATH --retry=3 --jobs=3"
 else
   travis_retry eval "bundle install --gemfile ./Gemfile --path REPLACE_BUNDLE_PATH --retry=3 --jobs=3"
 fi


### PR DESCRIPTION
Other builds are unable to run Ruby 2.5.1 due to RSpec Rails so lets fix that and update Ruby versions at the same time.