### PR TITLE
Let Travis CI runs on all branches 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,3 @@ matrix:
       env: RAILS_VERSION=4-2-stable
 
   fast_finish: true
-
-branches:
-  only:
-    - master
-    - /^\d+-\d+-maintenance$/


### PR DESCRIPTION
Since the build matrix will be smaller into RSpec next release. I am in favor of letting Travis build all branches.

It will also help people who open PR for `4-0-dev` branch to run the CI on their pull request.

😉 