### PR TITLE
Vendor RSpec::Matchers::BuiltIn::BaseMatcher.

### DIFF
--- a/lib/rspec/rails/matchers.rb
+++ b/lib/rspec/rails/matchers.rb
@@ -11,6 +11,7 @@ module RSpec
   end
 end
 
+require 'rspec/rails/matchers/base_matcher'
 require 'rspec/rails/matchers/have_rendered'
 require 'rspec/rails/matchers/redirect_to'
 require 'rspec/rails/matchers/routing_matchers'

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -10,7 +10,7 @@ module RSpec
       module ActiveJob
         # rubocop: disable Style/ClassLength
         # @private
-        class Base < RSpec::Matchers::BuiltIn::BaseMatcher
+        class Base < RSpec::Rails::Matchers::BaseMatcher
           def initialize
             @args = []
             @queue = nil

--- a/lib/rspec/rails/matchers/base_matcher.rb
+++ b/lib/rspec/rails/matchers/base_matcher.rb
@@ -48,8 +48,8 @@ module RSpec
         # Generates a description using {EnglishPhrasing}.
         # @return [String]
         def description
-          desc = EnglishPhrasing.split_words(self.class.matcher_name)
-          desc << EnglishPhrasing.list(@expected) if defined?(@expected)
+          desc = RSpec::Matchers::EnglishPhrasing.split_words(self.class.matcher_name)
+          desc << RSpec::Matchers::EnglishPhrasing.list(@expected) if defined?(@expected)
           desc
         end
 
@@ -113,7 +113,7 @@ module RSpec
 
         def assert_ivars(*expected_ivars)
           return unless (expected_ivars - present_ivars).any?
-          ivar_list = EnglishPhrasing.list(expected_ivars)
+          ivar_list = RSpec::Matchers::EnglishPhrasing.list(expected_ivars)
           raise "#{self.class.name} needs to supply#{ivar_list}"
         end
 

