### PR TITLE
Documentation for `have_enqueued_job` (#1576)

### DIFF
--- a/features/matchers/have_enqueued_job_matcher.feature
+++ b/features/matchers/have_enqueued_job_matcher.feature
@@ -39,6 +39,26 @@ Feature: have_enqueued_job matcher
     When I run `rspec spec/jobs/upload_backups_job_spec.rb`
     Then the examples should all pass
 
+  Scenario: Checking passed arguments to job - block syntax
+    Given a file named "spec/jobs/upload_backups_job_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe UploadBackupsJob do
+        it "matches with enqueued job" do
+          ActiveJob::Base.queue_adapter = :test
+          expect {
+            UploadBackupsJob.perform_later('backups.txt', rand(100), 'uninteresting third argument')
+          }.to have_enqueued_job.with { |file_name, seed|
+            expect(file_name).to eq 'backups.txt'
+            expect(seed).to be < 100
+          }
+        end
+      end
+      """
+    When I run `rspec spec/jobs/upload_backups_job_spec.rb`
+    Then the examples should all pass
+
   Scenario: Checking job enqueued time
     Given a file named "spec/jobs/upload_backups_job_spec.rb" with:
       """ruby

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -240,6 +240,14 @@ module RSpec
       #     expect {
       #       HelloJob.set(queue: "low").perform_later(42)
       #     }.to have_enqueued_job.with(42).on_queue("low").at(:no_wait)
+      #
+      #     expect {
+      #       HelloJob.perform_later('rspec_rails', %w[ world rspec rails ], 42)
+      #     }.to have_enqueued_job.with { |_from, to, times|
+      #       # I don't want to check argument `from`
+      #       expect(to).to include 'rspec'
+      #       expect(times).to eq 42
+      #     }
       def have_enqueued_job(job = nil)
         check_active_job_adapter
         ActiveJob::HaveEnqueuedJob.new(job)


### PR DESCRIPTION
Updating the docs for checking arguments passed to job with `block` syntax