### PR TITLE
Truncate more method names in system tests

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -37,7 +37,7 @@ module RSpec
         @method_name ||= [
           self.class.name.underscore,
           RSpec.current_example.description.underscore
-        ].join("_").tr(CHARS_TO_TRANSLATE.join, "_")[0...251] + "_#{rand(1000)}"
+        ].join("_").tr(CHARS_TO_TRANSLATE.join, "_")[0...100] + "_#{rand(1000)}"
       end
 
       # Delegates to `Rails.application`.


### PR DESCRIPTION
ref: https://github.com/rspec/rspec-rails/pull/1999/files

If system test fails, a screenshot is taken, but if the file name exceeds 255 characters(e.g. using turnip), the following error will be output.

```
File name too long @ rb_sysopen
```

The reason is the test fails, `failures_` is appended to first of file name.
So I truncated it to a certain length so that the length of the file name does not become long.