### PR TITLE
address rubocop offenses:

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -153,6 +153,9 @@ Style/EmptyMethod:
 Style/FormatStringToken:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/GuardClause:
   Enabled: false
 

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -54,7 +54,7 @@ module RSpec
     end
 
     # @private
-    # rubocop:disable Style/MethodLength
+    # rubocop:disable Metrics/MethodLength
     def self.initialize_configuration(config)
       config.backtrace_exclusion_patterns << /vendor\//
       config.backtrace_exclusion_patterns << %r{lib/rspec/rails}
@@ -146,7 +146,7 @@ module RSpec
         config.include RSpec::Rails::MailboxExampleGroup, :type => :mailbox
       end
     end
-    # rubocop:enable Style/MethodLength
+    # rubocop:enable Metrics/MethodLength
 
     initialize_configuration RSpec.configuration
   end

--- a/lib/rspec/rails/example/mailer_example_group.rb
+++ b/lib/rspec/rails/example/mailer_example_group.rb
@@ -22,7 +22,7 @@ if defined?(ActionMailer)
         included do
           include ::Rails.application.routes.url_helpers
           options = ::Rails.configuration.action_mailer.default_url_options
-          options.each { |key, value| default_url_options[key] = value } if options
+          options&.each { |key, value| default_url_options[key] = value }
         end
 
         # Class-level DSL for mailer specs.

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -8,7 +8,7 @@ module RSpec
       #
       # @api private
       module ActiveJob
-        # rubocop: disable Style/ClassLength
+        # rubocop: disable Metrics/ClassLength
         # @private
         class Base < RSpec::Rails::Matchers::BaseMatcher
           def initialize
@@ -179,7 +179,7 @@ module RSpec
             ::ActiveJob::Base.queue_adapter
           end
         end
-        # rubocop: enable Style/ClassLength
+        # rubocop: enable Metrics/ClassLength
 
         # @private
         class HaveEnqueuedJob < Base


### PR DESCRIPTION
- fix warnings for wrong namespaces
- fix safe navigation offense
- turn off frozen string literal cop

rubocop released new [version](https://github.com/rubocop-hq/rubocop/releases/tag/v0.69.0), which break our CI..

PS: let me know if I should open this against master instead..