### PR TITLE
Update and clean up Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,129 +34,201 @@ before_script:
 
 script: "script/run_build 2>&1"
 
-rvm:
-  - 1.8.7
-  - 2.4.4
-  - 2.3.7
-  - 2.2
-  - 2.1
-  - 2.0.0
-  - 1.9.3
-  - 1.9.2
-
-env:
-  - RAILS_VERSION='~> 4.2.0'
-  - RAILS_VERSION=4-2-stable
-  - RAILS_VERSION='~> 4.1.0'
-  - RAILS_VERSION=4-1-stable
-  - RAILS_VERSION='~> 4.0.4'
-  - RAILS_VERSION=4-0-stable
-  - RAILS_VERSION='~> 3.2.17'
-  - RAILS_VERSION=3-2-stable
-  - RAILS_VERSION='~> 3.1.12'
-  - RAILS_VERSION='~> 3.0.20'
-
 matrix:
   include:
-    # Rails 5.x only supports 2.2+
-    - rvm: 2.2.2
-      env: RAILS_VERSION=master
-    - rvm: 2.2.2
-      env: RAILS_VERSION=5-0-stable
-    - rvm: 2.2.2
-      env: RAILS_VERSION=5.1.0
-    - rvm: 2.3.7
-      env: RAILS_VERSION=master
-    - rvm: 2.3.7
-      env: RAILS_VERSION=5-0-stable
-    - rvm: 2.3.7
-      env: RAILS_VERSION=5.1.0
-    - rvm: 2.3.7
-      env: RAILS_VERSION=5.2.0
-    - rvm: 2.4.4
-      env: RAILS_VERSION=master
-    - rvm: 2.4.4
-      env: RAILS_VERSION=5-0-stable
-    - rvm: 2.4.4
-      env: RAILS_VERSION=5.1.0
-    - rvm: 2.4.4
-      env: RAILS_VERSION=5.2.0
+    # Test each supported Ruby minor version against applicable minor versions
+    # of Rails.
     - rvm: 2.5.1
       env: RAILS_VERSION=master
     - rvm: 2.5.1
+      env: RAILS_VERSION=5-2-stable
+    - rvm: 2.5.1
+      env: RAILS_VERSION=5-1-stable
+    - rvm: 2.5.1
       env: RAILS_VERSION=5-0-stable
     - rvm: 2.5.1
-      env: RAILS_VERSION=5.1.0
-    - rvm: 2.5.1
-      env: RAILS_VERSION=5.2.0
-  exclude:
-    # 3.0.x is not supported on MRI 2.0+
-    - rvm: 2.0.0
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.1
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.2
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.3.7
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.4.4
-      env: RAILS_VERSION='~> 3.0.20'
-    # 4.x is not supported on MRI ruby-1.8.7 or 1.9.2
-    - rvm: 1.8.7
-      env: RAILS_VERSION='~> 4.0.4'
-    - rvm: 1.9.2
-      env: RAILS_VERSION='~> 4.0.4'
-    - rvm: 1.8.7
-      env: RAILS_VERSION=4-0-stable
-    - rvm: 1.9.2
-      env: RAILS_VERSION=4-0-stable
-    - rvm: 1.8.7
-      env: RAILS_VERSION='~> 4.1.0'
-    - rvm: 1.9.2
-      env: RAILS_VERSION='~> 4.1.0'
-    - rvm: 1.8.7
-      env: RAILS_VERSION=4-1-stable
-    - rvm: 1.9.2
-      env: RAILS_VERSION=4-1-stable
-    - rvm: 1.8.7
-      env: RAILS_VERSION='~> 4.2.0'
-    - rvm: 1.9.2
-      env: RAILS_VERSION='~> 4.2.0'
-    - rvm: 1.8.7
       env: RAILS_VERSION=4-2-stable
