### PR TITLE
add missing require to have_enqueued_mail

### DIFF
--- a/features/matchers/have_enqueued_mail_matcher.feature
+++ b/features/matchers/have_enqueued_mail_matcher.feature
@@ -1,0 +1,78 @@
+Feature: have_enqueued_mail matcher
+
+  The `have_enqueued_mail` (also aliased as `enqueue_mail`) matcher is used to check if given mailer was enqueued.
+
+  Background:
+    Given active job is available
+
+  @rails_post_5
+  Scenario: Checking mailer class and method name
+    Given a file named "spec/mailers/user_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe NotificationsMailer do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
+          expect {
+            NotificationsMailer.signup.deliver_later
+          }.to have_enqueued_mail(NotificationsMailer, :signup)
+        end
+      end
+      """
+    When I run `rspec spec/mailers/user_mailer_spec.rb`
+    Then the examples should all pass
+
+  @rails_post_5
+  Scenario: Checking mailer enqueued time
+    Given a file named "spec/mailers/user_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe NotificationsMailer do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
+          expect {
+            NotificationsMailer.signup.deliver_later(:wait_until => Date.tomorrow.noon)
+          }.to have_enqueued_mail.at(Date.tomorrow.noon)
+        end
+      end
+      """
+    When I run `rspec spec/mailers/user_mailer_spec.rb`
+    Then the examples should all pass
+
+  @rails_pre_5
+  Scenario: Checking mailer class and method name
+    Given a file named "spec/mailers/user_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe Notifications do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
+          expect {
+            Notifications.signup.deliver_later
+          }.to have_enqueued_mail(Notifications, :signup)
+        end
+      end
+      """
+    When I run `rspec spec/mailers/user_mailer_spec.rb`
+    Then the examples should all pass
+
+  @rails_pre_5
+  Scenario: Checking mailer enqueued time
+    Given a file named "spec/mailers/user_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe Notifications do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
+          expect {
+            Notifications.signup.deliver_later(:wait_until => Date.tomorrow.noon)
+          }.to have_enqueued_mail.at(Date.tomorrow.noon)
+        end
+      end
+      """
+    When I run `rspec spec/mailers/user_mailer_spec.rb`
+    Then the examples should all pass

--- a/lib/rspec/rails/matchers.rb
+++ b/lib/rspec/rails/matchers.rb
@@ -23,6 +23,7 @@ require 'rspec/rails/matchers/have_http_status'
 
 if RSpec::Rails::FeatureCheck.has_active_job?
   require 'rspec/rails/matchers/active_job'
+  require 'rspec/rails/matchers/have_enqueued_mail'
 end
 
 if RSpec::Rails::FeatureCheck.has_action_cable_testing?


### PR DESCRIPTION
Hiya, I'm having issue when trying out #2047 in the beta release.. the error raised was `You must pass an argument rather than a block to 'expect' to use the provided matcher (have enqueued mail ReservationMailer, :complete), or the matcher must implement 'supports_block_expectations?'.`

which seems to be caused by the matcher not being required.. hence, this PR fix it by adding the missing `require` call..