### PR TITLE
Error message language: call them system specs

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -57,7 +57,7 @@ module RSpec
             System test integration requires Rails >= 5.1 and has a hard
             dependency on a webserver and `capybara`, please add capybara to
             your Gemfile and configure a webserver (e.g. `Capybara.server =
-            :webrick`) before attempting to use system tests.
+            :webrick`) before attempting to use system specs.
           """.gsub(/\s+/, ' ').strip
         end
 


### PR DESCRIPTION
After close-reading the text of this error message, I offer this change: call the thing the user is trying to start using by its name "system specs".