### PR TITLE
fix arity

### DIFF
--- a/example_app_generator/spec/verify_custom_renderers_spec.rb
+++ b/example_app_generator/spec/verify_custom_renderers_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "template rendering", :type => :controller do
       ActionView::Template.new(
         "",
         name,
-        lambda { |_template| %("Dynamic template with path '#{_template.virtual_path}'") },
+        lambda { |_template, _source = nil| %("Dynamic template with path '#{_template.virtual_path}'") },
         :virtual_path => path,
         :format => :html
       )


### PR DESCRIPTION
similar to https://github.com/rspec/rspec-rails/pull/2089

fixes 2 failures
```
 template rendering with render_views enabled with a custom renderer prepended to the view path renders the contents of the template
     Failure/Error: lambda { |_template| %("Dynamic template with path '#{_template.virtual_path}'") },
     
     ActionView::Template::Error:
       wrong number of arguments (given 2, expected 1)
     # ./spec/verify_custom_renderers_spec.rb:153:in `block in find_template'
     # ./spec/verify_custom_renderers_spec.rb:120:in `index'
     # /home/travis/build/rspec/bundle/ruby/2.6.0/bundler/gems/rails-controller-testing-21014e48be12/lib/rails/controller/testing/template_assertions.rb:61:in `process'
     # /home/travis/build/rspec/bundle/ruby/2.6.0/bundler/gems/rails-controller-testing-21014e48be12/lib/rails/controller/testing/integration.rb:13:in `block (2 levels) in <module:Integration>'
     # ./spec/verify_custom_renderers_spec.rb:131:in `block (4 levels) in <main>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 2, expected 1)
     #   ./spec/verify_custom_renderers_spec.rb:153:in `block in find_template'
 template rendering with render_views enabled with a custom renderer prepended to the view path renders the 'baz' template
     Failure/Error: lambda { |_template| %("Dynamic template with path '#{_template.virtual_path}'") },
     
     ActionView::Template::Error:
       wrong number of arguments (given 2, expected 1)
     # ./spec/verify_custom_renderers_spec.rb:153:in `block in find_template'
     # ./spec/verify_custom_renderers_spec.rb:120:in `index'
     # /home/travis/build/rspec/bundle/ruby/2.6.0/bundler/gems/rails-controller-testing-21014e48be12/lib/rails/controller/testing/template_assertions.rb:61:in `process'
     # /home/travis/build/rspec/bundle/ruby/2.6.0/bundler/gems/rails-controller-testing-21014e48be12/lib/rails/controller/testing/integration.rb:13:in `block (2 levels) in <module:Integration>'
     # ./spec/verify_custom_renderers_spec.rb:125:in `block (4 levels) in <main>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 2, expected 1)
     #   ./spec/verify_custom_renderers_spec.rb:153:in `block in find_template'
```