### PR TITLE
[ruby-head] Turn value into a String before regex match

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -1,5 +1,5 @@
 version_file = File.expand_path("../.rails-version", __FILE__)
-case version = ENV['RAILS_VERSION'] || (File.exist?(version_file) && File.read(version_file).chomp)
+case version = ENV['RAILS_VERSION'] || (File.exist?(version_file) && File.read(version_file).chomp) || ''
 when /master/
   gem "rails", :git => "https://github.com/rails/rails.git"
   gem "arel", :git => "https://github.com/rails/arel.git"


### PR DESCRIPTION
This PR is tries to avoid a warning output in 2.7.0 (`ruby-head`), which causes a test failure in `rspec-core`:

> expected `"/home/travis/build/rspec/rspec-rails/Gemfile-rails-dependencies:49:
warning: deprecated Object#=~ is called on FalseClass; it always returns nil\n".empty?` to return true, got false

[Error in rspec-core Travis build](https://travis-ci.org/rspec/rspec-core/jobs/514297628#L3562)

This PR turns the value (`version`) being matched with `=~` into a String, first.

The change to ruby was introduced in https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=65989&view=revision