### PR TITLE
Add gem version and semver stability badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rspec-rails [![Build Status](https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=master)](http://travis-ci.org/rspec/rspec-rails) [![Code Climate](https://img.shields.io/codeclimate/github/rspec/rspec-rails.svg)](https://codeclimate.com/github/rspec/rspec-rails)
+# rspec-rails [![Build Status](https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=master)](http://travis-ci.org/rspec/rspec-rails) [![Code Climate](https://img.shields.io/codeclimate/coverage/rspec/rspec-rails.svg)](https://codeclimate.com/github/rspec/rspec-rails) [![Gem Version](https://badge.fury.io/rb/rspec-rails.svg)](http://badge.fury.io/rb/rspec-rails)
 **rspec-rails** is a testing framework for Rails 3.x, 4.x and 5.x.
 
 Use **[rspec-rails 1.x](http://github.com/dchelimsky/rspec-rails)** for Rails

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rspec-rails [![Build Status](https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=master)](http://travis-ci.org/rspec/rspec-rails) [![Code Climate](https://img.shields.io/codeclimate/coverage/rspec/rspec-rails.svg)](https://codeclimate.com/github/rspec/rspec-rails) [![Gem Version](https://badge.fury.io/rb/rspec-rails.svg)](http://badge.fury.io/rb/rspec-rails)
+# rspec-rails [![Build Status](https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=master)](http://travis-ci.org/rspec/rspec-rails) [![Code Climate](https://codeclimate.com/github/rspec/rspec-rails.svg)](https://codeclimate.com/github/rspec/rspec-rails) [![Gem Version](https://badge.fury.io/rb/rspec-rails.svg)](http://badge.fury.io/rb/rspec-rails)
 **rspec-rails** is a testing framework for Rails 3.x, 4.x and 5.x.
 
 Use **[rspec-rails 1.x](http://github.com/dchelimsky/rspec-rails)** for Rails


### PR DESCRIPTION
First of all, thanks for rspec-rails! I've used it on every Rails project I've ever worked on, and love it.

Would you be up for adding badges that display the current version on `rspec-rails`, and its semver stability? The former is pretty self-explanatory, the later is a new badge I've made that displays the percentage of rspec-rails users' CI runs that pass when updating rspec-rails between SemVer compatible versions. Data comes from Dependabot (disclosure: I built it).

I've also fixed the Code Climate badge in this PR (the URL must have changed on shields.io).

The badges now look like this:

[![Build Status](https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=master)](http://travis-ci.org/rspec/rspec-rails) [![Code Climate](https://img.shields.io/codeclimate/coverage/rspec/rspec-rails.svg)](https://codeclimate.com/github/rspec/rspec-rails) [![Gem Version](https://badge.fury.io/rb/rspec-rails.svg)](http://badge.fury.io/rb/rspec-rails) [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=rspec-rails&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=rspec-rails&package-manager=bundler&version-scheme=semver)