### PR TITLE
CI: Drop sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-sudo: false
-
 # We deviate from the rspec-dev cache setting here.
 #
 # Travis has special bundler support where it knows to run `bundle clean`


### PR DESCRIPTION
  - Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration