### PR TITLE
Explicitly list Ruby/Rails combinations in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,129 +34,170 @@ before_script:
 
 script: "script/run_build 2>&1"
 
-rvm:
-  - 1.8.7
-  - 2.4.4
-  - 2.3.7
-  - 2.2
-  - 2.1
-  - 2.0.0
-  - 1.9.3
-  - 1.9.2
-
-env:
-  - RAILS_VERSION='~> 4.2.0'
-  - RAILS_VERSION=4-2-stable
-  - RAILS_VERSION='~> 4.1.0'
-  - RAILS_VERSION=4-1-stable
-  - RAILS_VERSION='~> 4.0.4'
-  - RAILS_VERSION=4-0-stable
-  - RAILS_VERSION='~> 3.2.17'
-  - RAILS_VERSION=3-2-stable
-  - RAILS_VERSION='~> 3.1.12'
-  - RAILS_VERSION='~> 3.0.20'
-
 matrix:
   include:
-    # Rails 5.x only supports 2.2+
-    - rvm: 2.2.2
-      env: RAILS_VERSION=master
-    - rvm: 2.2.2
-      env: RAILS_VERSION=5-0-stable
-    - rvm: 2.2.2
-      env: RAILS_VERSION=5.1.0
-    - rvm: 2.3.7
-      env: RAILS_VERSION=master
-    - rvm: 2.3.7
-      env: RAILS_VERSION=5-0-stable
-    - rvm: 2.3.7
-      env: RAILS_VERSION=5.1.0
-    - rvm: 2.3.7
-      env: RAILS_VERSION=5.2.0
-    - rvm: 2.4.4
-      env: RAILS_VERSION=master
-    - rvm: 2.4.4
-      env: RAILS_VERSION=5-0-stable
-    - rvm: 2.4.4
-      env: RAILS_VERSION=5.1.0
-    - rvm: 2.4.4
-      env: RAILS_VERSION=5.2.0
+    # Test each supported Ruby minor version against applicable minor versions
+    # of Rails.
     - rvm: 2.5.1
       env: RAILS_VERSION=master
     - rvm: 2.5.1
       env: RAILS_VERSION=5-0-stable
     - rvm: 2.5.1
-      env: RAILS_VERSION=5.1.0
+      env: RAILS_VERSION='~> 5.2.0'
     - rvm: 2.5.1
-      env: RAILS_VERSION=5.2.0
-  exclude:
-    # 3.0.x is not supported on MRI 2.0+
-    - rvm: 2.0.0
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.1
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.2
-      env: RAILS_VERSION='~> 3.0.20'
-    - rvm: 2.3.7
-      env: RAILS_VERSION='~> 3.0.20'
+      env: RAILS_VERSION='~> 5.1.6'
+
     - rvm: 2.4.4
-      env: RAILS_VERSION='~> 3.0.20'
-    # 4.x is not supported on MRI ruby-1.8.7 or 1.9.2
-    - rvm: 1.8.7
-      env: RAILS_VERSION='~> 4.0.4'
-    - rvm: 1.9.2
-      env: RAILS_VERSION='~> 4.0.4'
-    - rvm: 1.8.7
-      env: RAILS_VERSION=4-0-stable
-    - rvm: 1.9.2
-      env: RAILS_VERSION=4-0-stable
-    - rvm: 1.8.7
-      env: RAILS_VERSION='~> 4.1.0'
-    - rvm: 1.9.2
-      env: RAILS_VERSION='~> 4.1.0'
-    - rvm: 1.8.7
-      env: RAILS_VERSION=4-1-stable
-    - rvm: 1.9.2
-      env: RAILS_VERSION=4-1-stable
-    - rvm: 1.8.7
-      env: RAILS_VERSION='~> 4.2.0'
-    - rvm: 1.9.2
-      env: RAILS_VERSION='~> 4.2.0'
-    - rvm: 1.8.7
+      env: RAILS_VERSION=master
+    - rvm: 2.4.4
+      env: RAILS_VERSION=5-0-stable
+    - rvm: 2.4.4
       env: RAILS_VERSION=4-2-stable
-    - rvm: 1.9.2
-      env: RAILS_VERSION=4-2-stable
-    # MRI 2.2+ is not supported on a few versions
-    - rvm: 2.2
-      env: RAILS_VERSION='~> 3.1.12'
+    - rvm: 2.4.4
+      env: RAILS_VERSION='~> 5.2.0'
+    - rvm: 2.4.4
+      env: RAILS_VERSION='~> 5.1.6'
+    - rvm: 2.4.4
+      env: RAILS_VERSION='~> 4.2.10'
+
     - rvm: 2.3.7
-      env: RAILS_VERSION='~> 3.1.12'
-    # MRI 2.4+ is not supported on a few versions
-    - rvm: 2.4.4
-      env: RAILS_VERSION='~> 4.1.0'
-    - rvm: 2.4.4
+      env: RAILS_VERSION=5-0-stable
+    - rvm: 2.3.7
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 2.3.7
       env: RAILS_VERSION=4-1-stable
