### PR TITLE
System Spec feature: include System Tests text

### DIFF
--- a/features/system_specs/system_specs.feature
+++ b/features/system_specs/system_specs.feature
@@ -1,13 +1,28 @@
 Feature: System spec
 
     System specs are RSpec's wrapper around Rails' own
-    [system tests](http://guides.rubyonrails.org/testing.html#system-testing).
-    We encourage you to familiarize yourself with their documentation.
+    [system tests](https://guides.rubyonrails.org/testing.html#system-testing).
 
-    RSpec **does not** use your `ApplicationSystemTestCase` helper. Instead it uses
-    the default `driven_by(:selenium)` from Rails. If you want to override this
-    behaviour you can call `driven_by` manually in a test.
+    > System tests allow you to test user interactions with your application,
+    > running tests in either a real or a headless browser. System tests use
+    > Capybara under the hood.
+    >
+    > By default, system tests are run with the Selenium driver, using the
+    > Chrome browser, and a screen size of 1400x1400. The next section explains
+    > how to change the default settings.
 
+    System specs are marked by setting type to :system, e.g. `:type => :system`.
+
+    The Capybara gem is automatically required, and Rails includes it in
+    generated application Gemfiles. Configure a webserver (e.g.
+    `Capybara.server = :webrick`) before attempting to use system specs.
+
+    RSpec **does not** use your `ApplicationSystemTestCase` helper. Instead it
+    uses the default `driven_by(:selenium)` from Rails. If you want to override
+    this behaviour you can call `driven_by` manually in a test.
+
+    System specs run in a transaction. So unlike feature specs with
+    javascript, you do not need [DatabaseCleaner](https://github.com/DatabaseCleaner/database_cleaner).
 
     @system_test
     Scenario: System specs


### PR DESCRIPTION
This PR introduces a few sentences from the Rails documentation on System Testing.

Goals:

1. keep more of the story in the same document - easier to navigate
2. tell the story in an rspec-rails frame - talk about how to get things done in this spec

When we close in on those goals, perhaps the link to the System Tests documentation can be de-emphasised.

## Questions for reviewer

- [ ] What is the smallest iterative step we can take towards those goals?
- [ ] Should this PR include more _Scenarios_?