### PR TITLE
Expect new ActionDispatch::Response#content_type on Rails 6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,6 +50,10 @@ Cucumber::Rake::Task.new(:cucumber) do |t|
     tags << "~@system_test"
   end
 
+  if version.to_f >= 6.0
+    tags << "~@rails_pre_6"
+  end
+
   if version.to_f < 6.0
     tags << "~@rails_post_6"
   end

--- a/features/controller_specs/controller_spec.feature
+++ b/features/controller_specs/controller_spec.feature
@@ -57,7 +57,7 @@ Feature: controller spec
     When I run `rspec spec`
     Then the example should pass
 
-  @rails_post_5
+  @rails_post_5 @rails_pre_6
   Scenario: setting a different content type for example json (request type)
     Given a file named "spec/controllers/widgets_controller_spec.rb" with:
       """ruby
@@ -77,5 +77,51 @@ Feature: controller spec
         end
       end
       """
+    When I run `rspec spec`
+    Then the example should pass
+
+  @rails_post_6
+  Scenario: setting a different content type for example json (request type)
+    Given a file named "spec/controllers/widgets_controller_spec.rb" with:
+    """ruby
+    require "rails_helper"
+
+    RSpec.describe WidgetsController, :type => :controller do
+      describe "responds to" do
+        it "responds to html by default" do
+          post :create, :params => { :widget => { :name => "Any Name" } }
+            expect(response.content_type).to eq "text/html; charset=utf-8"
+          end
+
+          it "responds to custom formats when provided in the params" do
+            post :create, :params => { :widget => { :name => "Any Name" }, :format => :json }
+            expect(response.content_type).to eq "application/json; charset=utf-8"
+        end
+      end
+    end
+    """
+    When I run `rspec spec`
+    Then the example should pass
+
+  @rails_post_6
+  Scenario: setting a different media type for example json (request type)
+    Given a file named "spec/controllers/widgets_controller_spec.rb" with:
+    """ruby
+    require "rails_helper"
+
+    RSpec.describe WidgetsController, :type => :controller do
+      describe "responds to" do
+        it "responds to html by default" do
+          post :create, :params => { :widget => { :name => "Any Name" } }
+          expect(response.media_type).to eq "text/html"
+        end
+
+        it "responds to custom formats when provided in the params" do
+          post :create, :params => { :widget => { :name => "Any Name" }, :format => :json }
+          expect(response.media_type).to eq "application/json"
+        end
+      end
+    end
+    """
     When I run `rspec spec`
     Then the example should pass

--- a/features/request_specs/request_spec.feature
+++ b/features/request_specs/request_spec.feature
@@ -110,7 +110,7 @@ Feature: request spec
     When I run `rspec spec/requests/widget_management_spec.rb`
     Then the example should pass
 
-  @rails_post_5
+  @rails_post_5 @rails_pre_6
   Scenario: requesting a JSON response
     Given a file named "spec/requests/widget_management_spec.rb" with:
       """ruby
@@ -131,6 +131,25 @@ Feature: request spec
 
       end
       """
+    When I run `rspec spec/requests/widget_management_spec.rb`
+    Then the example should pass
+
+  @rails_post_6
+  Scenario: requesting a JSON response
+    Given a file named "spec/requests/widget_management_spec.rb" with:
+    """ruby
+    require "rails_helper"
+
+    RSpec.describe "Widget management", :type => :request do
+      it "creates a Widget" do
+        headers = { "ACCEPT" => "application/json" }
+        post "/widgets", :params => { :widget => {:name => "My Widget"} }, :headers => headers
+
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(response).to have_http_status(:created)
+      end
+    end
+    """
     When I run `rspec spec/requests/widget_management_spec.rb`
     Then the example should pass
 

--- a/features/request_specs/request_spec.feature
+++ b/features/request_specs/request_spec.feature
@@ -119,10 +119,7 @@ Feature: request spec
       RSpec.describe "Widget management", :type => :request do
 
         it "creates a Widget" do
-          headers = {
-            "ACCEPT" => "application/json",     # This is what Rails 4 accepts
-            "HTTP_ACCEPT" => "application/json" # This is what Rails 3 accepts
-          }
+          headers = { "ACCEPT" => "application/json" }
           post "/widgets", :params => { :widget => {:name => "My Widget"} }, :headers => headers
 
           expect(response.content_type).to eq("application/json")


### PR DESCRIPTION
Address changes made by https://github.com/rails/rails/pull/36034

`ActionDispatch::Response#content_type` returns Content-Type header as it is now.