--- a/lib/rspec/rails/matchers/base_matcher.rb
+++ b/lib/rspec/rails/matchers/base_matcher.rb
@@ -1,0 +1,183 @@
+module RSpec
+  module Rails
+    module Matchers
+      class BaseMatcher
+        include RSpec::Matchers::Composable
+
+        # @api private
+        # Used to detect when no arg is passed to `initialize`.
+        # `nil` cannot be used because it's a valid value to pass.
+        UNDEFINED = Object.new.freeze
+
+        # @private
+        attr_reader :actual, :expected, :rescued_exception
+
+        # @private
+        attr_writer :matcher_name
+
+        def initialize(expected=UNDEFINED)
+          @expected = expected unless UNDEFINED.equal?(expected)
+        end
+
+        # @api private
+        # Indicates if the match is successful. Delegates to `match`, which
+        # should be defined on a subclass. Takes care of consistently
+        # initializing the `actual` attribute.
+        def matches?(actual)
+          @actual = actual
+          match(expected, actual)
+        end
+
+        # @api private
+        # Used to wrap a block of code that will indicate failure by
+        # raising one of the named exceptions.
+        #
+        # This is used by rspec-rails for some of its matchers that
+        # wrap rails' assertions.
+        def match_unless_raises(*exceptions)
+          exceptions.unshift Exception if exceptions.empty?
+          begin
+            yield
+            true
+          rescue *exceptions => @rescued_exception
+            false
+          end
+        end
+
+        # @api private
+        # Generates a description using {EnglishPhrasing}.
+        # @return [String]
+        def description
+          desc = EnglishPhrasing.split_words(self.class.matcher_name)
+          desc << EnglishPhrasing.list(@expected) if defined?(@expected)
+          desc
+        end
+
+        # @api private
+        # Matchers are not diffable by default. Override this to make your
+        # subclass diffable.
+        def diffable?
+          false
+        end
+
+        # @api private
+        # Most matchers are value matchers (i.e. meant to work with `expect(value)`)
+        # rather than block matchers (i.e. meant to work with `expect { }`), so
+        # this defaults to false. Block matchers must override this to return true.
+        def supports_block_expectations?
+          false
+        end
+
+        # @api private
+        def expects_call_stack_jump?
+          false
+        end
+
+        # @private
+        def expected_formatted
+          RSpec::Support::ObjectFormatter.format(@expected)
+        end
+
+        # @private
+        def actual_formatted
+          RSpec::Support::ObjectFormatter.format(@actual)
+        end
+
+        # @private
+        def self.matcher_name
+          @matcher_name ||= underscore(name.split('::').last)
+        end
+
+        # @private
+        def matcher_name
+          if defined?(@matcher_name)
+            @matcher_name
+          else
+            self.class.matcher_name
+          end
+        end
+
+        # @private
+        # Borrowed from ActiveSupport.
+        def self.underscore(camel_cased_word)
+          word = camel_cased_word.to_s.dup
+          word.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+          word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+          word.tr!('-', '_')
+          word.downcase!
+          word
+        end
+        private_class_method :underscore
+
+      private
+
+        def assert_ivars(*expected_ivars)
+          return unless (expected_ivars - present_ivars).any?
+          ivar_list = EnglishPhrasing.list(expected_ivars)
+          raise "#{self.class.name} needs to supply#{ivar_list}"
+        end
+
+        if RUBY_VERSION.to_f < 1.9
+          # :nocov:
+          def present_ivars
+            instance_variables.map(&:to_sym)
+          end
+          # :nocov:
+        else
+          alias present_ivars instance_variables
+        end
+
+        # @private
+        module HashFormatting
+          # `{ :a => 5, :b => 2 }.inspect` produces:
+          #
+          #     {:a=>5, :b=>2}
+          #
+          # ...but it looks much better as:
+          #
+          #     {:a => 5, :b => 2}
+          #
+          # This is idempotent and safe to run on a string multiple times.
+          def improve_hash_formatting(inspect_string)
+            inspect_string.gsub(/(\S)=>(\S)/, '\1 => \2')
+          end
+          module_function :improve_hash_formatting
+        end
+
+        include HashFormatting
+
+        # @api private
+        # Provides default implementations of failure messages, based on the `description`.
+        module DefaultFailureMessages
+          # @api private
+          # Provides a good generic failure message. Based on `description`.
+          # When subclassing, if you are not satisfied with this failure message
+          # you often only need to override `description`.
+          # @return [String]
+          def failure_message
+            "expected #{description_of @actual} to #{description}".dup
+          end
+
+          # @api private
+          # Provides a good generic negative failure message. Based on `description`.
+          # When subclassing, if you are not satisfied with this failure message
+          # you often only need to override `description`.
+          # @return [String]
+          def failure_message_when_negated
+            "expected #{description_of @actual} not to #{description}".dup
+          end
+
+          # @private
+          def self.has_default_failure_messages?(matcher)
+            matcher.method(:failure_message).owner == self &&
+              matcher.method(:failure_message_when_negated).owner == self
+          rescue NameError
+            false
+          end
+        end
+
+        include DefaultFailureMessages
+      end
+    end
+  end
+end

--- a/lib/rspec/rails/matchers/base_matcher.rb
+++ b/lib/rspec/rails/matchers/base_matcher.rb
@@ -1,6 +1,7 @@
 module RSpec
   module Rails
     module Matchers
+      # @ api private
       class BaseMatcher
         include RSpec::Matchers::Composable
 

--- a/lib/rspec/rails/matchers/base_matcher.rb
+++ b/lib/rspec/rails/matchers/base_matcher.rb
@@ -46,7 +46,7 @@ module RSpec
         end
 
         # @api private
-        # Generates a description using {EnglishPhrasing}.
+        # Generates a description using {RSpec::Matchers::EnglishPhrasing}.
         # @return [String]
         def description
           desc = RSpec::Matchers::EnglishPhrasing.split_words(self.class.matcher_name)

--- a/lib/rspec/rails/matchers/base_matcher.rb
+++ b/lib/rspec/rails/matchers/base_matcher.rb
@@ -16,7 +16,7 @@ module RSpec
         # @private
         attr_writer :matcher_name
 
-        def initialize(expected=UNDEFINED)
+        def initialize(expected = UNDEFINED)
           @expected = expected unless UNDEFINED.equal?(expected)
         end
 

--- a/lib/rspec/rails/matchers/be_a_new.rb
+++ b/lib/rspec/rails/matchers/be_a_new.rb
@@ -6,7 +6,7 @@ module RSpec
       # Matcher class for `be_a_new`. Should not be instantiated directly.
       #
       # @see RSpec::Rails::Matchers#be_a_new
-      class BeANew < RSpec::Matchers::BuiltIn::BaseMatcher
+      class BeANew < RSpec::Rails::Matchers::BaseMatcher
         # @private
         def initialize(expected)
           @expected = expected

