### PR TITLE
Check for ActionCable const before adding matchers

### DIFF
--- a/lib/rspec/rails/example/channel_example_group.rb
+++ b/lib/rspec/rails/example/channel_example_group.rb
@@ -15,7 +15,7 @@ module RSpec
   end
 end
 
-if ::Rails::VERSION::MAJOR >= 6
+if ::Rails::VERSION::MAJOR >= 6 && defined?(ActionCable)
   module RSpec
     module Rails
       # @api public


### PR DESCRIPTION
If your app hasn't requried `action_cable`, running `rspec` will raise `NameError: uninitialized constant RSpec::Rails::ChannelExampleGroup::ActionCable`. This fixes it.