### PR TITLE
Updated travis build scripts (from rspec-dev)

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-04-18T19:41:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # This file contains defaults for RSpec projects. Individual projects

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-04-18T19:41:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 version: "{build}"

--- a/script/clone_all_rspec_repos
+++ b/script/clone_all_rspec_repos
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-04-18T19:41:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-04-18T19:41:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-04-18T19:41:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 function is_mri {

--- a/script/run_build
+++ b/script/run_build
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-04-18T19:41:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/travis_functions.sh
+++ b/script/travis_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-04-18T19:41:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # Taken from:

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-04-18T19:41:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e


### PR DESCRIPTION
This PR updates the CI matrix to use `ruby-2.6.3`.