### PR TITLE
Jump to last bundler version how doesn't break on CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ bundler_args: "--binstubs --path ../bundle --retry=3 --jobs=3"
 
 before_install:
   - gem update --system
-  - gem install bundler -v 1.16.2
+  - gem install bundler
   - script/clone_all_rspec_repos
 
 before_script:


### PR DESCRIPTION
On bundle 1.16.3 we start seeing fail builds:
- https://github.com/rspec/rspec-rails/pull/2013#issuecomment-406566941

This is related to:
- https://github.com/rspec/rspec-rails/pull/2013#issuecomment-406567191

As mentionned this has been fixed in 1.16.4:
- https://github.com/bundler/bundler/issues/6629#issuecomment-422576906