### PR TITLE
removed rails 5.0 check for mailer preview generator

### DIFF
--- a/lib/generators/rspec/mailer/templates/preview.rb
+++ b/lib/generators/rspec/mailer/templates/preview.rb
@@ -5,7 +5,7 @@ class <%= class_name %>Preview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/<%= file_path %>/<%= action %>
   def <%= action %>
-    <%= class_name %><%= Rails.version.to_f >= 5.0 ? "Mailer" : "" %>.<%= action %>
+    <%= Rails.version.to_f >= 5.0 ? class_name.sub(/(Mailer)?$/, 'Mailer') : class_name %>.<%= action %>
   end
 <% end -%>
 

--- a/spec/generators/rspec/mailer/mailer_generator_spec.rb
+++ b/spec/generators/rspec/mailer/mailer_generator_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe Rspec::Generators::MailerGenerator, :type => :generator do
     it { is_expected.to exist }
     it { is_expected.to contain(/class PostsPreview < ActionMailer::Preview/) }
     it { is_expected.to contain(/def index/) }
+    if Rails.version.to_f >= 5.0
+      it { is_expected.to contain(/PostsMailer.index/) }
+    else
+      it { is_expected.to contain(/Posts.index/) }
+    end
     it { is_expected.to contain(/def show/) }
+    if Rails.version.to_f >= 5.0
+      it { is_expected.to contain(/PostsMailer.show/) }
+    else
+      it { is_expected.to contain(/Posts.show/) }
+    end
   end
 end


### PR DESCRIPTION
# before

```
$ rails g mailer SomeMailer some_message
Running via Spring preloader in process 68477
      create  app/mailers/some_mailer.rb
      invoke  erb
      create    app/views/some_mailer
      create    app/views/some_mailer/some_message.text.erb
      create    app/views/some_mailer/some_message.html.erb
      invoke  rspec
      create    spec/mailers/some_mailer_spec.rb
      create    spec/fixtures/some_mailer/some_message
      create    spec/mailers/previews/some_mailer_preview.rb
```

```
$ cat spec/mailers/previews/some_mailer_preview.rb
# Preview all emails at http://localhost:3000/rails/mailers/some_mailer
class SomeMailerPreview < ActionMailer::Preview

  # Preview this email at http://localhost:3000/rails/mailers/some_mailer/some_message
  def some_message
    SomeMailerMailer.some_message
  end

end
```

👎     SomeMailerMailer.some_message



# after

```
$ rails g mailer SomeMailer some_message
Running via Spring preloader in process 89456
      create  app/mailers/some_mailer.rb
      invoke  erb
      create    app/views/some_mailer
      create    app/views/some_mailer/some_message.text.erb
      create    app/views/some_mailer/some_message.html.erb
      invoke  rspec
      create    spec/mailers/some_mailer_spec.rb
      create    spec/fixtures/some_mailer/some_message
      create    spec/mailers/previews/some_mailer_preview.rb
```

```      
$ cat spec/mailers/previews/some_mailer_preview.rb
# Preview all emails at http://localhost:3000/rails/mailers/some_mailer
class SomeMailerPreview < ActionMailer::Preview

  # Preview this email at http://localhost:3000/rails/mailers/some_mailer/some_message
  def some_message
    SomeMailer.some_message
  end

end
```

👍     SomeMailer.some_message