-    - rvm: 2.4.4
-      env: RAILS_VERSION='~> 4.0.4'
-    - rvm: 2.4.4
+    - rvm: 2.3.7
       env: RAILS_VERSION=4-0-stable
-    - rvm: 2.4.4
-      env: RAILS_VERSION='~> 3.2.17'
-    - rvm: 2.4.4
+    - rvm: 2.3.7
       env: RAILS_VERSION=3-2-stable
-    - rvm: 2.4.4
-      env: RAILS_VERSION='~> 3.1.12'
-    - rvm: 2.4.4
-      env: RAILS_VERSION=5.2.0.rc1
-  allow_failures:
-    - rvm: 2.2.2
-      env: RAILS_VERSION=master
     - rvm: 2.3.7
-      env: RAILS_VERSION=master
-    - rvm: 2.4.4
-      env: RAILS_VERSION=master
-    - rvm: 2.5.1
-      env: RAILS_VERSION=master
+      env: RAILS_VERSION='~> 5.2.0'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 5.1.6'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 4.2.10'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 4.1.16'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 4.0.13'
+    - rvm: 2.3.7
+      env: RAILS_VERSION='~> 3.2.22'
+
+      env: RAILS_VERSION=5-0-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION=4-0-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 5.1.6'
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 4.2.10'
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 4.1.16'
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 4.0.13'
+    - rvm: 2.2.10
+      env: RAILS_VERSION='~> 3.2.22'
+
+    - rvm: 2.1.10
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 2.1.10
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 2.1.10
+      env: RAILS_VERSION=4-0-stable
+    - rvm: 2.1.10
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 2.1.10
+      env: RAILS_VERSION=3-1-stable
+    - rvm: 2.1.10
+      env: RAILS_VERSION='~> 4.2.10'
+    - rvm: 2.1.10
+      env: RAILS_VERSION='~> 4.1.16'
+    - rvm: 2.1.10
+      env: RAILS_VERSION='~> 4.0.13'
+    - rvm: 2.1.10
+      env: RAILS_VERSION='~> 3.2.22'
+    - rvm: 2.1.10
+      env: RAILS_VERSION='~> 3.1.12'
+
+    - rvm: 2.0.0
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 2.0.0
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 2.0.0
+      env: RAILS_VERSION=4-0-stable
+    - rvm: 2.0.0
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 2.0.0
+      env: RAILS_VERSION=3-1-stable
+    - rvm: 2.0.0
+      env: RAILS_VERSION='~> 4.2.10'
+    - rvm: 2.0.0
+      env: RAILS_VERSION='~> 4.1.16'
+    - rvm: 2.0.0
+      env: RAILS_VERSION='~> 4.0.13'
+    - rvm: 2.0.0
+      env: RAILS_VERSION='~> 3.2.22'
+    - rvm: 2.0.0
+      env: RAILS_VERSION='~> 3.1.12'
+
+    - rvm: 1.9.3
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION=4-0-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION=3-0-stable
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 4.2.10'
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 4.1.16'
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 4.0.13'
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 3.2.22'
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 3.1.12'
+    - rvm: 1.9.3
+      env: RAILS_VERSION='~> 3.0.20'
+
+    - rvm: 1.9.2
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 1.9.2
+      env: RAILS_VERSION=3-1-stable
+    - rvm: 1.9.2
+      env: RAILS_VERSION=3-0-stable
+    - rvm: 1.9.2
+      env: RAILS_VERSION='~> 3.2.22'
+    - rvm: 1.9.2
+      env: RAILS_VERSION='~> 3.1.12'
+    - rvm: 1.9.2
+      env: RAILS_VERSION='~> 3.0.20'
+
+    - rvm: 1.8.7
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 1.8.7
+      env: RAILS_VERSION=3-1-stable
+    - rvm: 1.8.7
+      env: RAILS_VERSION=3-0-stable
+    - rvm: 1.8.7
+      env: RAILS_VERSION='~> 3.2.22'
+    - rvm: 1.8.7
+      env: RAILS_VERSION='~> 3.1.12'
+    - rvm: 1.8.7
+      env: RAILS_VERSION='~> 3.0.20'
+
+  allow_failures:
+    - env: RAILS_VERSION=master
   fast_finish: true
 
 branches:


### PR DESCRIPTION
This PR separates out some of the changes originally included in #1998. Instead of applying inclusions and exclusions to an auto-generated matrix, now every Ruby/Rails combination to be tested is explicitly listed.

Other changes:
1. Patch version bumps
2. Specific versions changed to tilde version specifiers
3. Tests for Ruby < 2.4 not tested against Rails master, which now requires Ruby 2.4+