### PR TITLE
Make README more accessible to novices

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 `rspec-rails` brings the [RSpec][] testing framework to [Ruby on Rails][]
 as a drop-in alternative to its default testing framework, Minitest.
 
-In RSpec, tests are not just scripts that verify your application code;
-they’re also detailed explanations of how the application is supposed to behave,
-expressed in plain English—in other words, _specs._
+In RSpec, tests are not just scripts that verify your application code.
+They’re also detailed explanations of how the application is supposed to behave,
+expressed in plain English; in other words, _specs._
 
 Use **[`rspec-rails` 1.x][]** for Rails 2.x.
 
@@ -36,6 +36,9 @@ Use **[`rspec-rails` 1.x][]** for Rails 2.x.
      end
    end
    ```
+
+   (Adding it to the `:development` group is not strictly necessary,
+   but without it, generators and rake tasks must be preceded by `RAILS_ENV=test`.)
 
 2. Then, in your project directory:
 
@@ -290,25 +293,31 @@ and the expectations revolve around page content.
 
 Because system specs are a wrapper around Rails’ built-in `SystemTestCase`,
 they’re only available on Rails 5.1+.
+(Feature specs serve the same purpose, but without this dependency.)
 
 #### Feature specs
 
-Feature specs serve the same purpose,
-but `SystemTestCase` solves some longstanding configuration issues they had,
-so the RSpec team [officially recommends system specs][] over feature specs.
+Before Rails introduced system testing facilities,
+feature specs were the only spec type for end-to-end testing.
+While the RSpec team now [officially recommends system specs][] instead,
+feature specs are still fully supported, look basically identical,
+and work on older versions of Rails.
 
-If you don’t have the luxury of upgrading,
-there’s no problem with using feature specs instead.
-Be sure to add [Capybara][] to the `:test` group of your `Gemfile` first:
+On the other hand, feature specs require non-trivial configuration
+to get some important features working,
+like JavaScript testing or making sure each test runs with a fresh DB state.
+With system specs, this configuration is provided out-of-the-box.
+
+Like system specs, feature specs require the [Capybara][] gem.
+Rails 5.1+ includes it by default as part of system tests,
+but if you don’t have the luxury of upgrading,
+be sure to add it to the `:test` group of your `Gemfile` first:
 
 ```ruby
 group :test do
   gem "capybara"
 end
 ```
-
-(It’s actually required for both feature and system specs,
-but Rails includes it by default in versions 5.1+.)
 
 [officially recommends system specs]: http://rspec.info/blog/2017/10/rspec-3-7-has-been-released/#rails-actiondispatchsystemtest-integration-system-specs
 [Capybara]: https://github.com/teamcapybara/capybara

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use **[`rspec-rails` 1.x][]** for Rails 2.x.
    group :development, :test do
      gem 'rspec-rails', '~> 3.8'
    end
-   
+
    # Or, run against the master branch
    # (requires master-branch versions of all related RSpec libraries)
    group :development, :test do
@@ -230,7 +230,7 @@ Follow the links above to see examples of each spec type,
 or for official Rails API documentation on the given `TestCase` class.
 
 > **Note: This is not a checklist.**
-> 
+>
 > Ask a hundred developers how to test an application,
 > and you’ll get a hundred different answers.
 >
@@ -353,7 +353,7 @@ you can run the specs and Cucumber features, or submit a pull request.
 ### Recommended third-party extensions
 
 * [FactoryBot](https://github.com/thoughtbot/factory_bot)
-* [Capybara](https://github.com/jnicklas/capybara)  
+* [Capybara](https://github.com/jnicklas/capybara)
   (Included by default in Rails 5.1+.
   Note that [additional configuration is required][] to use the Capybara DSL
   anywhere other than system specs and feature specs.)

--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ Use **[`rspec-rails` 1.x][]** for Rails 2.x.
          create  spec
          create  spec/spec_helper.rb
          create  spec/rails_helper.rb
-
-   # Rails 4+ only: generate a binstub
-   # (so you can run `bin/rspec` instead of `bundle exec rspec`)
-   $ bundle binstubs rspec-core
    ```
 
 ## Upgrading
@@ -118,6 +114,14 @@ $ bundle exec rspec spec/controllers/accounts_controller_spec.rb:8
 # See all options for running specs
 $ bundle exec rspec --help
 ```
+
+**Optional:** If `bundle exec rspec` is too verbose for you,
+you can generate a binstub at `bin/rspec`
+and use that instead (Rails 4+ only):
+
+ ```sh
+ $ bundle binstubs rspec-core
+ ```
 
 ## RSpec DSL Basics (or, how do I write a spec?)
 
@@ -241,6 +245,25 @@ or for official Rails API documentation on the given `TestCase` class.
 > to encourage good testing practices, but there’s no “right” way to do it.
 > Ultimately, it’s up to you to decide how your test suite will be composed.
 
+When creating a spec file,
+assign it a type by placing it [in the appropriate folder][]
+(_e.g.,_ `spec/models/` for model specs).
+If you want to be extra explicit,
+you can set the `:type` option at the top of the file, like so:
+
+```ruby
+# spec/models/user_spec.rb
+
+RSpec.describe User, type: :model do
+...
+```
+
+If you use the built-in generators, these details will be handled automatically:
+
+```sh
+$ rails generate rspec:<type> <name>
+```
+
 [request]: https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec
 [feature]: https://www.relishapp.com/rspec/rspec-rails/docs/feature-specs/feature-spec
 [system]: https://relishapp.com/rspec/rspec-rails/docs/system-specs/system-spec
@@ -254,23 +277,6 @@ or for official Rails API documentation on the given `TestCase` class.
 [`ActionDispatch::IntegrationTest`]: https://api.rubyonrails.org/classes/ActionDispatch/IntegrationTest.html
 [`ActionDispatch::SystemTestCase`]: https://api.rubyonrails.org/classes/ActionDispatch/SystemTestCase.html
 [`ActionController::TestCase`]: https://api.rubyonrails.org/classes/ActionController/TestCase.html
-
-### I’m writing a spec file from scratch. How do I assign it a type?
-
-Simply place the spec [in the appropriate folder][]
-(_e.g.,_ `spec/models/` for model specs)
-and RSpec will set its type automatically.
-
-If you want to be extra explicit,
-you can set the `:type` option at the top of the file, like so:
-
-```ruby
-# spec/models/user_spec.rb
-
-RSpec.describe User, type: :model do
-...
-```
-
 [in the appropriate folder]: https://relishapp.com/rspec/rspec-rails/docs/directory-structure
 
 ### System specs, feature specs, request specs–what’s the difference?

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ $ bundle exec rspec spec/controllers/accounts_controller_spec.rb
 
 # Run a single example from a spec file (by line number)
 $ bundle exec rspec spec/controllers/accounts_controller_spec.rb:8
+
+# See all options for running specs
+$ bundle exec rspec --help
 ```
 
 ## RSpec DSL Basics (or, how do I write a spec?)
@@ -234,8 +237,6 @@ or for official Rails API documentation on the given `TestCase` class.
 > RSpec Rails provides thoughtfully selected features
 > to encourage good testing practices, but there’s no “right” way to do it.
 > Ultimately, it’s up to you to decide how your test suite will be composed.
-> 
-> (You may even define custom types, or write specs with no type at all.)
 
 [request]: https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec
 [feature]: https://www.relishapp.com/rspec/rspec-rails/docs/feature-specs/feature-spec
@@ -253,7 +254,7 @@ or for official Rails API documentation on the given `TestCase` class.
 
 ### I’m writing a spec file from scratch. How do I assign it a type?
 
