### PR TITLE
jbuilder

### DIFF
--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -28,6 +28,10 @@ in_root do
     gsub_file "Gemfile", /.*rdoc.*/, "gem 'rdoc', '< 6'"
   end
 
+  if Rails::VERSION::STRING >= '6'
+    gsub_file "Gemfile", /.*jbuilder.*/, "gem 'jbuilder', :git => 'https://github.com/rails/jbuilder.git', :branch => 'master'"
+  end
+
   if Rails::VERSION::STRING >= '5.0.0'
     append_to_file('Gemfile', "gem 'rails-controller-testing', :git => 'https://github.com/rails/rails-controller-testing'\n")
   end


### PR DESCRIPTION
use the master branch until https://github.com/rails/jbuilder/pull/453 is released

fixes
```
Action Mailer railtie hook in a non-development environment respects the setting from `show_previews`
     Failure/Error:
       expect(
         capture_exec(custom_env.merge('SHOW_PREVIEWS' => 'true'), exec_script)
       ).to eq("#{::Rails.root}/spec/mailers/previews")
     
       expected: "/home/travis/build/rspec/rspec-rails/tmp/example_app/spec/mailers/previews"
            got: #<struct CaptureExec io="DEPRECATION WARNING: Single arity template handlers are deprecated.  Templat....rb:37)\n/home/travis/build/rspec/rspec-rails/tmp/example_app/spec/mailers/previews", exit_status=0>
     
       (compared using ==)
     
       Diff:
       @@ -1,2 +1,2 @@
       -"/home/travis/build/rspec/rspec-rails/tmp/example_app/spec/mailers/previews"
       +"#<struct CaptureExec io=\"DEPRECATION WARNING: Single arity template handlers are deprecated.  Templat....rb:37)\\n/home/travis/build/rspec/rspec-rails/tmp/example_app/spec/mailers/previews\", exit_status=0>"
...
```