### PR TITLE
Improve path parsing in _default_render_options

### DIFF
--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -130,11 +130,10 @@ module RSpec
         def _default_render_options
           if ::Rails::VERSION::STRING >= '3.2'
             formats = if ActionView::Template::Types.respond_to?(:symbols)
-              ActionView::Template::Types.symbols
-            else
-              [:html, :text, :js, :css, :xml, :json].map(&:to_s)
+                        ActionView::Template::Types.symbols
+                      else
+                        [:html, :text, :js, :css, :xml, :json].map(&:to_s)
             end.map { |x| Regexp.escape(x) }.join("|")
-
 
             handlers = ActionView::Template::Handlers.extensions.map { |x| Regexp.escape(x) }.join("|")
             locales = "[a-z]{2}(?:-[A-Z]{2})?"

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -129,14 +129,30 @@ module RSpec
 
         def _default_render_options
           if ::Rails::VERSION::STRING >= '3.2'
-            # pluck the handler, format, and locale out of, eg, posts/index.de.html.haml
-            template, *components   = _default_file_to_render.split('.')
-            handler, format, locale = *components.reverse
+            handlers = ActionView::Template::Handlers.extensions.map { |x| Regexp.escape(x) }.join("|")
+            formats = ActionView::Template::Types.symbols.map { |x| Regexp.escape(x) }.join("|")
+            locales = "[a-z]{2}(?:-[A-Z]{2})?"
+            variants = "[^.]*"
+            path_regex = %r{
+              \A
+              (?<template>.*?)
+              (?:\.(?<locale>#{locales}))??
+              (?:\.(?<format>#{formats}))??
+              (?:\+(?<variant>#{variants}))??
+              (?:\.(?<handler>#{handlers}))?
+              \z
+            }x
 
-            render_options = { :template => template }
-            render_options[:handlers] = [handler] if handler
-            render_options[:formats] = [format.to_sym] if format
-            render_options[:locales] = [locale] if locale
+            # This regex should always find a match.
+            # Worst case, everything will be nil, and :template will just be
+            # the original string.
+            match = path_regex.match(_default_file_to_render)
+
+            render_options = { :template => match[:template] }
+            render_options[:handlers] = [match[:handler]] if match[:handler]
+            render_options[:formats] = [match[:format].to_sym] if match[:format]
+            render_options[:locales] = [match[:locale]] if match[:locale]
+            render_options[:variants] = [match[:variant]] if match[:variant]
 
             render_options
           else

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -133,7 +133,7 @@ module RSpec
                         ActionView::Template::Types.symbols
                       else
                         [:html, :text, :js, :css, :xml, :json].map(&:to_s)
-            end.map { |x| Regexp.escape(x) }.join("|")
+                      end.map { |x| Regexp.escape(x) }.join("|")
 
             handlers = ActionView::Template::Handlers.extensions.map { |x| Regexp.escape(x) }.join("|")
             locales = "[a-z]{2}(?:-[A-Z]{2})?"

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -129,14 +129,20 @@ module RSpec
 
         def _default_render_options
           if ::Rails::VERSION::STRING >= '3.2'
+            formats = if ActionView::Template::Types.respond_to?(:symbols)
+              ActionView::Template::Types.symbols.map { |x| Regexp.escape(x) }.join("|")
+            else
+              [:html, :text, :js, :css, :xml, :json].map(&:to_s)
+            end.map { |x| Regexp.escape(x) }.join("|")
+
+
             handlers = ActionView::Template::Handlers.extensions.map { |x| Regexp.escape(x) }.join("|")
-            formats = ActionView::Template::Types.symbols.map { |x| Regexp.escape(x) }.join("|")
             locales = "[a-z]{2}(?:-[A-Z]{2})?"
             variants = "[^.]*"
             path_regex = %r{
-              \A
-              (?<template>.*?)
-              (?:\.(?<locale>#{locales}))??
+            \A
+            (?<template>.*?)
+            (?:\.(?<locale>#{locales}))??
               (?:\.(?<format>#{formats}))??
               (?:\+(?<variant>#{variants}))??
               (?:\.(?<handler>#{handlers}))?

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -130,7 +130,7 @@ module RSpec
         def _default_render_options
           if ::Rails::VERSION::STRING >= '3.2'
             formats = if ActionView::Template::Types.respond_to?(:symbols)
-              ActionView::Template::Types.symbols.map { |x| Regexp.escape(x) }.join("|")
+              ActionView::Template::Types.symbols
             else
               [:html, :text, :js, :css, :xml, :json].map(&:to_s)
             end.map { |x| Regexp.escape(x) }.join("|")

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -137,17 +137,32 @@ module RSpec::Rails
           expect(view_spec.received.first).to eq([{:template => "widgets/new"},{}, nil])
         end
 
-        it "converts the filename components into render options" do
-          allow(view_spec).to receive(:_default_file_to_render) { "widgets/new.en.html.erb" }
-          view_spec.render
-
-          if ::Rails::VERSION::STRING >= '3.2'
+        if ::Rails::VERSION::STRING >= '3.2'
+          it "converts the filename components into render options" do
+            allow(view_spec).to receive(:_default_file_to_render) { "widgets/new.en.html.erb" }
+            view_spec.render
             expect(view_spec.received.first).to eq([{:template => "widgets/new", :locales=>['en'], :formats=>[:html], :handlers=>['erb']}, {}, nil])
-          else
+          end
+
+          it "converts the filename with variant into render options" do
+            allow(view_spec).to receive(:_default_file_to_render) { "widgets/new.en.html+fancy.erb" }
+            view_spec.render
+            expect(view_spec.received.first).to eq([{:template => "widgets/new", :locales=>['en'], :formats=>[:html], :handlers=>['erb'], variants: ['fancy']}, {}, nil])
+          end
+
+          it "converts the filename without format into render options" do
+            allow(view_spec).to receive(:_default_file_to_render) { "widgets/new.en.erb" }
+            view_spec.render
+            expect(view_spec.received.first).to eq([{:template => "widgets/new", :locales=>['en'], :handlers=>['erb']}, {}, nil])
+          end
+        else
+          it "uses the filename as a template" do
+            allow(view_spec).to receive(:_default_file_to_render) { "widgets/new.en.html.erb" }
+            view_spec.render
             expect(view_spec.received.first).to eq([{:template => "widgets/new.en.html.erb"}, {}, nil])
           end
         end
-      end
+    end
 
       context "given a string" do
         it "sends string as the first arg to render" do


### PR DESCRIPTION
This improves the path parsing here to be more strict, understand variants, and should support the additional validations around format in Rails 6.0.

I added a few previously failing specs, which this makes pass.

Fixes #2114

cc @samphippen @benoittgt @jaredmoody 