### PR TITLE
add support for recognizing mailer many jobs:

### DIFF
--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -38,6 +38,14 @@ module RSpec
           ::ActionMailer::Base.respond_to?(:show_previews=)
       end
 
+      def has_action_mailer_parameterized?
+        has_action_mailer? && defined?(::ActionMailer::Parameterized)
+      end
+
+      def has_action_mailer_unified_delivery?
+        has_action_mailer? && defined?(::ActionMailer::MailDeliveryJob)
+      end
+
       def has_action_mailbox?
         defined?(::ActionMailbox)
       end

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -97,7 +97,7 @@ module RSpec
 
           def check(jobs)
             @matching_jobs, @unmatching_jobs = jobs.partition do |job|
-              if arguments_match?(job) && other_attributes_match?(job)
+              if job_match?(job) && arguments_match?(job) && other_attributes_match?(job)
                 args = deserialize_arguments(job)
                 @block.call(*args)
                 true
@@ -134,6 +134,10 @@ module RSpec
             end
           end
 
+          def job_match?(job)
+            @job ? @job == job[:job] : true
+          end
+
           def arguments_match?(job)
             if @args.any?
               deserialized_args = deserialize_arguments(job)
@@ -151,7 +155,6 @@ module RSpec
             {}.tap do |attributes|
               attributes[:at]    = serialized_at if @at
               attributes[:queue] = @queue if @queue
-              attributes[:job]   = @job if @job
             end
           end
 


### PR DESCRIPTION
- parameterized mailer when RAILS_VERSION >= 5.1
- unified mailer job when RAILS_VERSION >= 6.0

per https://github.com/rspec/rspec-rails/pull/2117#issuecomment-491651319

this PR supersede #2121 with added support for recognizing `ActionMailer::MailDeliveryJob` freshly added into rails 6.0 