-    - rvm: 1.9.2
+    - rvm: 2.5.1
+      env: RAILS_VERSION='~> 5.2.0'
+    - rvm: 2.5.1
+      env: RAILS_VERSION='~> 5.1.6'
+    - rvm: 2.5.1
+      env: RAILS_VERSION='~> 5.0.7'
+    - rvm: 2.5.1
+      env: RAILS_VERSION='~> 4.2.10'
+
+    - rvm: 2.4.4
+      env: RAILS_VERSION=master
+    - rvm: 2.4.4
+      env: RAILS_VERSION=5-2-stable
+    - rvm: 2.4.4
+      env: RAILS_VERSION=5-1-stable
+    - rvm: 2.4.4
+      env: RAILS_VERSION=5-0-stable
+    - rvm: 2.4.4
       env: RAILS_VERSION=4-2-stable
-    # MRI 2.2+ is not supported on a few versions
-    - rvm: 2.2
-      env: RAILS_VERSION='~> 3.1.12'
+    - rvm: 2.4.4
+      env: RAILS_VERSION='~> 5.2.0'
+    - rvm: 2.4.4
+      env: RAILS_VERSION='~> 5.1.6'
+    - rvm: 2.4.4
+      env: RAILS_VERSION='~> 5.0.7'
+    - rvm: 2.4.4
+      env: RAILS_VERSION='~> 4.2.10'
+
     - rvm: 2.3.7
-      env: RAILS_VERSION='~> 3.1.12'
-    # MRI 2.4+ is not supported on a few versions
-    - rvm: 2.4.4
-      env: RAILS_VERSION='~> 4.1.0'
-    - rvm: 2.4.4
+      env: RAILS_VERSION=5-2-stable
+    - rvm: 2.3.7
+      env: RAILS_VERSION=5-1-stable
+    - rvm: 2.3.7
+      env: RAILS_VERSION=5-0-stable
+    - rvm: 2.3.7
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 2.3.7
       env: RAILS_VERSION=4-1-stable
-    - rvm: 2.4.4
-      env: RAILS_VERSION='~> 4.0.4'
-    - rvm: 2.4.4
+    - rvm: 2.3.7
       env: RAILS_VERSION=4-0-stable
-    - rvm: 2.4.4
-      env: RAILS_VERSION='~> 3.2.17'
-    - rvm: 2.4.4
+    - rvm: 2.3.7
       env: RAILS_VERSION=3-2-stable
-    - rvm: 2.4.4
-      env: RAILS_VERSION='~> 3.1.12'
-    - rvm: 2.4.4
-      env: RAILS_VERSION=5.2.0.rc1
-  allow_failures:
-    - rvm: 2.2.2
-      env: RAILS_VERSION=master
     - rvm: 2.3.7
