### PR TITLE
Use __dir__ for expand_path in rails_helper template

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -1,7 +1,11 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
+<% if RUBY_VERSION >= '2.0.0' %>
 require File.expand_path('../config/environment', __dir__)
+<% else %>
+require File.expand_path('../../config/environment', __FILE__)
+<% end %>
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'


### PR DESCRIPTION
Ruby 2.0 introduced `__dir__` pseudo variable, and we can replace it with `__FILE__` for `expand_path` method.
There is a RuboCop Cop pointing this out.
http://www.rubocop.org/en/latest/cops_style/#styleexpandpatharguments
This change reduces one RuboCop warning after installing rspec-rails.