### PR TITLE
Use Rubygems 2.7.8 (avoid Rubygems 3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache: bundler
 bundler_args: "--binstubs --path ../bundle --retry=3 --jobs=3"
 
 before_install:
-  - gem update --system
+  - gem update --system 2.7.8
   - gem install bundler
   - script/clone_all_rspec_repos
 


### PR DESCRIPTION
Rubygems 3 [drops support for older rubies](https://github.com/rubygems/rubygems/pull/2182) so this is needed to keep the Travis matrix working.