### PR TITLE
Optional ActiveRecord config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bundle
 specs.out
 spec/examples.txt
 specs.out
+test.db

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -33,6 +33,10 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 <% end -%>
 RSpec.configure do |config|
+  # You can explicitly turn off ActiveRecord support on rspec-rails by
+  # uncommenting the following line.
+  # config.use_active_record = false
+
 <% if RSpec::Rails::FeatureCheck.has_active_record? -%>
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -64,6 +64,7 @@ module RSpec
       config.add_setting :infer_base_class_for_anonymous_controllers, default: true
 
       # fixture support
+      config.add_setting :use_active_record, default: true
       config.add_setting :use_transactional_fixtures, alias_with: :use_transactional_examples
       config.add_setting :use_instantiated_fixtures
       config.add_setting :global_fixtures

--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -2,14 +2,15 @@ module RSpec
   module Rails
     # @private
     module FixtureSupport
-      if defined?(ActiveRecord::TestFixtures)
-        extend ActiveSupport::Concern
-        include RSpec::Rails::SetupAndTeardownAdapter
-        include RSpec::Rails::MinitestLifecycleAdapter
-        include RSpec::Rails::MinitestAssertionAdapter
-        include ActiveRecord::TestFixtures
+      extend ActiveSupport::Concern
 
-        included do
+      included do
+        if RSpec.configuration.use_active_record? && defined?(ActiveRecord::TestFixtures)
+          include RSpec::Rails::SetupAndTeardownAdapter
+          include RSpec::Rails::MinitestLifecycleAdapter
+          include RSpec::Rails::MinitestAssertionAdapter
+          include ActiveRecord::TestFixtures
+
           self.fixture_path = RSpec.configuration.fixture_path
           if ::Rails::VERSION::STRING > '5'
             self.use_transactional_tests = RSpec.configuration.use_transactional_fixtures

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -64,6 +64,9 @@ RSpec.describe "Configuration" do
                      :use_transactional_fixtures,
                      alias_with: :use_transactional_examples
 
+    include_examples "adds setting", :use_active_record,
+                     :default => true
+
     include_examples "adds setting", :use_instantiated_fixtures
 
     include_examples "adds setting", :global_fixtures

--- a/spec/rspec/rails/fixture_support_spec.rb
+++ b/spec/rspec/rails/fixture_support_spec.rb
@@ -2,7 +2,8 @@ module RSpec::Rails
   RSpec.describe FixtureSupport do
     context "with use_transactional_fixtures set to false" do
       it "still supports fixture_path" do
-        allow(RSpec.configuration).to receive(:use_transactional_fixtures) { false }
+        allow(RSpec.configuration).to \
+          receive(:use_transactional_fixtures) { false }
         group = RSpec::Core::ExampleGroup.describe do
           include FixtureSupport
         end
@@ -20,6 +21,58 @@ module RSpec::Rails
       end
 
       expect { group.new.setup_fixtures }.to_not raise_error
+    end
+
+    context "without database available" do
+      let(:example_group) do
+        RSpec::Core::ExampleGroup.describe("FixtureSupport") do
+          include FixtureSupport
+          include RSpec::Rails::MinitestLifecycleAdapter
+        end
+      end
+      let(:example) do
+        example_group.example("foo") do
+          expect(true).to be(true)
+        end
+      end
+
+      RSpec.shared_examples_for "unrelated example raise" do
+        it "raise due to no connection established" do
+          expect(example_group.run).to be(false)
+          expect(example.execution_result.exception).to \
+            be_a(ActiveRecord::ConnectionNotEstablished)
+        end
+      end
+
+      RSpec.shared_examples_for "unrelated example does not raise" do
+        it "does not raise" do
+          expect(example_group.run).to be(true)
+          expect(example.execution_result.exception).not_to \
+            be_a(ActiveRecord::ConnectionNotEstablished)
+        end
+      end
+
+      before { clear_active_record_connection }
+
+      after { establish_active_record_connection }
+
+      context "with use_active_record set to false" do
+        before { RSpec.configuration.use_active_record = false }
+
+        after { RSpec.configuration.use_active_record = true }
+
+        include_examples "unrelated example does not raise"
+      end
+
+      context "with use_active_record set to true" do
+        before { RSpec.configuration.use_active_record = true }
+
+        if Rails.version.to_f >= 4.0
+          include_examples "unrelated example does not raise"
+        else
+          include_examples "unrelated example raise"
+        end
+      end
     end
   end
 end

--- a/spec/support/ar_classes.rb
+++ b/spec/support/ar_classes.rb
@@ -1,7 +1,24 @@
-ActiveRecord::Base.establish_connection(
-  :adapter => 'sqlite3',
-  :database => ':memory:'
-)
+FileUtils.rm_f('./test.db')
+
+def establish_active_record_connection
+  ActiveRecord::Base.establish_connection(
+    :adapter => 'sqlite3',
+    :database => './test.db'
+  )
+end
+
+def clear_active_record_connection
+  ActiveRecord::Base.connection_handler.clear_all_connections!
+  ActiveRecord::Base.connection_handler.connection_pool_list.each do |pool|
+    if Rails.version.to_f >= 5.0
+      ActiveRecord::Base.connection_handler.remove_connection(pool.spec.name)
+    else
+      ActiveRecord::Base.connection_handler.remove_connection(ActiveRecord::Base)
+    end
+  end
+end
+
+establish_active_record_connection
 
 module Connections
   def self.extended(host)


### PR DESCRIPTION
**- What is it good for**

This PR ships a solution for #1876.

**- What I did**

I added a new option `use_active_record` to the RSpec config. This option is also added to the generator for new `spec/rails_helper.rb` files. The config option is read on the `FixtureSupport` module before the ActiveRecord loading happens. Tests with and without this setting were added in the case a database connection is not established.

**- A picture of a cute animal (not mandatory but encouraged)**

![download](https://user-images.githubusercontent.com/2496275/47506451-60657a00-d870-11e8-99af-2a7218bec9b8.jpeg)
