### PR TITLE
Clarify that binstub can be created on Rails 4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ bundle exec rspec spec/controllers/accounts_controller_spec.rb:8
 Specs can also be run via `rake spec`, though this command may be slower to
 start than the `rspec` command.
 
-In Rails 4, you may want to create a binstub for the `rspec` command so it can
+In Rails 4+, you may want to create a binstub for the `rspec` command so it can
 be run via `bin/rspec`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ bundle exec rspec spec/controllers/accounts_controller_spec.rb:8
 Specs can also be run via `rake spec`, though this command may be slower to
 start than the `rspec` command.
 
-In Rails 4+, you may want to create a binstub for the `rspec` command so it can
+In Rails 4/5+, you may want to create a binstub for the `rspec` command so it can
 be run via `bin/rspec`:
 
 ```


### PR DESCRIPTION
It's not just Rails 4.

I know this is a baby change but people could be confused into thinking it only works on Rails 4, not 5.