### PR TITLE
Change negated active job matcher, fixes #1870

### DIFF
--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -197,6 +197,12 @@ module RSpec
 
             check(in_block_jobs)
           end
+
+          def does_not_match?(proc)
+            set_expected_number(:at_least, 1)
+
+            !matches?(proc)
+          end
         end
 
         # @private
@@ -204,6 +210,12 @@ module RSpec
           def matches?(job)
             @job = job
             check(queue_adapter.enqueued_jobs)
+          end
+
+          def does_not_match?(proc)
+            set_expected_number(:at_least, 1)
+
+            !matches?(proc)
           end
         end
       end

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -122,7 +122,16 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
     it "fails when negated and job is enqueued" do
       expect {
         expect { heavy_lifting_job.perform_later }.not_to have_enqueued_job
-      }.to raise_error(/expected not to enqueue exactly 1 jobs, but enqueued 1/)
+      }.to raise_error(/expected not to enqueue at least 1 jobs, but enqueued 1/)
+    end
+
+    it "fails when negated and several jobs enqueued" do
+      expect {
+        expect {
+          heavy_lifting_job.perform_later
+          heavy_lifting_job.perform_later
+        }.not_to have_enqueued_job
+      }.to raise_error(/expected not to enqueue at least 1 jobs, but enqueued 2/)
     end
 
     it "passes with job name" do
@@ -343,6 +352,14 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       expect {
         expect(heavy_lifting_job).to have_been_enqueued
       }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
+    end
+
+    it "fails when negated and several jobs enqueued" do
+      heavy_lifting_job.perform_later
+      heavy_lifting_job.perform_later
+      expect {
+        expect(heavy_lifting_job).not_to have_been_enqueued
+      }.to raise_error(/expected not to enqueue at least 1 jobs, but enqueued 2/)
     end
   end
 end

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "HaveEnqueuedMail matchers", :skip => !RSpec::Rails::FeatureCheck
         expect {
           TestMailer.test_email.deliver_later
         }.not_to have_enqueued_mail(TestMailer, :test_email)
-      }.to raise_error(/expected not to enqueue TestMailer.test_email exactly 1 time but enqueued 1/)
+      }.to raise_error(/expected not to enqueue TestMailer.test_email at least 1 time but enqueued 1/)
     end
 
     it "passes with :once count" do


### PR DESCRIPTION
# Change negated active job matcher, fixes #1870 
When using the active job matchers, they will default to expecting a job to be enqueued exactly once. This results in some non intuitional behaviour, when using the negated matcher.

Consider the following example:
```ruby
expect {
  heavy_lifting_job.perform_later
  heavy_lifting_job.perform_later
}.not_to have_enqueued_job
```

Some would read this as "When enqueuing two heavy lifting jobs I expect no jobs to have been enqueued". Since two jobs are actually enqueued it should fail, which it previously would not.

This pull request fixes this issue by setting the default expectation to use "at least once" when using the negated matcher.