### PR TITLE
add support for parameterized mailer when RAILS_VERSION > 5.1

### DIFF
--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -38,6 +38,10 @@ module RSpec
           ::ActionMailer::Base.respond_to?(:show_previews=)
       end
 
+      def has_action_mailer_parameterized?
+        has_action_mailer? && defined?(::ActionMailer::Parameterized)
+      end
+
       def has_action_mailbox?
         defined?(::ActionMailbox)
       end

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -97,7 +97,7 @@ module RSpec
 
           def check(jobs)
             @matching_jobs, @unmatching_jobs = jobs.partition do |job|
-              if arguments_match?(job) && other_attributes_match?(job)
+              if job_match?(job) && arguments_match?(job) && other_attributes_match?(job)
                 args = deserialize_arguments(job)
                 @block.call(*args)
                 true
@@ -134,6 +134,10 @@ module RSpec
             end
           end
 
+          def job_match?(job)
+            @job ? @job == job[:job] : true
+          end
+
           def arguments_match?(job)
             if @args.any?
               deserialized_args = deserialize_arguments(job)
@@ -151,7 +155,6 @@ module RSpec
             {}.tap do |attributes|
               attributes[:at]    = serialized_at if @at
               attributes[:queue] = @queue if @queue
-              attributes[:job]   = @job if @job
             end
           end
 

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -283,5 +283,30 @@ RSpec.describe "HaveEnqueuedMail matchers", :skip => !RSpec::Rails::FeatureCheck
         expect(second_arg).to eq('noon')
       }
     end
+
+    context 'when parameterized', :skip => !RSpec::Rails::FeatureCheck.has_action_mailer_parameterized? do
+      it "passes when mailer is parameterized" do
+        expect {
+          TestMailer.with('foo' => 'bar').test_email.deliver_later
+        }.to have_enqueued_mail(TestMailer, :test_email)
+      end
+
+      it "passes when mixing parameterized and non-parameterized emails" do
+        expect {
+          TestMailer.with('foo' => 'bar').test_email.deliver_later
+          TestMailer.email_with_args(1, 2).deliver_later
+        }.to have_enqueued_mail(TestMailer, :test_email).and have_enqueued_mail(TestMailer, :email_with_args)
+      end
+
+      it "passes with provided argument matchers" do
+        expect {
+          TestMailer.with('foo' => 'bar').test_email.deliver_later
+        }.to have_enqueued_mail(TestMailer, :test_email).with('foo' => 'bar')
+
+        expect {
+          TestMailer.with('foo' => 'bar').email_with_args(1, 2).deliver_later
+        }.to have_enqueued_mail(TestMailer, :email_with_args).with({ 'foo' => 'bar' }, 1, 2)
+      end
+    end
   end
 end


### PR DESCRIPTION
rails 5.1 introduced parameterized email via https://github.com/rails/rails/pull/27825.. this PR introduce support for using the recently added `have_enqueued_email` to recognize parameterized email.. 

PS: might conflict with #2118 