### PR TITLE
Fix typo in changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ Bug Fixes:
 * Fix issue with generator for preview specs where `Mailer` would be duplicated
   in the name. (Kohei Sugi, #2037)
 
-### Development
+### 3.8.1 / 2018-10-23
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.8.0...v3.8.1)
 
 Bug Fixes:


### PR DESCRIPTION
There seems to be a typo in the changelog for version 3.8.1