### PR TITLE
Fix SourceAnnotationExtractor on Rails 6

### DIFF
--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -10,7 +10,7 @@ module RSpec
       if ::Rails::VERSION::STRING >= '5.1'
         require 'rails/source_annotation_extractor'
         if ::Rails::VERSION::STRING >= '6.0'
-          Rails::SourceAnnotationExtractor::Annotation.register_directories("spec")
+          ::Rails::SourceAnnotationExtractor::Annotation.register_directories("spec")
         else
           SourceAnnotationExtractor::Annotation.register_directories("spec")
         end


### PR DESCRIPTION
Without this fix, my tests fail when loading RSpec.
`uninitialized constant RSpec::Rails::SourceAnnotationExtractor`

With the fix, the constant is appropriately nested under the top-level `Rails` constant instead of trying to nest under `RSpec`, so my tests pass again.