### PR TITLE
Fix `errors` method check in be_valid matcher

### DIFF
--- a/lib/rspec/rails/matchers/be_valid.rb
+++ b/lib/rspec/rails/matchers/be_valid.rb
@@ -15,7 +15,7 @@ module RSpec
         def failure_message
           message = "expected #{actual.inspect} to be valid"
 
-          if actual.respond_to?(:errors)
+          if actual.respond_to?(:errors) && actual.method(:errors).arity < 1
             errors = if actual.errors.respond_to?(:full_messages)
                        actual.errors.full_messages
                      else

--- a/spec/rspec/rails/matchers/be_valid_spec.rb
+++ b/spec/rspec/rails/matchers/be_valid_spec.rb
@@ -24,9 +24,19 @@ describe "be_valid matcher" do
     end
   end
 
+  class Car
+    def valid?
+      false
+    end
+
+    def errors(_)
+    end
+  end
+
   let(:post) { Post.new }
   let(:book) { Book.new }
   let(:boat) { Boat.new }
+  let(:car) { Car.new }
 
   it "includes the error messages in the failure message" do
     expect {
@@ -43,6 +53,12 @@ describe "be_valid matcher" do
   it "includes a brief error message for the simplest implementation of validity" do
     expect {
       expect(boat).to be_valid
+    }.to raise_exception(/expected .+ to be valid\z/)
+  end
+
+  it "includes a brief error message when error message is wrong arity" do
+    expect {
+      expect(car).to be_valid
     }.to raise_exception(/expected .+ to be valid\z/)
   end
 


### PR DESCRIPTION
Bug report + bug fix PR.

If the `.be_valid?` matcher fails, it checks for the presence of a
`.errors` method and uses it, if present, in the failure message.  This
works great, unless the subject happens to include an `errors` method
that takes an argument, in which case we get an error (because we call
errors with 0 arguments).

Here's a simple repro case which'll result in `wrong number of arguments (given 0, expected 1)` for the `.errors` method.

```
  it 'foo' do
    some_obj = Object.new
    def some_obj.valid?() false; end
    def some_obj.errors(foo) 'bar'; end

    expect(some_obj).to be_valid
  end
```

I'd propose to fix this with an arity check (this PR).  I've included a spec that fails without this fix (piggybacking on an existing spec that already tested the general case of an object with a `valid?` method but no `errors` method).