-Simply place the spec in the appropriate folder
+Simply place the spec [in the appropriate folder][]
 (_e.g.,_ `spec/models/` for model specs)
 and RSpec will set its type automatically.
 
@@ -267,7 +268,7 @@ RSpec.describe User, type: :model do
 ...
 ```
 
-[modified the default `rails_helper.rb` configuration]: https://relishapp.com/rspec/rspec-rails/docs/upgrade#file-type-inference-disabled
+[in the appropriate folder]: https://relishapp.com/rspec/rspec-rails/docs/directory-structure
 
 ### System specs, feature specs, request specs–what’s the difference?
 

--- a/README.md
+++ b/README.md
@@ -246,22 +246,13 @@ or for official Rails API documentation on the given `TestCase` class.
 > Ultimately, it’s up to you to decide how your test suite will be composed.
 
 When creating a spec file,
-assign it a type by placing it [in the appropriate folder][]
-(_e.g.,_ `spec/models/` for model specs).
-If you want to be extra explicit,
-you can set the `:type` option at the top of the file, like so:
+assign it a type in the top-level `describe` block, like so:
 
 ```ruby
 # spec/models/user_spec.rb
 
 RSpec.describe User, type: :model do
 ...
-```
-
-If you use the built-in generators, these details will be handled automatically:
-
-```sh
-$ rails generate rspec:<type> <name>
 ```
 
 [request]: https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec

--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ RSpec.describe User, type: :model do
 
 ### System specs, feature specs, request specs–what’s the difference?
 
-RSpec Rails provides three types of specs
-that do not directly correspond to any Rails application component.
+RSpec Rails provides some end-to-end (entire application) testing capability
+to specify the interaction with the client.
 
 #### System specs
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ as a drop-in alternative to its default testing framework, Minitest.
 
 In RSpec, tests are not just scripts that verify your application code.
 They’re also detailed explanations of how the application is supposed to behave,
-expressed in plain English: in other words, _specs._
+expressed in plain English, or in other words, _specs._
 
 Use **[`rspec-rails` 1.x][]** for Rails 2.x.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ as a drop-in alternative to its default testing framework, Minitest.
 
 In RSpec, tests are not just scripts that verify your application code.
 They’re also detailed explanations of how the application is supposed to behave,
-expressed in plain English; in other words, _specs._
+expressed in plain English: in other words, _specs._
 
 Use **[`rspec-rails` 1.x][]** for Rails 2.x.
 

--- a/README.md
+++ b/README.md
@@ -1,602 +1,387 @@
-# rspec-rails [![Build Status](https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=master)](http://travis-ci.org/rspec/rspec-rails) [![Code Climate](https://img.shields.io/codeclimate/github/rspec/rspec-rails.svg)](https://codeclimate.com/github/rspec/rspec-rails)
-**rspec-rails** is a testing framework for Rails 3.x, 4.x and 5.x.
+# rspec-rails [![Build Status][]][travis-ci] [![Code Climate][]][code-climate]
 
-Use **[rspec-rails 1.x](http://github.com/dchelimsky/rspec-rails)** for Rails
-2.x.
+`rspec-rails` brings the [RSpec][] testing framework to [Ruby on Rails][]
+as a drop-in alternative to its default testing framework, Minitest.
+
+In RSpec, tests are not just scripts that verify your application code;
+they’re also detailed explanations of how the application is supposed to behave,
+expressed in plain English—in other words, _specs._
+
+Use **[`rspec-rails` 1.x][]** for Rails 2.x.
+
+[Build Status]: https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=master
+[travis-ci]: http://travis-ci.org/rspec/rspec-rails
+[Code Climate]: https://img.shields.io/codeclimate/github/rspec/rspec-rails.svg
+[code-climate]: https://codeclimate.com/github/rspec/rspec-rails
+[RSpec]: http://rspec.info/
+[Ruby on Rails]: https://rubyonrails.org/
+[`rspec-rails` 1.x]: http://github.com/dchelimsky/rspec-rails
 
 ## Installation
 
-Add `rspec-rails` to **both** the `:development` and `:test` groups in the
-`Gemfile`:
+1. Add `rspec-rails` to **both** the `:development` and `:test` groups
+   of your app’s `Gemfile`:
+
+   ```ruby
+   # Run against the latest stable release
+   group :development, :test do
+     gem 'rspec-rails', '~> 3.8'
+   end
+   
+   # Or, run against the master branch
+   # (requires master-branch versions of all related RSpec libraries)
+   group :development, :test do
+     %w[rspec-core rspec-expectations rspec-mocks rspec-rails rspec-support].each do |lib|
+       gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => 'master'
+     end
+   end
+   ```
+
+2. Then, in your project directory:
+
+   ```sh
+   # Download and install
+   $ bundle install
+
+   # Generate boilerplate configuration files
+   # (check the comments in each generated file for more information)
+   $ rails generate rspec:install
+         create  .rspec
+         create  spec
+         create  spec/spec_helper.rb
+         create  spec/rails_helper.rb
+
+   # Rails 4+ only: generate a binstub
+   # (so you can run `bin/rspec` instead of `bundle exec rspec`)
+   $ bundle binstubs rspec-core
+   ```
+
+## Upgrading
+
+If your project is already using an older version of `rspec-rails`,
+upgrade to the latest version with:
+
+```sh
+$ bundle update rspec-rails
+```
+
+RSpec follows [semantic versioning](https://semver.org/),
+which means that “major version” upgrades (_e.g.,_ 2.x → 3.x)
+come with **breaking changes**.
+If you’re upgrading from version 2.x or below,
+read the [`rspec-rails` upgrade notes][] to find out what to watch out for.
+
+Be sure to check the general [RSpec upgrade notes][] as well.
+
+[`rspec-rails` upgrade notes]: https://www.relishapp.com/rspec/rspec-rails/docs/upgrade
+[RSpec upgrade notes]: https://relishapp.com/rspec/docs/upgrade
+
+## Usage
+
+### Creating boilerplate specs with `rails generate`
+
+```sh
+# RSpec hooks into built-in generators
+$ rails generate model user
+      invoke  active_record
+      create    db/migrate/20181017040312_create_users.rb
+      create    app/models/user.rb
+      invoke    rspec
+      create      spec/models/user_spec.rb
+
+# RSpec also provides its own spec file generators
+$ rails generate rspec:model user
+      create  spec/models/user_spec.rb
+
+# List all RSpec generators
+$ rails generate --help | grep rspec
+```
+
+### Running specs
+
+```sh
+# Default: Run all spec files (i.e., those matching spec/**/*_spec.rb)
+$ bundle exec rspec
+
+# Run all spec files in a single directory (recursively)
+$ bundle exec rspec spec/models
+
+# Run a single spec file
+$ bundle exec rspec spec/controllers/accounts_controller_spec.rb
+
+# Run a single example from a spec file (by line number)
+$ bundle exec rspec spec/controllers/accounts_controller_spec.rb:8
+```
+
+## RSpec DSL Basics (or, how do I write a spec?)
+
+In RSpec, application behavior is described
+**first in (almost) plain English, then again in test code**, like so:
 
 ```ruby