--- a/lib/rspec/rails/matchers/be_new_record.rb
+++ b/lib/rspec/rails/matchers/be_new_record.rb
@@ -2,7 +2,7 @@ module RSpec
   module Rails
     module Matchers
       # @private
-      class BeANewRecord < RSpec::Matchers::BuiltIn::BaseMatcher
+      class BeANewRecord < RSpec::Rails::Matchers::BaseMatcher
         def matches?(actual)
           actual.new_record?
         end

--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -73,7 +73,7 @@ module RSpec
         #   expect(response).to have_http_status(404)
         #
         # @see RSpec::Rails::Matchers.have_http_status
-        class NumericCode < RSpec::Matchers::BuiltIn::BaseMatcher
+        class NumericCode < RSpec::Rails::Matchers::BaseMatcher
           include HaveHttpStatus
 
           def initialize(code)
@@ -124,7 +124,7 @@ module RSpec
         #
         # @see RSpec::Rails::Matchers.have_http_status
         # @see https://github.com/rack/rack/blob/master/lib/rack/utils.rb `Rack::Utils::SYMBOL_TO_STATUS_CODE`
-        class SymbolicStatus < RSpec::Matchers::BuiltIn::BaseMatcher
+        class SymbolicStatus < RSpec::Rails::Matchers::BaseMatcher
           include HaveHttpStatus
 
           def initialize(status)
@@ -236,7 +236,7 @@ module RSpec
         #
         # @see RSpec::Rails::Matchers.have_http_status
         # @see ActionDispatch::TestResponse
-        class GenericStatus < RSpec::Matchers::BuiltIn::BaseMatcher
+        class GenericStatus < RSpec::Rails::Matchers::BaseMatcher
           include HaveHttpStatus
 
           # @return [Array<Symbol>] of status codes which represent a HTTP status

--- a/lib/rspec/rails/matchers/have_rendered.rb
+++ b/lib/rspec/rails/matchers/have_rendered.rb
@@ -4,7 +4,7 @@ module RSpec
       # Matcher for template rendering.
       module RenderTemplate
         # @private
-        class RenderTemplateMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
+        class RenderTemplateMatcher < RSpec::Rails::Matchers::BaseMatcher
           def initialize(scope, expected, message = nil)
             @expected = Symbol === expected ? expected.to_s : expected
             @message = message

--- a/lib/rspec/rails/matchers/redirect_to.rb
+++ b/lib/rspec/rails/matchers/redirect_to.rb
@@ -4,7 +4,7 @@ module RSpec
       # Matcher for redirects.
       module RedirectTo
         # @private
-        class RedirectTo < RSpec::Matchers::BuiltIn::BaseMatcher
+        class RedirectTo < RSpec::Rails::Matchers::BaseMatcher
           def initialize(scope, expected)
             @expected = expected
             @scope = scope

--- a/lib/rspec/rails/matchers/routing_matchers.rb
+++ b/lib/rspec/rails/matchers/routing_matchers.rb
@@ -6,7 +6,7 @@ module RSpec
         extend RSpec::Matchers::DSL
 
         # @private
-        class RouteToMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
+        class RouteToMatcher < RSpec::Rails::Matchers::BaseMatcher
           def initialize(scope, *expected)
             @scope = scope
             @expected = expected[1] || {}
@@ -63,7 +63,7 @@ module RSpec
         end
 
         # @private
-        class BeRoutableMatcher < RSpec::Matchers::BuiltIn::BaseMatcher
+        class BeRoutableMatcher < RSpec::Rails::Matchers::BaseMatcher
           def initialize(scope)
             @scope = scope
           end


### PR DESCRIPTION
This is in aid of moving RSpec Rails off RSpec expectations private API.

Going forward, it would be cool to refactor this base matcher to not be
a total and direct copy of RSpec Expectations' implementation, and
rather an implementation of the matcher API that rails needs, but for
right now this was the fastest route to green.

Going forward in to RSpec 4, it's good to flag that this might cause breakage,
given that the internal matcher API might change. I'd say that the matcher API
is mostly stable enough at this point, so I'm not hugely concerned.
@myronmarston, @jonrowe, @benoittgt do you predict the RSpec matchers API
changing drastically enough in RSpec 4 to cause this to be problematic?

One thing that I'd note here is that I think it'd be cool if we had a really
good step by step guide for implementing the matcher protocol from scratch, as
opposed to using custom matchers or inheriting from base matcher. Right now
there's no obvious human readable documentation for that. Maybe that's
something I could find a new contributor to do?