### PR TITLE
Use trusty for TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ before_script:
 
 script: "script/run_build 2>&1"
 
+# In order to install old Rubies, we need to use old Ubuntu distibution.
+dist: trusty
+
 matrix:
   include:
     # Rails dev / 6 builds >= 2.4.4


### PR DESCRIPTION
RVM doesn't provide old Ruby binaries for newer Ubuntu distributions.
Until it's fixed, we need to use old Ubuntu distributions in CI.