-group :development, :test do
-  gem 'rspec-rails', '~> 3.8'
+RSpec.describe Member do  #
+  context 'in death' do   # (almost) plain English
+    it 'has a name' do    #
+      expect(dead_member.name).to eq('Robert Paulson')  # test code
+    end
+  end
 end
 ```
 
-Want to run against the `master` branch? You'll need to include the dependent
-RSpec repos as well. Add the following to your `Gemfile`:
+Running `rspec` will execute this test code,
+and then use the plain-English descriptions
+to generate a report of where the application
+conforms to (or fails to meet) the spec:
+
+```
+$ rspec --format documentation spec/models/member_spec.rb
+
+Member
+  in death
+    has a name
+
+Failures:
+
+  1) Member in death has a name
+     Failure/Error: expect(dead_member.name).to eq('Robert Paulson')
+
+       expected: "Robert Paulson"
+            got: nil
+
+       (compared using ==)
+     # ./spec/models/member.rb:4:in `block (3 levels) in <top (required)>'
+
+Finished in 0.00527 seconds (files took 0.29657 seconds to load)
+1 example, 1 failure
+
+Failed examples:
+
+rspec ./spec/models/member_spec.rb:3 # Member in death has a name
+```
+
+For an in-depth look at the RSpec DSL, including lots of examples,
+read the official Cucumber documentation for [RSpec Core][].
+
+[RSpec Core]: https://relishapp.com/rspec/rspec-core/docs
+
+### Helpful Rails Matchers
+
+In RSpec, assertions are called _expectations,_
+and every expectation is built around a _matcher._
+When you `expect(a).to eq(b)`, you’re using the `eq` matcher.
+
+In addition to [the matchers that come standard in RSpec][],
+here are some extras that make it easier
+to test the various parts of a Rails system:
+
+| RSpec matcher            | Delegates to      | Available in                    | Notes                                                    |
+| ------------------------ | ----------------- | ------------------------------- | -------------------------------------------------------- |
+| [`be_a_new`][]           |                   | all                             | primarily intended for controller specs                  |
+| [`render_template`][]    | `assert_template` | request / controller / view     | use with `expect(response).to`                           |
+| [`redirect_to`][]        | `assert_redirect` | request / controller            | use with `expect(response).to`                           |
+| [`route_to`]             | `assert_routing`  | routing / controller            | replaces `route_for` from version 1.x                    |
+| [`be_routable`]          |                   | routing / controller            | usu. for `expect(...).not_to be_routable`                |
+| [`have_http_status`][]   |                   | request / controller / feature  |                                                          |
+| [`match_array`][]        |                   | all                             | for comparing arrays of ActiveRecord objects             |
+| [`have_been_enqueued`][] |                   | all                             | requires config: `ActiveJob::Base.queue_adapter = :test` |
+| [`have_enqueued_job`][]  |                   | all                             | requires config: `ActiveJob::Base.queue_adapter = :test` |
+
+Follow the links above for examples of how each matcher is used.
+
+[the matchers that come standard in RSpec]: https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+[`be_a_new`]: https://relishapp.com/rspec/rspec-rails/docs/matchers/be-a-new-matcher
+[`render_template`]: https://relishapp.com/rspec/rspec-rails/docs/matchers/render-template-matcher
+[`redirect_to`]: https://relishapp.com/rspec/rspec-rails/docs/matchers/redirect-to-matcher
+[`route_to`]: https://relishapp.com/rspec/rspec-rails/docs/routing-specs/route-to-matcher
+[`be_routable`]: https://relishapp.com/rspec/rspec-rails/docs/routing-specs/be-routable-matcher
+[`have_http_status`]: https://relishapp.com/rspec/rspec-rails/docs/matchers/have-http-status-matcher
+[`match_array`]: https://relishapp.com/rspec/rspec-rails/docs/matchers/activerecord-relation-match-array
+[`have_been_enqueued`]: https://relishapp.com/rspec/rspec-rails/docs/matchers/have-been-enqueued-matcher
+[`have_enqueued_job`]: https://relishapp.com/rspec/rspec-rails/docs/matchers/have-enqueued-job-matcher
+
+### What else does RSpec Rails add?
+
+For a comprehensive look at RSpec Rails’ features,
+read the [official Cucumber documentation][].
+
+[official Cucumber documentation]: https://relishapp.com/rspec/rspec-rails/docs
+
+## What tests should I write?
+
+At the risk of grossly oversimplifying,
+there are two kinds of tests you can write:
+those that verify
+**an individual component of your application** (unit tests),
+and those that verify
+**how multiple parts of your application work as a whole** (integration tests).
+
+RSpec Rails defines ten different _types_ of specs (7 unit, 3 integration)
+for testing different parts of a typical Rails application.
+Many inherit from one of Rails’ built-in `TestCase` classes,
+meaning the helper methods provided by default in Rails tests
+are available in RSpec, as well.
+
+- **Unit**
+
+  | Spec type        | Corresponding Rails test class     |
+  | ---------------- | ---------------------------------- |
+  | [model][]        |                                    |
+  | [controller][]\* | [`ActionController::TestCase`][]   |
+  | [mailer][]       | `ActionMailer::TestCase`           |
+  | [job][]          |                                    |
+  | [view][]         | `ActionView::TestCase`             |
+  | [routing][]      |                                    |
+  | [helper][]       | `ActionView::TestCase`             |
+
+- **Integration**
+
+  | Spec type       | Corresponding Rails test class        |
+  | --------------- | ------------------------------------- |
+  | [request][]     | [`ActionDispatch::IntegrationTest`][] |
+  | [feature][]\*   |                                       |
+  | [system][]      | [`ActionDispatch::SystemTestCase`][]  |
+
+_\* discouraged in favor new alternatives_
+
+Follow the links above to see examples of each spec type,
+or for official Rails API documentation on the given `TestCase` class.
+
+> **Note: This is not a checklist.**
+> 
+> Ask a hundred developers how to test an application,
+> and you’ll get a hundred different answers.
+> Some may insist on exhaustively testing every single method on every model;
+> others may contend that since integration tests capture model behavior anyway,
+> much unit testing is redundant and burdensome.
+>
+> RSpec Rails provides thoughtfully selected features
+> to encourage good testing practices, but there’s no “right” way to do it.
+> Ultimately, it’s up to you to decide how your test suite will be composed.
+> 
+> (You may even define custom types, or write specs with no type at all.)
+
+[request]: https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec
+[feature]: https://www.relishapp.com/rspec/rspec-rails/docs/feature-specs/feature-spec
+[system]: https://relishapp.com/rspec/rspec-rails/docs/system-specs/system-spec
+[model]: https://www.relishapp.com/rspec/rspec-rails/docs/model-specs
+[controller]: https://www.relishapp.com/rspec/rspec-rails/docs/controller-specs
+[mailer]: https://relishapp.com/rspec/rspec-rails/docs/mailer-specs
+[job]: https://relishapp.com/rspec/rspec-rails/docs/job-specs/job-spec
+[view]: https://www.relishapp.com/rspec/rspec-rails/docs/view-specs/view-spec
+[routing]: https://www.relishapp.com/rspec/rspec-rails/docs/routing-specs
+[helper]: https://www.relishapp.com/rspec/rspec-rails/docs/helper-specs/helper-spec
+[`ActionDispatch::IntegrationTest`]: https://edgeapi.rubyonrails.org/classes/ActionDispatch/IntegrationTest.html
+[`ActionDispatch::SystemTestCase`]: https://edgeapi.rubyonrails.org/classes/ActionDispatch/SystemTestCase.html
+[`ActionController::TestCase`]: https://edgeapi.rubyonrails.org/classes/ActionController/TestCase.html
+
+### I’m writing a spec file from scratch. How do I assign it a type?
+
+Assuming you haven’t [modified the default `rails_helper.rb` configuration][],
+simply place the spec in the appropriate folder
+(_e.g.,_ `spec/models/` for model specs)
+and RSpec will set its type automatically.
+
+If you _have_ modified the default config
+(or if you just want to be extra explicit),
+you can set the `:type` option at the top of the file, like so:
 
 ```ruby
