### PR TITLE
README: Repair CodeClimate SVG badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use **[`rspec-rails` 1.x][]** for Rails 2.x.
 
 [Build Status]: https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=master
 [travis-ci]: https://travis-ci.org/rspec/rspec-rails
-[Code Climate]: https://img.shields.io/codeclimate/github/rspec/rspec-rails.svg
+[Code Climate]: https://codeclimate.com/github/rspec/rspec-rails.svg
 [code-climate]: https://codeclimate.com/github/rspec/rspec-rails
 [Gem Version]: https://badge.fury.io/rb/rspec-rails.svg
 [gem-version]: https://badge.fury.io/rb/rspec-rails


### PR DESCRIPTION
This PR changes the URL to the badge for CodeClimate, to make it display.

The new URL used points to codeclimate.com.

Perhaps there are even better ways? https://codeclimate.com/github/codeclimate/codeclimate/badges#test-coverage-markdown