### PR TITLE
Update supported Rails versions in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rspec-rails [![Build Status](https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=master)](http://travis-ci.org/rspec/rspec-rails) [![Code Climate](https://img.shields.io/codeclimate/github/rspec/rspec-rails.svg)](https://codeclimate.com/github/rspec/rspec-rails)
-**rspec-rails** is a testing framework for Rails 3.x, 4.x and 5.0.
+**rspec-rails** is a testing framework for Rails 3.x, 4.x and 5.x.
 
 Use **[rspec-rails 1.x](http://github.com/dchelimsky/rspec-rails)** for Rails
 2.x.


### PR DESCRIPTION
Clear-up that `rspec-rails` works with Rails versions above 5.0