### PR TITLE
Gemfile: Update Nokogiri, FFI deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ if RUBY_VERSION >= '2.4.0'
   gem 'json', '>= 2.0.2'
 end
 
-gem 'ffi', '~> 1.9.25'
+gem 'ffi', '~> 1.10.0'
 
 gem 'rake', '>= 10.0.0'
 
@@ -33,7 +33,7 @@ gem 'mime-types', '< 3'
 
 gem 'capybara', '~> 2.13', :require => false
 
-gem 'nokogiri', '1.8.5'
+gem 'nokogiri', '1.10.1'
 
 gem "rubyzip", '>= 1.2.2'
 


### PR DESCRIPTION
This PR onto 4.0-dev made it possible for me to install on Ruby 2.6.0.

(Are there any special reasons to avoid latest, for these two?)

- [Nokogiri Changelog](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#1101--2019-01-13)
- [FFI Changelog](https://github.com/ffi/ffi/blob/master/CHANGELOG.md#1100--2019-01-06)
