### PR TITLE
Various fixes for Rails 6

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -56,8 +56,18 @@ module RSpec
               template.identifier,
               EmptyTemplateHandler,
               :virtual_path => template.virtual_path,
-              :format => template.formats
+              :format => template_format(template)
             )
+          end
+        end
+
+        if ::Rails::VERSION::STRING >= '6'
+          def self.template_format(template)
+            template.format
+          end
+        else
+          def self.template_format(template)
+            template.formats
           end
         end
 


### PR DESCRIPTION
Whilst investigating a Rails 6 upgrade (`6.0.0.beta3`) I discovered the following issues:

* The `ActionView::Template#formats` method has been deprecated [1]
* ~The Template handler API has changed [2]~ (already fixed on `4-0-dev`) 

This branch attempts to fix these issues whilst retaining support for Rails <= 5.2.

[1] https://www.github.com/rails/rails/commit/ca5e23ed4d8
[2] https://www.github.com/rails/rails/commit/28f88e0074