### PR TITLE
Pin webdrivers on older ruby.

### DIFF
--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -33,7 +33,11 @@ in_root do
   end
 
   if Rails::VERSION::STRING >= "5.1.0"
-    gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers'"
+    if Rails::VERSION::STRING >= "5.2.0" && RUBY_VERSION < '2.3.0'
+      gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers', '< 4.0.0'"
+    else
+      gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers'"
+    end
   end
 
   if Rails::VERSION::STRING >= '5.2.0' && Rails::VERSION::STRING < '6'


### PR DESCRIPTION
Prevent webdrivers from using `&.` method on unsupported ruby.