-      env: RAILS_VERSION=master
-    - rvm: 2.4.4
-      env: RAILS_VERSION=master
-    - rvm: 2.5.1
-      env: RAILS_VERSION=master
+      env: RAILS_VERSION='~> 5.2.0'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 5.1.6'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 5.0.7'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 4.2.10'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 4.1.16'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 4.0.13'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 3.2.22'
+
+    - rvm: 2.2.10
+      env: RAILS_VERSION=5-2-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION=5-1-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION=5-0-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION=4-0-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 5.2.0'
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 5.1.6'
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 5.0.7'
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 4.2.10'
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 4.1.16'
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 4.0.13'
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 3.2.22'
+
+    - rvm: 2.1.10
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 2.1.10
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 2.1.10
+      env: RAILS_VERSION=4-0-stable
+    - rvm: 2.1.10
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 2.1.10
+      env: RAILS_VERSION=3-1-stable
+    - rvm: 2.1.10
+      env: RAILS_VERSION='~> 4.2.10'
+    - rvm: 2.1.10
+      env: RAILS_VERSION='~> 4.1.16'
+    - rvm: 2.1.10
+      env: RAILS_VERSION='~> 4.0.13'
+    - rvm: 2.1.10
+      env: RAILS_VERSION='~> 3.2.22'
+    - rvm: 2.1.10
+      env: RAILS_VERSION='~> 3.1.12'
+
+    - rvm: 2.0.0
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 2.0.0
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 2.0.0
+      env: RAILS_VERSION=4-0-stable
+    - rvm: 2.0.0
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 2.0.0
+      env: RAILS_VERSION=3-1-stable
+    - rvm: 2.0.0
+      env: RAILS_VERSION='~> 4.2.10'
+    - rvm: 2.0.0
+      env: RAILS_VERSION='~> 4.1.16'
+    - rvm: 2.0.0
+      env: RAILS_VERSION='~> 4.0.13'
+    - rvm: 2.0.0
+      env: RAILS_VERSION='~> 3.2.22'
+    - rvm: 2.0.0
+      env: RAILS_VERSION='~> 3.1.12'
+
+    - rvm: 1.9.3
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION=4-0-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION=3-0-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 4.2.10'
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 4.1.16'
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 4.0.13'
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 3.2.22'
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 3.1.12'
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 3.0.20'
+
+    - rvm: 1.9.2
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 1.9.2
+      env: RAILS_VERSION=3-1-stable
+    - rvm: 1.9.2
+      env: RAILS_VERSION=3-0-stable
+    - rvm: 1.9.2
+      env: RAILS_VERSION='~> 3.2.22'
+    - rvm: 1.9.2
+      env: RAILS_VERSION='~> 3.1.12'
+    - rvm: 1.9.2
+      env: RAILS_VERSION='~> 3.0.20'
+
+    - rvm: 1.8.7
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 1.8.7
+      env: RAILS_VERSION=3-1-stable
+    - rvm: 1.8.7
+      env: RAILS_VERSION=3-0-stable
+    - rvm: 1.8.7
+      env: RAILS_VERSION='~> 3.2.22'
+    - rvm: 1.8.7
+      env: RAILS_VERSION='~> 3.1.12'
+    - rvm: 1.8.7
+      env: RAILS_VERSION='~> 3.0.20'
+
+  allow_failures:
+    - env: RAILS_VERSION=master
   fast_finish: true
 
 branches:

--- a/Gemfile
+++ b/Gemfile
@@ -31,10 +31,11 @@ end
 if RUBY_VERSION < '1.9'
   gem 'ffi', '< 1.9.19' # ffi dropped Ruby 1.8 support in 1.9.19
 end
+
 if RUBY_VERSION >= '2.0.0'
   gem 'rake', '>= 10.0.0'
 elsif RUBY_VERSION >= '1.9.3'
-  gem 'rake', '< 12.0.0' # rake 12 requires Ruby 2.0.0 or later
+  gem 'rake', '< 12.3' # rake 12.3 requires Ruby 2.0.0 or later
 else
   gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later
 end

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -1,8 +1,12 @@
 version_file = File.expand_path("../.rails-version", __FILE__)
+gem_list = %w[rails railties actionmailer actionpack activerecord activesupport activejob actionview]
+
 case version = ENV['RAILS_VERSION'] || (File.exist?(version_file) && File.read(version_file).chomp)
 when /master/
-  gem "rails", :git => "git://github.com/rails/rails.git"
-  gem "arel", :git => "git://github.com/rails/arel.git"
+  gem_list.each do |rails_gem|
+    gem rails_gem, :git => "git://github.com/rails/rails.git"
+  end
+
   gem "journey", :git => "git://github.com/rails/journey.git"
   gem "activerecord-deprecated_finders", :git => "git://github.com/rails/activerecord-deprecated_finders.git"
   gem "rails-observers", :git => "git://github.com/rails/rails-observers"
@@ -13,36 +17,27 @@ when /master/
   gem 'i18n', :git => 'git://github.com/svenfuchs/i18n.git', :branch => 'master'
   gem 'sprockets', :git => 'git://github.com/rails/sprockets.git', :branch => 'master'
   gem 'sprockets-rails', :git => 'git://github.com/rails/sprockets-rails.git', :branch => 'master'
