### PR TITLE
Prevent ActiveJob::DeserializationError when looking for active jobs with specific arguments in the queue

### DIFF
--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -170,11 +170,9 @@ module RSpec
           end
 
           def deserialize_arguments(job)
-            begin
-              ::ActiveJob::Arguments.deserialize(job[:args])
-            rescue ::ActiveJob::DeserializationError
-              job[:args]
-            end
+            ::ActiveJob::Arguments.deserialize(job[:args])
+          rescue ::ActiveJob::DeserializationError
+            job[:args]
           end
 
           def queue_adapter

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -98,7 +98,7 @@ module RSpec
           def check(jobs)
             @matching_jobs, @unmatching_jobs = jobs.partition do |job|
               if arguments_match?(job) && other_attributes_match?(job)
-                args = ::ActiveJob::Arguments.deserialize(job[:args])
+                args = deserialize_arguments(job) || []
                 @block.call(*args)
                 true
               else
@@ -125,7 +125,7 @@ module RSpec
 
           def base_job_message(job)
             msg_parts = []
-            msg_parts << "with #{::ActiveJob::Arguments.deserialize(job[:args])}" if job[:args].any?
+            msg_parts << "with #{deserialize_arguments(job) || job[:args].inspect}" if job[:args].any?
             msg_parts << "on queue #{job[:queue]}" if job[:queue]
             msg_parts << "at #{Time.at(job[:at])}" if job[:at]
 
@@ -136,8 +136,12 @@ module RSpec
 
           def arguments_match?(job)
             if @args.any?
-              deserialized_args = ::ActiveJob::Arguments.deserialize(job[:args])
-              RSpec::Mocks::ArgumentListMatcher.new(*@args).args_match?(*deserialized_args)
+              deserialized_args = deserialize_arguments(job)
+              if deserialized_args
+                RSpec::Mocks::ArgumentListMatcher.new(*@args).args_match?(*deserialized_args)
+              else
+                false
+              end
             else
               true
             end
@@ -167,6 +171,10 @@ module RSpec
                                when :thrice then 3
                                else Integer(count)
                                end
+          end
+
+          def deserialize_arguments(job)
+            ::ActiveJob::Arguments.deserialize(job[:args]) rescue nil
           end
 
           def queue_adapter

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -170,7 +170,11 @@ module RSpec
           end
 
           def deserialize_arguments(job)
-            ::ActiveJob::Arguments.deserialize(job[:args]) rescue job[:args]
+            begin
+              ::ActiveJob::Arguments.deserialize(job[:args])
+            rescue ::ActiveJob::DeserializationError
+              job[:args]
+            end
           end
 
           def queue_adapter

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -98,7 +98,7 @@ module RSpec
           def check(jobs)
             @matching_jobs, @unmatching_jobs = jobs.partition do |job|
               if arguments_match?(job) && other_attributes_match?(job)
-                args = deserialize_arguments(job) || []
+                args = deserialize_arguments(job)
                 @block.call(*args)
                 true
               else
@@ -125,7 +125,7 @@ module RSpec
 
           def base_job_message(job)
             msg_parts = []
-            msg_parts << "with #{deserialize_arguments(job) || job[:args].inspect}" if job[:args].any?
+            msg_parts << "with #{deserialize_arguments(job)}" if job[:args].any?
             msg_parts << "on queue #{job[:queue]}" if job[:queue]
             msg_parts << "at #{Time.at(job[:at])}" if job[:at]
 
@@ -137,11 +137,7 @@ module RSpec
           def arguments_match?(job)
             if @args.any?
               deserialized_args = deserialize_arguments(job)
-              if deserialized_args
-                RSpec::Mocks::ArgumentListMatcher.new(*@args).args_match?(*deserialized_args)
-              else
-                false
-              end
+              RSpec::Mocks::ArgumentListMatcher.new(*@args).args_match?(*deserialized_args)
             else
               true
             end
@@ -174,7 +170,7 @@ module RSpec
           end
 
           def deserialize_arguments(job)
-            ::ActiveJob::Arguments.deserialize(job[:args]) rescue nil
+            ::ActiveJob::Arguments.deserialize(job[:args]) rescue job[:args]
           end
 
           def queue_adapter

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -18,7 +18,7 @@ if RSpec::Rails::FeatureCheck.has_active_job?
     end
 
     def ==(comparison_object)
-      id == comparison_object.id
+      (GlobalIdModel === comparison_object) && (id == comparison_object.id)
     end
 
     def to_global_id(options = {})


### PR DESCRIPTION
When running a test expecting to find active jobs in the queue with specific arguments, the have_enqueued_job.with and have_been_enqueued.with matchers will iterate over each queued active jobs, deserialize its arguments and check if it matches the expected value. However, the deserialization of some arguments may raise an ActiveJob::DeserializationError, for example for jobs having destroyed active records as arguments.
This is an issue since some active jobs may be generated by some code that we are not testing but will make our test fail since we have to deserialize their arguments anyway.

This PR prevents this crash from happening by rescuing all the raised ActiveJob::DeserializationError in the matcher when deserializing arguments. This operation is done at 3 different places:
- when checking if a job arguments match the arguments specified in with(), if there is a deserialization error, return false
- when passing arguments to the with block, if there is a deserialization error, pass an empty array
- when displaying all queued jobs, if there is a deserialization error, print the serialized value