### PR TITLE
Fix generate request spec name has `/`

### DIFF
--- a/lib/generators/rspec/integration/integration_generator.rb
+++ b/lib/generators/rspec/integration/integration_generator.rb
@@ -15,7 +15,7 @@ module Rspec
         return unless options[:request_specs]
 
         template 'request_spec.rb',
-                 File.join('spec/requests', class_path, "#{table_name}_spec.rb")
+                 File.join('spec/requests', "#{name.underscore.pluralize}_spec.rb")
       end
     end
   end

--- a/lib/generators/rspec/integration/templates/request_spec.rb
+++ b/lib/generators/rspec/integration/templates/request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "<%= class_name.pluralize %>", <%= type_metatag(:request) %> do
-  describe "GET /<%= table_name %>" do
+  describe "GET /<%= name.underscore.pluralize %>" do
     it "works! (now write some real specs)" do
       get <%= index_helper %>_path
       expect(response).to have_http_status(200)

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -34,32 +34,65 @@ module RSpec
 
           describe 'generated with no flags' do
             before do
-              run_generator %w(posts)
+              run_generator name
             end
 
-            subject(:request_spec) { file('spec/requests/posts_spec.rb') }
+            subject(:request_spec) { file(spec_file_name) }
 
-            it "creates the request spec" do
-              expect(request_spec).to exist
+            context 'When NAME=posts' do
+              let(:name) { %w(posts) }
+              let(:spec_file_name) { 'spec/requests/posts_spec.rb' }
+
+              it "creates the request spec" do
+                expect(request_spec).to exist
+              end
+
+              it "the generator requires 'rails_helper'" do
+                expect(request_spec).to contain(/require 'rails_helper'/)
+              end
+
+              it "the generator describes the provided NAME without monkey " \
+                 "patching setting the type to `:request`" do
+                expect(request_spec).to contain(
+                  /^RSpec.describe \"Posts\", #{type_metatag(:request)}/
+                )
+              end
+
+              it "the generator includes a sample GET request" do
+                expect(request_spec).to contain(/describe "GET \/posts"/)
+              end
+
+              it "the generator sends the GET request to the index path" do
+                expect(request_spec).to contain(/get posts_index_path/)
+              end
             end
 
-            it "the generator requires 'rails_helper'" do
-              expect(request_spec).to contain(/require 'rails_helper'/)
-            end
+            context 'When NAME=api/posts' do
+              let(:name) { %w(api/posts) }
+              let(:spec_file_name) { 'spec/requests/api/api_posts_spec.rb' }
 
-            it "the generator describes the provided NAME without monkey " \
-               "patching setting the type to `:request`" do
-              expect(request_spec).to contain(
-                /^RSpec.describe \"Posts\", #{type_metatag(:request)}/
-              )
-            end
+              it "creates the request spec" do
+                expect(request_spec).to exist
+              end
 
-            it "the generator includes a sample GET request" do
-              expect(request_spec).to contain(/describe "GET \/posts"/)
-            end
+              it "the generator requires 'rails_helper'" do
+                expect(request_spec).to contain(/require 'rails_helper'/)
+              end
 
-            it "the generator sends the GET request to the index path" do
-              expect(request_spec).to contain(/get posts_index_path/)
+              it "the generator describes the provided NAME without monkey " \
+                 "patching setting the type to `:request`" do
+                expect(request_spec).to contain(
+                  /^RSpec.describe \"Api::Posts\", #{type_metatag(:request)}/
+                )
+              end
+
+              it "the generator includes a sample GET request" do
+                expect(request_spec).to contain(/describe "GET \/api_posts\"/)
+              end
+
+              it "the generator sends the GET request to the index path" do
+                expect(request_spec).to contain(/get api_posts_index_path\n/)
+              end
             end
           end
         end

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -69,7 +69,7 @@ module RSpec
 
             context 'When NAME=api/posts' do
               let(:name) { %w(api/posts) }
-              let(:spec_file_name) { 'spec/requests/api/api_posts_spec.rb' }
+              let(:spec_file_name) { 'spec/requests/api/posts_spec.rb' }
 
               it "creates the request spec" do
                 expect(request_spec).to exist
@@ -87,7 +87,7 @@ module RSpec
               end
 
               it "the generator includes a sample GET request" do
-                expect(request_spec).to contain(/describe "GET \/api_posts\"/)
+                expect(request_spec).to contain(/describe "GET \/api\/posts\"/)
               end
 
               it "the generator sends the GET request to the index path" do


### PR DESCRIPTION
## before

```
$ rails g rspec:request api/posts
Running via Spring preloader in process 2817
      create  spec/requests/api/api_posts_spec.rb
```

```
$ cat spec/requests/api/api_posts_spec.rb
require 'rails_helper'

RSpec.describe "Api::Posts", type: :request do
  describe "GET /api_posts" do
    it "works! (now write some real specs)" do
      get api_posts_index_path
      expect(response).to have_http_status(200)
    end
  end
end
```


## after

```
$ rails g rspec:request api/posts
Running via Spring preloader in process 36682
      create  spec/requests/api/posts_spec.rb
```

```
$ cat spec/requests/api/posts_spec.rb
require 'rails_helper'

RSpec.describe "Api::Posts", type: :request do
  describe "GET /api/posts" do
    it "works! (now write some real specs)" do
      get api_posts_index_path
      expect(response).to have_http_status(200)
    end
  end
end
```