### PR TITLE
AV::Base use #empty

### DIFF
--- a/spec/rspec/rails/example/helper_example_group_spec.rb
+++ b/spec/rspec/rails/example/helper_example_group_spec.rb
@@ -42,7 +42,11 @@ module RSpec::Rails
         group = RSpec::Core::ExampleGroup.describe do
           include HelperExampleGroup
           def _view
-            ActionView::Base.new
+            if ActionView::Base.respond_to?(:empty)
+              ActionView::Base.empty
+            else
+              ActionView::Base.new
+            end
           end
         end
         expect(group.new.helper).to be_kind_of(ApplicationHelper)


### PR DESCRIPTION
reference: https://github.com/rails/rails/commit/e17fe52e0e0ef0842b6c409e1110a862c4e005bc#diff-0f66ef96762e67b6746a49de6182c1a4

fixes
```
  1) RSpec::Rails::HelperExampleGroup#helper includes ApplicationHelper
     Failure/Error: example.run

     RuntimeError:
       Warnings were generated: DEPRECATION WARNING: ActionView::Base instances should be constructed with a lookup context,
       assignments, and a controller.
```