### PR TITLE
Fix builds by swapping to webdrivers instead of locking selenium-webdriver

### DIFF
--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -33,7 +33,7 @@ in_root do
   end
 
   if Rails::VERSION::STRING >= "5.1.0"
-    gsub_file "Gemfile", /.*selenium-webdriver.*/, "gem 'selenium-webdriver', '<= 3.14'"
+    gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers'"
   end
 
   if Rails::VERSION::STRING >= '5.2.0' && Rails::VERSION::STRING < '6'


### PR DESCRIPTION
`chromedriver-helper` was deprecated in favor of the `webdrivers` gem which includes handling of the `selenium-webdriver` deprecations.  This PR swaps to the `webdrivers` gem (as current Rails has) rather than locking `selenium-webdriver`