### PR TITLE
Switch out deprecated class name causing error on Rails 6

### DIFF
--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -9,7 +9,11 @@ module RSpec
       # As of Rails 5.1.0 you can register directories to work with `rake notes`
       if ::Rails::VERSION::STRING >= '5.1'
         require 'rails/source_annotation_extractor'
-        SourceAnnotationExtractor::Annotation.register_directories("spec")
+        if ::Rails::VERSION::STRING >= '6.0'
+          Rails::SourceAnnotationExtractor::Annotation.register_directories("spec")
+        else
+          SourceAnnotationExtractor::Annotation.register_directories("spec")
+        end
       end
       # Rails-3.0.1 requires config.app_generators instead of 3.0.0's config.generators
       generators = config.respond_to?(:app_generators) ? config.app_generators : config.generators


### PR DESCRIPTION
Fixes #1984