### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -13,6 +13,14 @@ Gem::Specification.new do |s|
   s.summary     = "RSpec for Rails"
   s.description = "rspec-rails is a testing framework for Rails 3+."
 
+  s.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/rspec/rspec-rails/issues',
+    'changelog_uri'     => "https://github.com/rspec/rspec-rails/blob/v#{s.version}/Changelog.md",
+    'documentation_uri' => 'https://rspec.info/documentation/',
+    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
+    'source_code_uri'   => 'https://github.com/rspec/rspec-rails',
+  }
+
   s.files            = `git ls-files -- lib/*`.split("\n")
   s.files           += %w[README.md LICENSE.md Changelog.md Capybara.md .yardopts .document]
   s.test_files       = []


### PR DESCRIPTION
Following on from rspec/rspec-core#2574.

Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `mailing_list_uri` and `source_code_uri` links will appear or replace those on the rubygems page at https://rubygems.org/gems/rspec-rails after the next release.