### PR TITLE
Fix `NoMethodError` for `Pathname` fixture paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,8 @@ Enhancements:
 
 Bug Fixes:
 
+* Fix `NoMethodError: undefined method 'strip'` when using a `Pathname` object
+  as the fixture file path. (Aaron Kromer, #2026)
 * Escape quotation characters when producing method names for system spec
   screenshots. (Shane Cavanaugh, #1955)
 * Use relative path for resolving fixtures when `fixture_path` is not set.

--- a/lib/rspec/rails/fixture_file_upload_support.rb
+++ b/lib/rspec/rails/fixture_file_upload_support.rb
@@ -8,7 +8,7 @@ module RSpec
 
       def rails_fixture_file_wrapper
         RailsFixtureFileWrapper.fixture_path = nil
-        resolved_fixture_path = (fixture_path || RSpec.configuration.fixture_path || '')
+        resolved_fixture_path = (fixture_path || RSpec.configuration.fixture_path || '').to_s
         RailsFixtureFileWrapper.fixture_path = File.join(resolved_fixture_path, '') unless resolved_fixture_path.strip.empty?
         RailsFixtureFileWrapper.instance
       end

--- a/spec/rspec/rails/fixture_file_upload_support_spec.rb
+++ b/spec/rspec/rails/fixture_file_upload_support_spec.rb
@@ -7,6 +7,11 @@ module RSpec::Rails
         RSpec.configuration.fixture_path = File.dirname(__FILE__)
         expect(fixture_file_upload_resolved('fixture_file_upload_support_spec.rb').run).to be true
       end
+
+      it 'resolves supports `Pathname` objects' do
+        RSpec.configuration.fixture_path = Pathname(File.dirname(__FILE__))
+        expect(fixture_file_upload_resolved('fixture_file_upload_support_spec.rb').run).to be true
+      end
     end
 
     context 'with fixture path set in spec' do


### PR DESCRIPTION
When the `fixture_path` is defined as a `Pathname` object the `rails_fixture_file_wrapper` fails with:

    NoMethodError:
      undefined method `strip' for #<Pathname:0x00007fab0a970e70>

This resolves the issue by ensuring the fixture path is converted into a string prior to resolving it.