### PR TITLE
[Fixes #1877] Do not duplicate namespace in the path name

### DIFF
--- a/lib/generators/rspec/feature/feature_generator.rb
+++ b/lib/generators/rspec/feature/feature_generator.rb
@@ -19,9 +19,9 @@ module Rspec
 
       def filename
         if options[:singularize]
-          "#{table_name.singularize}_spec.rb"
+          "#{file_name.singularize}_spec.rb"
         else
-          "#{table_name}_spec.rb"
+          "#{file_name}_spec.rb"
         end
       end
     end

--- a/spec/generators/rspec/feature/feature_generator_spec.rb
+++ b/spec/generators/rspec/feature/feature_generator_spec.rb
@@ -24,6 +24,21 @@ RSpec.describe Rspec::Generators::FeatureGenerator, :type => :generator do
       end
     end
 
+    describe 'are generated with the correct namespace' do
+      before do
+        run_generator %w(folder/posts)
+      end
+      describe 'the spec' do
+        subject(:feature_spec) { file('spec/features/folder/posts_spec.rb') }
+        it "exists" do
+          expect(feature_spec).to exist
+        end
+        it "contains the feature" do
+          expect(feature_spec).to contain(/^RSpec.feature \"Folder::Posts\", #{type_metatag(:feature)}/)
+        end
+      end
+    end
+
     describe 'are singularized appropriately with the --singularize flag' do
       before do
         run_generator %w(posts --singularize)


### PR DESCRIPTION
If a feature spec is generated with a namespaced name, the namespace gets duplicate in the filename as well.

The `table_name` method returns a string that [is already a combination](Link) of the `class_path` and `file_name`. We could used `file_name` directly instead of the `table_name`, which is also the [approach taken in the controller generator](https://github.com/rspec/rspec-rails/blob/master/lib/generators/rspec/controller/controller_generator.rb#L17).

Closes #1877