### PR TITLE
Update aruba to version 0.14.12

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -33,6 +33,10 @@ else
     gem "puma"
   end
 
+  if RUBY_VERSION < "2.5"
+    gem "sprockets", "~> 3.0"
+  end
+
   if version.gsub(/[^\d\.]/,'').to_f >= 6.0
     gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", platforms: [:jruby]
   else

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,23 +2,21 @@ require 'aruba/cucumber'
 require 'fileutils'
 
 module ArubaExt
-  def run(cmd, timeout = nil)
+  def run_command(cmd, timeout = nil)
     exec_cmd = cmd =~ /^rspec/ ? "bin/#{cmd}" : cmd
-    super(exec_cmd, timeout)
-  end
-  # This method over rides Aruba 0.5.4 implementation so that we can reset Bundler to use the sample app Gemfile
-  def in_current_dir(&block)
-    Bundler.with_clean_env do
-      _mkdir(current_dir)
-      Dir.chdir(current_dir, &block)
+    # Ensure bundler env vars are unset
+    unset_bundler_env_vars
+    # Ensure the correct Gemfile is found
+    in_current_directory do
+      super(exec_cmd, timeout)
     end
   end
 end
 
 World(ArubaExt)
 
-Before do
-  @aruba_timeout_seconds = 30
+Aruba.configure do |config|
+  config.exit_timeout = 30
 end
 
 unless File.directory?('./tmp/example_app')

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -55,6 +55,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency 'cucumber', '~> 1.3.5'
-  s.add_development_dependency 'aruba',    '~> 0.5.4'
+  s.add_development_dependency 'aruba',    '~> 0.14.12'
   s.add_development_dependency 'ammeter',  '~> 1.1.2'
 end


### PR DESCRIPTION
- Bump Aruba version
- Force older sprockets on old Rubies
- Update overrides to work with Aruba 0.14.12