### PR TITLE
Fix fixtures path for model generator when using namespaced models

### DIFF
--- a/lib/generators/rspec/model/model_generator.rb
+++ b/lib/generators/rspec/model/model_generator.rb
@@ -23,7 +23,7 @@ module Rspec
 
       def create_fixture_file
         return unless missing_fixture_replacement?
-        template 'fixtures.yml', File.join('spec/fixtures', "#{table_name}.yml")
+        template 'fixtures.yml', File.join('spec/fixtures', class_path, "#{(pluralize_table_names? ? plural_file_name : file_name)}.yml")
       end
 
     private

--- a/spec/generators/rspec/model/model_generator_spec.rb
+++ b/spec/generators/rspec/model/model_generator_spec.rb
@@ -12,27 +12,10 @@ RSpec.describe Rspec::Generators::ModelGenerator, :type => :generator do
     gen.invoke_all
   end
 
+  it_behaves_like 'a model generator with fixtures', 'admin/posts', 'Admin::Posts'
+  it_behaves_like 'a model generator with fixtures', 'posts', 'Posts'
+
   describe 'the generated files' do
-    describe 'with fixtures' do
-      before do
-        run_generator %w(posts --fixture)
-      end
-
-      describe 'the spec' do
-        subject { file('spec/models/posts_spec.rb') }
-
-        it { is_expected.to exist }
-        it { is_expected.to contain(/require 'rails_helper'/) }
-        it { is_expected.to contain(/^RSpec.describe Posts, #{type_metatag(:model)}/) }
-      end
-
-      describe 'the fixtures' do
-        subject { file('spec/fixtures/posts.yml') }
-
-        it { is_expected.to contain(Regexp.new('# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html')) }
-      end
-    end
-
     describe 'without fixtures' do
       before do
         run_generator %w(posts)

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -19,6 +19,24 @@ module RSpec
           klass.extend(Macros)
         end
 
+        shared_examples_for 'a model generator with fixtures' do |name, class_name|
+          before { run_generator [name, '--fixture'] }
+
+          describe 'the spec' do
+            subject { file("spec/models/#{name}_spec.rb") }
+
+            it { is_expected.to exist }
+            it { is_expected.to contain(/require 'rails_helper'/) }
+            it { is_expected.to contain(/^RSpec.describe #{class_name}, #{type_metatag(:model)}/) }
+          end
+
+          describe 'the fixtures' do
+            subject { file("spec/fixtures/#{name}.yml") }
+
+            it { is_expected.to contain(Regexp.new('# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html')) }
+          end
+        end
+
         shared_examples_for "a request spec generator" do
           describe 'generated with flag `--no-request-specs`' do
             before do


### PR DESCRIPTION
When fixures are enabled the model generator create the fixture files with an incorrect path for namespaced models

application.rb configuration
```ruby
config.generators do |g|
  g.test_framework :rspec, fixture: true
end
```

Running the generator for a namespaced model

```bash
bin/rails g model admin/posts
```

Expected
```
spec/fixtures/admin/posts.yml
```

Actual

```
spec/fixtures/admin_posts.yml
```