### PR TITLE
Fix `ActionView::Template#new` deprecation warning in Rails 6

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -56,7 +56,8 @@ module RSpec
               template.identifier,
               EmptyTemplateHandler,
               :virtual_path => template.virtual_path,
-              :format => template_format(template)
+              :format => template_format(template),
+              :locals => []
             )
           end
         end


### PR DESCRIPTION
In Rails 6 this method now requires the locals named argument [1].

[1] https://www.github.com/rails/rails/commit/d4015a7f06