### PR TITLE
Make EmptyTemplateHandler compatible with Rails 6

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -102,7 +102,7 @@ module RSpec
 
       # @private
       class EmptyTemplateHandler
-        def self.call(_template)
+        def self.call(_template, _source = nil)
           ::Rails.logger.info("  Template rendering was prevented by rspec-rails. Use `render_views` to verify rendered view contents if necessary.")
 
           %("")


### PR DESCRIPTION
Rails version: **6.0.0.beta2**

RSpec-Rails fails with:

```
ActionView::Template::Error:
       wrong number of arguments (given 2, expected 1)
```

It turned out that templates API has changed in Rails 6: https://github.com/rails/rails/pull/35119.