### PR TITLE
Fix system_test_example teardown

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -89,7 +89,7 @@ module RSpec
           @routes = ::Rails.application.routes
         end
 
-        after do
+        append_after do
           orig_stdout = $stdout
           $stdout = StringIO.new
           begin


### PR DESCRIPTION
## The problem

Failure screenshots stopped working in Rails 6.0 RC1: at the time of taking a screenshot the browser is reset to `about:` page (in case of Chrome), resulting in a blank page screenshots.

## The solution

Original `after_teardown` must be called after the original `before_teardown` (which is added to `after` hooks by RSpec::Rails::MinitestLifecycleAdapter).

The behavior in Rails changed with this commit: https://github.com/rails/rails/commit/ef12ccfd8bc42d88611dea1190988214836b951c.

Not sure, how to add a test for this change (except from "checked on my project—works like a charm"; it's passing, btw).