-  if RUBY_VERSION  >= "1.9.3"
-    gem 'puma', :git => 'git://github.com/puma/puma', :branch => 'master'
-  end
+  gem 'puma', :git => 'git://github.com/puma/puma', :branch => 'master'
 when /stable$/
-  gem_list = %w[rails railties actionmailer actionpack activerecord activesupport]
-  gem_list << 'activejob'  if version > '4-1-stable'
-  gem_list << 'actionview' if version > '4-0-stable'
-  if RUBY_VERSION  >= "1.9.3"
-    gem_list << 'puma' if version > '5-0-stable'
-  end
-
+  gem 'puma' if version > '5-0-stable'
   gem_list.each do |rails_gem|
     gem rails_gem, :git => "git://github.com/rails/rails.git", :branch => version
   end
 when nil, false, ""
   if RUBY_VERSION < '1.9.3'
     # Rails 4+ requires 1.9.3+, so on earlier versions default to the last 3.x release.
-    gem "rails", "~> 3.2.17"
+    gem "rails", "~> 3.2.22"
   elsif RUBY_VERSION < '2.2.0'
     # Rails 5+ requires 2.2+, so on earlier versions default to the last 4.x release.
     gem "rails", "~> 4.2.0"
   else
-    gem "rails", "~> 5.0.0"
+    # default to latest release
+    gem "rails", "~> 5.2.0"
+    gem "puma"
   end
 else
   gem "rails", version
-
-  if version >= '5-1-stable' && RUBY_VERSION  >= "1.9.3"
-    gem "puma"
-  end
+  gem "puma" if version.match(/\d*(\.\d*)+/).to_s >= '5.1'
 end
 
 gem "i18n", '< 0.7.0' if RUBY_VERSION < '1.9.3'

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,17 @@ RSpec::Core::RakeTask.new(:spec) do |t|
 end
 
 Cucumber::Rake::Task.new(:cucumber) do |t|
-  version = ENV.fetch("RAILS_VERSION", "~> 4.2.0")[/\d[\.-]\d/]
+
+  # Resolve Rails version from build environment.
+  # 'master' resolves to 'master'. Other non-numeric values resolve to nil.
+  # Numeric strings with dot or hyphen separators resolve to a string with dot separators.
+  # Ex. - '4-2-master' or '~> 4.2.0' both resolve to '4.2'
+  version = ENV.fetch("RAILS_VERSION", "~> 4.2.0")
+  unless version == 'master'
+    version = version[/\d[\.-]\d/]
+    version.gsub!('-', '.') unless version.nil?
+  end
+
   tags = []
 
   if version.to_f >= 5.1


### PR DESCRIPTION
Sorry for the big commit, but these changes are all pretty inter-related. Splitting it up seemed like it would make things more complicated, not less.

1. Reworked .travis.yml. It used to be an auto-generated matrix, but the number of specific inclusions and exclusions made it confusing to try and update. I changed it to specifically list each build, ordered by Ruby version first and Rails version second.
2. Added Ruby 2.5 to supported Rails versions in .travis.yml.
3. Added stable git branches for Rails 5.1 and 5.2.
4. Removed redundant Rails git branches. Versions below 4.2 receive no updates, so testing these git branches was redundant with testing the released versions.
5. Updated each Ruby/Rails to latest patch version.
6. Fixed some dependency issues with newer Rails versions that were causing build errors.
7. Fixed an issue in the Rakefile that caused some versions to be tagged incorrectly, causing build errors.
8. Added a build for development version of Ruby using Rails 5.2 (failures allowed).
9. Removed tests of Ruby < 2.4 for Rails master.

Currently all released versions and stable branches build correctly. Rails master has a dependency issue causing failures, and Ruby-head has a segfault.

Please note that I did not intentionally remove any builds for old versions. The only builds I removed were git branches that were redundant with released gem versions. This PR is not meant to remove support for anything, only to improve coverage of new versions and maintainability of the build.