### PR TITLE
Avoid deprecated TestResponse#success? method

### DIFF
--- a/lib/generators/rspec/scaffold/templates/api_controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/api_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% else -%>
       get :index, params: {}, session: valid_session
 <% end -%>
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 
@@ -64,7 +64,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% else -%>
       get :show, params: {id: <%= file_name %>.to_param}, session: valid_session
 <% end -%>
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% else -%>
       get :index, params: {}, session: valid_session
 <% end -%>
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 
@@ -64,7 +64,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% else -%>
       get :show, params: {id: <%= file_name %>.to_param}, session: valid_session
 <% end -%>
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 
@@ -75,7 +75,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% else -%>
       get :new, params: {}, session: valid_session
 <% end -%>
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 
@@ -87,7 +87,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% else -%>
       get :edit, params: {id: <%= file_name %>.to_param}, session: valid_session
 <% end -%>
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 
@@ -120,7 +120,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% else -%>
         post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
 <% end -%>
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end
@@ -161,7 +161,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 <% else -%>
         put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
 <% end -%>
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end


### PR DESCRIPTION
Closes #2009

`TestResponse#success?` was deprecated with [this commit](https://github.com/rails/rails/commit/af3500b18817a48d7ec83812a0d4869f3fe33b2f). Instead, we can use `#successful?` from `Rack::Response::Helpers`. This method has been available for a long time. I tried this change with Rails 3.2, 4.2, and 5.2 and everything seemed to work fine.