-%w[rspec-core rspec-expectations rspec-mocks rspec-rails rspec-support].each do |lib|
-  gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => 'master'
+# spec/models/user_spec.rb
+
+RSpec.describe User, type: :model do
+...
+```
+
+[modified the default `rails_helper.rb` configuration]: https://relishapp.com/rspec/rspec-rails/docs/upgrade#file-type-inference-disabled
+
+### System specs, feature specs, request specs–what’s the difference?
+
+RSpec Rails provides three types of specs
+for integration testing the application as a whole—in other words,
+specifying what the client sees when interacting with it.
+
+#### System specs
+
+Sometimes called **acceptance tests** or **browser tests**,
+system specs test the application from the perspective of a _human client._
+The test code walks through a user’s browser interactions,
+
+* `visit '/login'`
+* `fill_in 'Name', with: 'jdoe'`
+
+and the expectations revolve around page content.
+
+* `expect(page).to have_text('Welcome')`
+
+Because system specs are a wrapper around Rails’ built-in `SystemTestCase`,
+they’re only available on Rails 5.1+.
+
+#### Feature specs
+
+Feature specs serve the same purpose,
+but `SystemTestCase` solves some longstanding configuration issues they had,
+so the RSpec team [officially recommends system specs][] over feature specs.
+
+If you don’t have the luxury of upgrading,
+you’ll be limited to writing feature specs for your browser tests.
+They require [Capybara][],
+so make sure it’s listed in the `:test` group of your `Gemfile`:
+
+```ruby
+group :test do
+  gem "capybara"
 end
 ```
 
-Download and install by running:
+#### Request specs
 
-```
-bundle install
-```
+Request specs are for testing the application
+from the perspective of a _machine client._
+They begin with an HTTP request and end with the HTTP response,
+so they’re faster than feature specs,
+but do not examine your app’s UI or JavaScript.
 
-Initialize the `spec/` directory (where specs will reside) with:
+Request specs provide a high-level alternative to unit testing controllers.
+In fact, as of RSpec 3.5,
+the RSpec team [discourages controller specs entirely][]
+in favor of request specs.
 
-```
-rails generate rspec:install
-```
+When writing them, try to answer the question,
+“For a given HTTP request (verb + path + parameters),
+what HTTP response should the application return?”
 
-This adds the following files which are used for configuration:
-
-- `.rspec`
-- `spec/spec_helper.rb`
-- `spec/rails_helper.rb`
-
-Check the comments in each file for more information.
-
-Use the `rspec` command to run your specs:
-
-```
-bundle exec rspec
-```
-
-By default the above will run all `_spec.rb` files in the `spec` directory. For
-more details about this see the [RSpec spec file
-docs](https://www.relishapp.com/rspec/rspec-core/docs/spec-files).
-
-To run only a subset of these specs use the following command:
-
-```
-# Run only model specs
-bundle exec rspec spec/models
-
-# Run only specs for AccountsController
-bundle exec rspec spec/controllers/accounts_controller_spec.rb
-
-# Run only spec on line 8 of AccountsController
-bundle exec rspec spec/controllers/accounts_controller_spec.rb:8
-```
-
-Specs can also be run via `rake spec`, though this command may be slower to
-start than the `rspec` command.
-
-In Rails 4/5+, you may want to create a binstub for the `rspec` command so it can
-be run via `bin/rspec`:
-
-```
-bundle binstubs rspec-core
-```
-
-### Upgrade Note
-
-For detailed information on the general RSpec 3.x upgrade process see the
-[RSpec Upgrade docs](https://relishapp.com/rspec/docs/upgrade).
-
-There are three particular `rspec-rails` specific changes to be aware of:
-
-1. [The default helper files created in RSpec 3.x have changed](https://www.relishapp.com/rspec/rspec-rails/docs/upgrade#default-helper-files)
-2. [File-type inference disabled by default](https://www.relishapp.com/rspec/rspec-rails/docs/upgrade#file-type-inference-disabled)
-3. [Rails 4.x `ActiveRecord::Migration` pending migration checks](https://www.relishapp.com/rspec/rspec-rails/docs/upgrade#pending-migration-checks)
-4. Extraction of `stub_model` and `mock_model` to
-   [`rspec-activemodel-mocks`](https://github.com/rspec/rspec-activemodel-mocks)
-5. In Rails 5.x, controller testing has been moved to its own gem which is [rails-controller-testing](https://github.com/rails/rails-controller-testing). Using `assigns` in your controller specs without adding this gem will no longer work.
-6. `rspec-rails` now includes two helpers, `spec_helper.rb` and `rails_helper.rb`.
-   `spec_helper.rb` is the conventional RSpec configuration helper, whilst the
-    Rails specific loading and bootstrapping has moved to the `rails_helper.rb`
-    file. Rails specs now need this file required beforehand either at the top
-    of the specific file (recommended) or a common configuration location such
-    as your `.rspec` file.
-
-Please see the [RSpec Rails Upgrade
-docs](https://www.relishapp.com/rspec/rspec-rails/docs/upgrade) for full
-details.
-
-**NOTE:** Generators run in RSpec 3.x will now require `rails_helper` instead
-of `spec_helper`.
-
-### Generators
-
-Once installed, RSpec will generate spec files instead of Test::Unit test files
-when commands like `rails generate model` and `rails generate controller` are
-used.
-
-You may also invoke RSpec generators independently. For instance,
-running `rails generate rspec:model` will generate a model spec. For more
-information, see [list of all
-generators](https://www.relishapp.com/rspec/rspec-rails/docs/generators).
+[officially recommends system specs]: http://rspec.info/blog/2017/10/rspec-3-7-has-been-released/#rails-actiondispatchsystemtest-integration-system-specs
+[Capybara]: https://github.com/teamcapybara/capybara
+[discourages controller specs entirely]: rspec.info/blog/2016/07/rspec-3-5-has-been-released/#rails-support-for-rails-5
 
 ## Contributing
-
-Once you've set up the environment, you'll need to cd into the working
-directory of whichever repo you want to work in. From there you can run the
-specs and cucumber features, and make patches.
-
-NOTE: You do not need to use rspec-dev to work on a specific RSpec repo. You
-can treat each RSpec repo as an independent project.
-Please see the following files:
-
-For `rspec-rails`-specific development information, see
 
 - [Build details](BUILD_DETAIL.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Detailed contributing guide](CONTRIBUTING.md)
-- [Development setup guide](DEVELOPMENT.md)
 
+Once you’ve cloned the repo and [set up the environment](DEVELOPMENT.md),
+you can run the specs and Cucumber features, or submit a pull request.
 
-## Model Specs
+## See Also
 
-Use model specs to describe behavior of models (usually ActiveRecord-based) in
-the application.
+### RSpec base libraries
 
-Model specs default to residing in the `spec/models` folder. Tagging any
-context with the metadata `:type => :model` treats its examples as model
-specs.
+* <https://github.com/rspec/rspec>
+* <https://github.com/rspec/rspec-core>
+* <https://github.com/rspec/rspec-expectations>
+* <https://github.com/rspec/rspec-mocks>
 
-For example:
+### Recommended third-party extensions
 
-```ruby
-require "rails_helper"
+* [FactoryBot](https://github.com/thoughtbot/factory_bot)
+* [Capybara](https://github.com/jnicklas/capybara)  
+  (Included by default in Rails 5.1+.
+  Note that [additional configuration is required][] to use the Capybara DSL
+  anywhere other than system specs and feature specs.)
 
-RSpec.describe Post, :type => :model do
-  context "with 2 or more comments" do
-    it "orders them in reverse chronologically" do
-      post = Post.create!
-      comment1 = post.comments.create!(:body => "first comment")
-      comment2 = post.comments.create!(:body => "second comment")
-      expect(post.reload.comments).to eq([comment2, comment1])
-    end
-  end
-end
-```
+  [additional configuration is required]: http://rubydoc.info/gems/rspec-rails/file/Capybara.md
 
-For more information, see [cucumber scenarios for model
-specs](https://www.relishapp.com/rspec/rspec-rails/docs/model-specs).
+### RSpec style guides
 
-## Request Specs
-
-Use request specs to describe the client-facing behavior of the application —
-specifically, the HTTP response to be issued for a given request (a.k.a.
-integration tests). Since such client-facing behavior encompasses controller
-actions, this is the type of spec to use for controller testing.
-
-Request specs default to residing in the `spec/requests`, `spec/api`, and
-`spec/integration` directories. Tagging any context with the metadata `:type =>
-:request` treats its examples as request specs.
-
-Request specs mix in behavior from
-[ActionDispatch::Integration::Runner](http://api.rubyonrails.org/classes/ActionDispatch/Integration/Runner.html),
-which is the basis for [Rails' integration
-tests](http://guides.rubyonrails.org/testing.html#integration-testing).
-
-```ruby
-require 'rails_helper'
-
-RSpec.describe "home page", :type => :request do
-  it "displays the user's username after successful login" do
-    user = User.create!(:username => "jdoe", :password => "secret")
-    get "/login"
-    assert_select "form.login" do
-      assert_select "input[name=?]", "username"
-      assert_select "input[name=?]", "password"
-      assert_select "input[type=?]", "submit"
-    end
-
-    post "/login", :username => "jdoe", :password => "secret"
-    assert_select ".header .username", :text => "jdoe"
-  end
-end
-```
-
-The above example uses only standard Rails and RSpec APIs, but many
-RSpec/Rails users like to use extension libraries like
-[FactoryBot](https://github.com/thoughtbot/factory_bot) and
-[Capybara](https://github.com/jnicklas/capybara):
-
-```ruby
-require 'rails_helper'
-
-RSpec.describe "home page", :type => :request do
-  it "displays the user's username after successful login" do
-    user = FactoryBot.create(:user, :username => "jdoe", :password => "secret")
-    visit "/login"
-    fill_in "Username", :with => "jdoe"
-    fill_in "Password", :with => "secret"
-    click_button "Log in"
-
-    expect(page).to have_selector(".header .username", :text => "jdoe")
-  end
-end
-```
-
-FactoryBot decouples this example from changes to validation requirements,
-which can be encoded into the underlying factory definition without requiring
-changes to this example.
-
-Among other benefits, Capybara binds the form post to the generated HTML, which
-means we don't need to specify them separately. Note that Capybara's DSL as
-shown is, by default, only available in specs in the spec/features directory.
-For more information, see the [Capybara integration
-docs](http://rubydoc.info/gems/rspec-rails/file/Capybara.md).
-
-There are several other Ruby libs that implement the factory pattern or provide
-a DSL for request specs (a.k.a. acceptance or integration specs), but
-FactoryBot and Capybara seem to be the most widely used. Whether you choose
-these or other libs, we strongly recommend using something for each of these
-roles.
-
-For more information, see [cucumber scenarios for request
-specs](https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec).
-
-## Controller Specs
-
-Controller specs can be used to describe the behavior of Rails controllers. As
-of version 3.5, however, controller specs are discouraged in favor of request
-specs (which also focus largely on controllers, but capture other critical
-aspects of application behavior as well). Controller specs will continue to be
-supported until at least version 4.0 (see the [release
-notes](http://rspec.info/blog/2016/07/rspec-3-5-has-been-released/#rails-support-for-rails-5)
-for details).
-
-For more information, see [cucumber scenarios for controller
-specs](https://www.relishapp.com/rspec/rspec-rails/docs/controller-specs).
-
-## Feature Specs
-
-Feature specs test your application from the outside by simulating a browser.
-[`capybara`](https://github.com/jnicklas/capybara) is used to manage the
-simulated browser.
-
-Feature specs default to residing in the `spec/features` folder. Tagging any
-context with the metadata `:type => :feature` treats its examples as feature
-specs.
-
-Feature specs mix in functionality from the capybara gem, thus they require
-`capybara` to use. To use feature specs, add `capybara` to the `Gemfile`:
-
-```ruby
-gem "capybara"
-```
-
-For more information, see the [cucumber scenarios for feature
-specs](https://www.relishapp.com/rspec/rspec-rails/v/3-4/docs/feature-specs/feature-spec).
-
-## Mailer specs
-
-By default Mailer specs reside in the `spec/mailers` folder. Adding the metadata
-`:type => :mailer` to any context makes its examples be treated as mailer specs.
-
-`ActionMailer::TestCase::Behavior` is mixed into your mailer specs.
-
-```ruby
-require "rails_helper"
-
-RSpec.describe Notifications, :type => :mailer do
-  describe "notify" do
-    let(:mail) { Notifications.signup }
-
-    it "renders the headers" do
-      expect(mail.subject).to eq("Signup")
-      expect(mail.to).to eq(["to@example.org"])
-      expect(mail.from).to eq(["from@example.com"])
-    end
-
-    it "renders the body" do
-      expect(mail.body.encoded).to match("Hi")
-    end
-  end
-end
-```
-
-For more information, see the [cucumber scenarios for mailer specs
-](https://relishapp.com/rspec/rspec-rails/v/3-4/docs/mailer-specs).
-
-## Job specs
-
-Tagging a context with the metadata `:type => :job` treats its examples as job
-specs. Typically these specs will live in `spec/jobs`.
-
-```ruby
-require 'rails_helper'
-
-RSpec.describe UploadBackupsJob, :type => :job do
-  describe "#perform_later" do
-    it "uploads a backup" do
-      ActiveJob::Base.queue_adapter = :test
-      UploadBackupsJob.perform_later('backup')
-      expect(UploadBackupsJob).to have_been_enqueued
-    end
-  end
-end
-```
-
-For more information, see the [cucumber scenarios for job specs
-](https://relishapp.com/rspec/rspec-rails/docs/job-specs).
-
-## View specs
-
-View specs default to residing in the `spec/views` folder. Tagging any context
-with the metadata `:type => :view` treats its examples as view specs.
-
-View specs mix in `ActionView::TestCase::Behavior`.
-
-```ruby
-require 'rails_helper'
-
-RSpec.describe "events/index", :type => :view do
-  it "renders _event partial for each event" do
-    assign(:events, [double(Event), double(Event)])
-    render
-    expect(view).to render_template(:partial => "_event", :count => 2)
-  end
-end
-
-RSpec.describe "events/show", :type => :view do
-  it "displays the event location" do
-    assign(:event, Event.new(:location => "Chicago"))
-    render
-    expect(rendered).to include("Chicago")
-  end
-end
-```
-
-View specs infer the controller name and path from the path to the view
-template. e.g. if the template is `events/index.html.erb` then:
-
-```ruby
-controller.controller_path == "events"
-controller.request.path_parameters[:controller] == "events"
-```
-
-This means that most of the time you don't need to set these values. When
-spec'ing a partial that is included across different controllers, you _may_
-need to override these values before rendering the view.
-
-To provide a layout for the render, you'll need to specify _both_ the template
-and the layout explicitly. For example:
-
-```ruby
-render :template => "events/show", :layout => "layouts/application"
-```
-
-### `assign(key, val)`
-
-Use this to assign values to instance variables in the view:
-
-```ruby
-assign(:widget, Widget.new)
-render
-```
-
-The code above assigns `Widget.new` to the `@widget` variable in the view, and
-then renders the view.
-
-Note that because view specs mix in `ActionView::TestCase` behavior, any
-instance variables you set will be transparently propagated into your views
-(similar to how instance variables you set in controller actions are made
-available in views). For example:
-
-```ruby
-@widget = Widget.new
-render # @widget is available inside the view
-```
-
-RSpec doesn't officially support this pattern, which only works as a
-side-effect of the inclusion of `ActionView::TestCase`. Be aware that it may be
-made unavailable in the future.
-
-#### Upgrade note
-
-```ruby
-# rspec-rails-1.x
-assigns[key] = value
-
-# rspec-rails-2.x+
-assign(key, value)
-```
-
-### `rendered`
-
-This represents the rendered view.
-
-```ruby
-render
-expect(rendered).to match /Some text expected to appear on the page/
-```
-
-#### Upgrade note
-
-```ruby
-# rspec-rails-1.x
-render
-response.should xxx
-
-# rspec-rails-2.x+
-render
-rendered.should xxx
-
-# rspec-rails-2.x+ with expect syntax
-render
-expect(rendered).to xxx
-```
-
-## Routing specs
-
-Routing specs default to residing in the `spec/routing` folder. Tagging any
-context with the metadata `:type => :routing` treats its examples as routing
-specs.
-
-```ruby
-require 'rails_helper'
-
-RSpec.describe "routing to profiles", :type => :routing do
-  it "routes /profile/:username to profile#show for username" do
-    expect(:get => "/profiles/jsmith").to route_to(
-      :controller => "profiles",
-      :action => "show",
-      :username => "jsmith"
-    )
-  end
-
-  it "does not expose a list of profiles" do
-    expect(:get => "/profiles").not_to be_routable
-  end
-end
-```
-
-### Upgrade note
-
-`route_for` from rspec-rails-1.x is gone. Use `route_to` and `be_routable`
-instead.
-
-## Helper specs
-
-Helper specs default to residing in the `spec/helpers` folder. Tagging any
-context with the metadata `:type => :helper` treats its examples as helper
-specs.
-
-Helper specs mix in ActionView::TestCase::Behavior. A `helper` object is
-provided which mixes in the helper module being spec'd, along with
-`ApplicationHelper` (if present).
-
-```ruby
-require 'rails_helper'
-
-RSpec.describe EventsHelper, :type => :helper do
-  describe "#link_to_event" do
-    it "displays the title, and formatted date" do
-      event = Event.new("Ruby Kaigi", Date.new(2010, 8, 27))
-      # helper is an instance of ActionView::Base configured with the
-      # EventsHelper and all of Rails' built-in helpers
-      expect(helper.link_to_event).to match /Ruby Kaigi, 27 Aug, 2010/
-    end
-  end
-end
-```
-
-## Matchers
-
-Several domain-specific matchers are provided to each of the example group
-types. Most simply delegate to their equivalent Rails' assertions.
-
-### `be_a_new`
-
-- Available in all specs
-- Primarily intended for controller specs
-
-```ruby
-expect(object).to be_a_new(Widget)
-```
-
-Passes if the object is a `Widget` and returns true for `new_record?`
-
-### `render_template`
-
-- Delegates to Rails' `assert_template`
-- Available in request, controller, and view specs
-
-In request and controller specs, apply to the `response` object:
-
-```ruby
-expect(response).to render_template("new")
-```
-
-In view specs, apply to the `view` object:
-
-```ruby
-expect(view).to render_template(:partial => "_form", :locals => { :widget => widget } )
-```
-
-### `redirect_to`
-
-- Delegates to `assert_redirect`
-- Available in request and controller specs
-
-```ruby
-expect(response).to redirect_to(widgets_path)
-```
-
-### `route_to`
-
-- Delegates to Rails' `assert_routing`
-- Available in routing and controller specs
-
-```ruby
-expect(:get => "/widgets").to route_to(:controller => "widgets", :action => "index")
-```
-
-### `be_routable`
-
-Passes if the path is recognized by Rails' routing. This is primarily intended
-to be used with `not_to` to specify standard CRUD routes which should not be
-routable.
-
-```ruby
-expect(:get => "/widgets/1/edit").not_to be_routable
-```
-
-### `have_http_status`
-
-- Passes if `response` has a matching HTTP status code
-- The following symbolic status codes are allowed:
-  - `Rack::Utils::SYMBOL_TO_STATUS_CODE`
-  - One of the defined `ActionDispatch::TestResponse` aliases:
-    - `:error`
-    - `:missing`
-    - `:redirect`
-    - `:success`
-- Available in controller, feature, and request specs.
-
-In controller and request specs, apply to the `response` object:
-
-```ruby
-expect(response).to have_http_status(201)
-expect(response).not_to have_http_status(:created)
-```
-
-In feature specs, apply to the `page` object:
-
-```ruby
-expect(page).to have_http_status(:success)
-```
-
-## `rake` tasks
-
-Several rake tasks are provided as a convenience for working with RSpec. To run
-the entire spec suite use `rake spec`. To run a subset of specs use the
-associated type task, for example `rake spec:models`.
-
-A full list of the available rake tasks can be seen by running `rake -T | grep
-spec`.
-
-### Customizing `rake` tasks
-
-If you want to customize the behavior of `rake spec`, you may [define your own
-task in the `Rakefile` for your
-project](https://www.relishapp.com/rspec/rspec-core/docs/command-line/rake-task).
-However, you must first clear the task that rspec-rails defined:
-
-```ruby
-task("spec").clear
-```
-
-
-## Also see
-
-* [https://github.com/rspec/rspec](https://github.com/rspec/rspec)
-* [https://github.com/rspec/rspec-core](https://github.com/rspec/rspec-core)
-* [https://github.com/rspec/rspec-expectations](https://github.com/rspec/rspec-expectations)
-* [https://github.com/rspec/rspec-mocks](https://github.com/rspec/rspec-mocks)
-
-## Feature Requests & Bugs
-
-See <http://github.com/rspec/rspec-rails/issues>
+* [Better Specs](http://www.betterspecs.org/)

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ In RSpec, application behavior is described
 **first in (almost) plain English, then again in test code**, like so:
 
 ```ruby
-RSpec.describe Member do  #
-  context 'in death' do   # (almost) plain English
-    it 'has a name' do    #
-      expect(dead_member.name).to eq('Robert Paulson')  # test code
+RSpec.describe 'Post' do           #
+  context 'before publication' do  # (almost) plain English
+    it 'cannot have comments' do   #
+      expect { Post.create.comments.create! }.to raise_error(ActiveRecord::RecordInvalid)  # test code
     end
   end
 end
@@ -134,29 +134,25 @@ to generate a report of where the application
 conforms to (or fails to meet) the spec:
 
 ```
-$ rspec --format documentation spec/models/member_spec.rb
+$ rspec --format documentation spec/models/post_spec.rb
 
-Member
-  in death
-    has a name
+Post
+  before publication
+    cannot have comments
 
 Failures:
 
-  1) Member in death has a name
-     Failure/Error: expect(dead_member.name).to eq('Robert Paulson')
-
-       expected: "Robert Paulson"
-            got: nil
-
-       (compared using ==)
-     # ./spec/models/member.rb:4:in `block (3 levels) in <top (required)>'
+  1) Post before publication cannot have comments
+     Failure/Error: expect { Post.create.comments.create! }.to raise_error(ActiveRecord::RecordInvalid)
+       expected ActiveRecord::RecordInvalid but nothing was raised
+     # ./spec/models/post.rb:4:in `block (3 levels) in <top (required)>'
 
 Finished in 0.00527 seconds (files took 0.29657 seconds to load)
 1 example, 1 failure
 
 Failed examples:
 
-rspec ./spec/models/member_spec.rb:3 # Member in death has a name
+rspec ./spec/models/post_spec.rb:3 # Post before publication cannot have comments
 ```
 
 For an in-depth look at the RSpec DSL, including lots of examples,
@@ -208,40 +204,24 @@ read the [official Cucumber documentation][].
 
 ## What tests should I write?
 
-At the risk of grossly oversimplifying,
-there are two kinds of tests you can write:
-those that verify
-**an individual component of your application** (unit tests),
-and those that verify
-**how multiple parts of your application work as a whole** (integration tests).
-
-RSpec Rails defines ten different _types_ of specs (7 unit, 3 integration)
+RSpec Rails defines ten different _types_ of specs
 for testing different parts of a typical Rails application.
-Many inherit from one of Rails’ built-in `TestCase` classes,
+Each one inherits from one of Rails’ built-in `TestCase` classes,
 meaning the helper methods provided by default in Rails tests
 are available in RSpec, as well.
 
-- **Unit**
-
-  | Spec type        | Corresponding Rails test class     |
-  | ---------------- | ---------------------------------- |
-  | [model][]        |                                    |
-  | [controller][]\* | [`ActionController::TestCase`][]   |
-  | [mailer][]       | `ActionMailer::TestCase`           |
-  | [job][]          |                                    |
-  | [view][]         | `ActionView::TestCase`             |
-  | [routing][]      |                                    |
-  | [helper][]       | `ActionView::TestCase`             |
-
-- **Integration**
-
-  | Spec type       | Corresponding Rails test class        |
-  | --------------- | ------------------------------------- |
-  | [request][]     | [`ActionDispatch::IntegrationTest`][] |
-  | [feature][]\*   |                                       |
-  | [system][]      | [`ActionDispatch::SystemTestCase`][]  |
-
-_\* discouraged in favor new alternatives_
+  | Spec type      | Corresponding Rails test class        |
+  | -------------- | --------------------------------      |
+  | [model][]      |                                       |
+  | [controller][] | [`ActionController::TestCase`][]      |
+  | [mailer][]     | `ActionMailer::TestCase`              |
+  | [job][]        |                                       |
+  | [view][]       | `ActionView::TestCase`                |
+  | [routing][]    |                                       |
+  | [helper][]     | `ActionView::TestCase`                |
+  | [request][]    | [`ActionDispatch::IntegrationTest`][] |
+  | [feature][]    |                                       |
+  | [system][]     | [`ActionDispatch::SystemTestCase`][]  |
 
 Follow the links above to see examples of each spec type,
 or for official Rails API documentation on the given `TestCase` class.
@@ -250,9 +230,6 @@ or for official Rails API documentation on the given `TestCase` class.
 > 
 > Ask a hundred developers how to test an application,
 > and you’ll get a hundred different answers.
-> Some may insist on exhaustively testing every single method on every model;
-> others may contend that since integration tests capture model behavior anyway,
-> much unit testing is redundant and burdensome.
 >
 > RSpec Rails provides thoughtfully selected features
 > to encourage good testing practices, but there’s no “right” way to do it.
@@ -270,19 +247,17 @@ or for official Rails API documentation on the given `TestCase` class.
 [view]: https://www.relishapp.com/rspec/rspec-rails/docs/view-specs/view-spec
 [routing]: https://www.relishapp.com/rspec/rspec-rails/docs/routing-specs
 [helper]: https://www.relishapp.com/rspec/rspec-rails/docs/helper-specs/helper-spec
-[`ActionDispatch::IntegrationTest`]: https://edgeapi.rubyonrails.org/classes/ActionDispatch/IntegrationTest.html
-[`ActionDispatch::SystemTestCase`]: https://edgeapi.rubyonrails.org/classes/ActionDispatch/SystemTestCase.html
-[`ActionController::TestCase`]: https://edgeapi.rubyonrails.org/classes/ActionController/TestCase.html
+[`ActionDispatch::IntegrationTest`]: https://api.rubyonrails.org/classes/ActionDispatch/IntegrationTest.html
+[`ActionDispatch::SystemTestCase`]: https://api.rubyonrails.org/classes/ActionDispatch/SystemTestCase.html
+[`ActionController::TestCase`]: https://api.rubyonrails.org/classes/ActionController/TestCase.html
 
 ### I’m writing a spec file from scratch. How do I assign it a type?
 
-Assuming you haven’t [modified the default `rails_helper.rb` configuration][],
-simply place the spec in the appropriate folder
+Simply place the spec in the appropriate folder
 (_e.g.,_ `spec/models/` for model specs)
 and RSpec will set its type automatically.
 
-If you _have_ modified the default config
-(or if you just want to be extra explicit),
+If you want to be extra explicit,
 you can set the `:type` option at the top of the file, like so:
 
 ```ruby
@@ -297,12 +272,11 @@ RSpec.describe User, type: :model do
 ### System specs, feature specs, request specs–what’s the difference?
 
 RSpec Rails provides three types of specs
-for integration testing the application as a whole—in other words,
-specifying what the client sees when interacting with it.
+that do not directly correspond to any Rails application component.
 
 #### System specs
 
-Sometimes called **acceptance tests** or **browser tests**,
+Also called **acceptance tests**, **browser tests**, or **end-to-end tests**,
 system specs test the application from the perspective of a _human client._
 The test code walks through a user’s browser interactions,
 
@@ -323,15 +297,20 @@ but `SystemTestCase` solves some longstanding configuration issues they had,
 so the RSpec team [officially recommends system specs][] over feature specs.
 
 If you don’t have the luxury of upgrading,
-you’ll be limited to writing feature specs for your browser tests.
-They require [Capybara][],
-so make sure it’s listed in the `:test` group of your `Gemfile`:
+there’s no problem with using feature specs instead.
+Be sure to add [Capybara][] to the `:test` group of your `Gemfile` first:
 
 ```ruby
 group :test do
   gem "capybara"
 end
 ```
+
+(It’s actually required for both feature and system specs,
+but Rails includes it by default in versions 5.1+.)
+
+[officially recommends system specs]: http://rspec.info/blog/2017/10/rspec-3-7-has-been-released/#rails-actiondispatchsystemtest-integration-system-specs
+[Capybara]: https://github.com/teamcapybara/capybara
 
 #### Request specs
 
@@ -341,18 +320,16 @@ They begin with an HTTP request and end with the HTTP response,
 so they’re faster than feature specs,
 but do not examine your app’s UI or JavaScript.
 
-Request specs provide a high-level alternative to unit testing controllers.
-In fact, as of RSpec 3.5,
-the RSpec team [discourages controller specs entirely][]
-in favor of request specs.
+Request specs provide a high-level alternative to controller specs.
+In fact, as of RSpec 3.5, both the Rails and RSpec teams
+[discourage directly testing controllers][]
+in favor of functional tests like request specs.
 
 When writing them, try to answer the question,
 “For a given HTTP request (verb + path + parameters),
 what HTTP response should the application return?”
 
-[officially recommends system specs]: http://rspec.info/blog/2017/10/rspec-3-7-has-been-released/#rails-actiondispatchsystemtest-integration-system-specs
-[Capybara]: https://github.com/teamcapybara/capybara
-[discourages controller specs entirely]: rspec.info/blog/2016/07/rspec-3-5-has-been-released/#rails-support-for-rails-5
+[discourage directly testing controllers]: rspec.info/blog/2016/07/rspec-3-5-has-been-released/#rails-support-for-rails-5
 
 ## Contributing
 
@@ -381,7 +358,3 @@ you can run the specs and Cucumber features, or submit a pull request.
   anywhere other than system specs and feature specs.)
 
   [additional configuration is required]: http://rubydoc.info/gems/rspec-rails/file/Capybara.md
