### PR TITLE
Skip RescuedExceptionsVariableName cop with Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,3 +67,6 @@ Lint/EmptyExpression:
 
 Layout/AlignHash:
   Enabled: false
+
+Naming/RescuedExceptionsVariableName:
+  Enabled: false


### PR DESCRIPTION
This is a new default cop introduced in [Rubocop 0.67.1](https://github.com/rubocop-hq/rubocop/blob/fc0fe57a950593db69bd465a813b3120d0dc2aa1/CHANGELOG.md#changes-1). It [breaks the build](https://travis-ci.org/rspec/rspec-rails/jobs/508775231) for 4-0-dev.

Related: https://github.com/rspec/rspec-rails/pull/2071