### PR TITLE
Rename two Rubocop cops in config that break the build

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -132,7 +132,7 @@ Style/ParallelAssignment:
 Layout/EmptyLineBetweenDefs:
   Enabled: false
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: false
 
 Naming/ConstantName:
@@ -254,7 +254,7 @@ Naming/HeredocDelimiterNaming:
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   Enabled: false
 
 Layout/IndentAssignment:


### PR DESCRIPTION
Fix:
Error: The `Layout/FirstParameterIndentation` cop has been renamed to `Layout/IndentFirstArgument`.
(obsolete configuration found in .rubocop_rspec_base.yml, please update it)
The `Layout/IndentArray` cop has been renamed to `Layout/IndentFirstArrayElement`.
(obsolete configuration found in .rubocop_rspec_base.yml, please update it)

I push this fix to 4-0-dev already https://github.com/rspec/rspec-rails/pull/2071#issuecomment-488266080