-
-### RSpec style guides
-
-* [Better Specs](http://www.betterspecs.org/)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 as a drop-in alternative to its default testing framework, Minitest.
 
 In RSpec, tests are not just scripts that verify your application code.
-They’re also detailed explanations of how the application is supposed to behave,
-expressed in plain English, or in other words, _specs._
+They’re also specifications (or _specs,_ for short):
+detailed explanations of how the application is supposed to behave,
+expressed in plain English.
 
 Use **[`rspec-rails` 1.x][]** for Rails 2.x.
 

--- a/features/matchers/have_http_status_matcher.feature
+++ b/features/matchers/have_http_status_matcher.feature
@@ -3,14 +3,14 @@ Feature: `have_http_status` matcher
   The `have_http_status` matcher is used to specify that a response returns a
   desired status code. It accepts one argument in any of the following formats:
 
-  * numeric
-  * name (defined in `Rack::Utils::SYMBOL_TO_STATUS_CODE`)
-  * `ActionDispatch::TestResponse` alias (`:success`, `:missing`, `:redirect`, or `:error`)
+  * numeric code
+  * status name as defined in `Rack::Utils::SYMBOL_TO_STATUS_CODE`
+  * generic status type (`:success`, `:missing`, `:redirect`, or `:error`)
 
   The matcher works on any `response` object. It is available for use in
   [controller specs](../controller-specs), [request specs](../request-specs), and [feature specs](../feature-specs).
 
-  Scenario: Checking a numeric response code
+  Scenario: Checking a numeric status code
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -35,7 +35,7 @@ Feature: `have_http_status` matcher
     When I run `rspec spec`
     Then the examples should all pass
 
-  Scenario: Checking a symbolic response code (by name)
+  Scenario: Checking a symbolic status name
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -60,7 +60,7 @@ Feature: `have_http_status` matcher
     When I run `rspec spec`
     Then the examples should all pass
 
-  Scenario: Checking a symbolic response code (by `ActionDispatch::TestRespose` alias)
+  Scenario: Checking a symbolic generic status type
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby
       require "rails_helper"

--- a/features/matchers/have_http_status_matcher.feature
+++ b/features/matchers/have_http_status_matcher.feature
@@ -5,12 +5,12 @@ Feature: `have_http_status` matcher
 
   * numeric
   * name (defined in `Rack::Utils::SYMBOL_TO_STATUS_CODE`)
-  * type (`:success`, `:missing`, `:redirect`, or `:error`)
+  * `ActionDispatch::TestResponse` alias (`:success`, `:missing`, `:redirect`, or `:error`)
 
   The matcher works on any `response` object. It is available for use in
   [controller specs](../controller-specs), [request specs](../request-specs), and [feature specs](../feature-specs).
 
-  Scenario: Checking a response code by number
+  Scenario: Checking a numeric response code
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -35,7 +35,7 @@ Feature: `have_http_status` matcher
     When I run `rspec spec`
     Then the examples should all pass
 
-  Scenario: Checking a response code by name
+  Scenario: Checking a symbolic response code (by name)
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -60,7 +60,7 @@ Feature: `have_http_status` matcher
     When I run `rspec spec`
     Then the examples should all pass
 
-  Scenario: Checking a response code by type
+  Scenario: Checking a symbolic response code (by `ActionDispatch::TestRespose` alias)
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby
       require "rails_helper"

--- a/features/matchers/have_http_status_matcher.feature
+++ b/features/matchers/have_http_status_matcher.feature
@@ -1,12 +1,16 @@
 Feature: `have_http_status` matcher
 
   The `have_http_status` matcher is used to specify that a response returns a
-  desired status code.
+  desired status code. It accepts one argument in any of the following formats:
+
+  * numeric
+  * name (defined in `Rack::Utils::SYMBOL_TO_STATUS_CODE`)
+  * type (`:success`, `:missing`, `:redirect`, or `:error`)
 
   The matcher works on any `response` object. It is available for use in
   [controller specs](../controller-specs), [request specs](../request-specs), and [feature specs](../feature-specs).
 
-  Scenario: Checking a numeric response code
+  Scenario: Checking a response code by number
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -31,7 +35,7 @@ Feature: `have_http_status` matcher
     When I run `rspec spec`
     Then the examples should all pass
 
-  Scenario: Checking a symbolic response code
+  Scenario: Checking a response code by name
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby
       require "rails_helper"
@@ -56,7 +60,7 @@ Feature: `have_http_status` matcher
     When I run `rspec spec`
     Then the examples should all pass
 
-  Scenario: Checking a general response code
+  Scenario: Checking a response code by type
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby
       require "rails_helper"

--- a/features/view_specs/view_spec.feature
+++ b/features/view_specs/view_spec.feature
@@ -1,6 +1,55 @@
 Feature: view spec
 
-  View specs live in spec/views and render view templates in isolation.
+  View specs should be placed in `spec/views`,
+  and verify the content of view templates in isolation
+  (that is, without invoking a controller).
+
+  Overview
+  --------
+
+  View specs generally follow three steps:
+
+  ```ruby
+  assign(:widget, Widget.new)  # sets @widget = Widget.new in the view template
+
+  render
+
+  expect(rendered).to match(/text/)
+  ```
+
+  1. Use the `assign` method to set instance variables in the view.
+     Technically, `@widget = Widget.new` would work too,
+     but RSpec doesn't officially support this pattern.
+     (It only works as a side effect of the fact that
+     view specs include `ActionView::TestCase` behavior.
+     Be aware that it may be made unavailable in the future.)
+
+  2. Use the `render` method to render the view.
+
+  3. Set expectations against the resulting `rendered` object.
+
+  Notes
+  -----
+
+  * To apply a layout to the view template being rendered,
+    be sure to specify both the template and layout explicitly:
+
+    ```ruby
+    render :template => "events/show", :layout => "layouts/application"
+    ```
+
+  * View specs expose a `controller` object,
+    which can be used to set expectations about the route (path + parameters)
+    to the view template being tested.
+    Some attributes of this object are based on
+    the name of the view itself—that is, in a spec for `events/index.html.erb`:
+
+    * `controller.controller_path == "events"`
+    * `controller.request.path_parameters[:controller] == "events"`
+
+    Be careful of these automatically-inferred values
+    when writing specs for partials
+    (which may be shared across multiple controllers).
 
   Scenario: View specs render the described view file
     Given a file named "spec/views/widgets/index.html.erb_spec.rb" with:

--- a/features/view_specs/view_spec.feature
+++ b/features/view_specs/view_spec.feature
@@ -4,8 +4,8 @@ Feature: view spec
   or if you have set `config.infer_spec_type_from_file_location!`
   by placing them in `spec/views`.
 
-  Use them to test the content of view templates in isolation
-  (that is, without invoking a controller).
+  Use them to test the content of view templates
+  without invoking a specific controller.
   They generally follow three steps:
 
   ```ruby


### PR DESCRIPTION
This is an extensive rewrite of the README written as a follow-up to issue #1840. It has the following goals:

* give explanatory context for users who are new to _both_ RSpec and RSpec rails,
* name section headings with the questions they answer,
* make each section concise enough that a reader can comprehend the visual structure of the document on a quick scroll-through,
* replace "redundant" info (code blocks that demonstrate concepts readily available in the cucumber doc scenarios, or upgrade notes) with links to corresponding cucumber docs,
* update for latest version of RSpec Rails (specifically re: recommendations for controller specs and feature specs).

Notably, I've removed the section on rake tasks, and mostly removed the section on FactoryBot/Capybara. I've also added a link to betterspecs.org as an RSpec style guide.

Thoughts?