### PR TITLE
The #hash method was renamed to #data.

### DIFF
--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -272,7 +272,7 @@ module RSpec::Rails
         result = view_spec.view.view_paths.first
 
         expect(result).to be_instance_of(ActionView::FixtureResolver)
-        expect(result.hash).to eq('some_path/some_template' => 'stubbed-contents')
+        expect(result.data).to eq('some_path/some_template' => 'stubbed-contents')
       end
 
       it 'caches FixtureResolver instances between example groups' do


### PR DESCRIPTION
See here: https://github.com/rails/rails/commit/a2be6ce3eb94516a57c07c98f3cb19502b05cff1