### PR TITLE
have_enqueued_job supports time object

### DIFF
--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -140,8 +140,9 @@ module RSpec
 
           def arguments_match?(job)
             if @args.any?
+              args = serialize_and_deserialize_arguments(@args)
               deserialized_args = deserialize_arguments(job)
-              RSpec::Mocks::ArgumentListMatcher.new(*@args).args_match?(*deserialized_args)
+              RSpec::Mocks::ArgumentListMatcher.new(*args).args_match?(*deserialized_args)
             else
               true
             end
@@ -170,6 +171,13 @@ module RSpec
                                when :thrice then 3
                                else Integer(count)
                                end
+          end
+
+          def serialize_and_deserialize_arguments(args)
+            serialized = ::ActiveJob::Arguments.serialize(args)
+            ::ActiveJob::Arguments.deserialize(serialized)
+          rescue ::ActiveJob::SerializationError
+            args
           end
 
           def deserialize_arguments(job)

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -328,6 +328,24 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
         expect(arg).to eq("asdf")
       }
     end
+
+    if Rails.version.to_f >= 6.0
+      it "passes with Time" do
+        usec_time = Time.iso8601('2016-07-01T00:00:00.000001Z')
+
+        expect {
+          hello_job.perform_later(usec_time)
+        }.to have_enqueued_job(hello_job).with(usec_time)
+      end
+
+      it "passes with ActiveSupport::TimeWithZone" do
+        usec_time = Time.iso8601('2016-07-01T00:00:00.000001Z').in_time_zone
+
+        expect {
+          hello_job.perform_later(usec_time)
+        }.to have_enqueued_job(hello_job).with(usec_time)
+      end
+    end
   end
 
   describe "have_been_enqueued" do


### PR DESCRIPTION
Rails6 can pass Time as arguments to ActiveJob but `have_enqueued_job#with` doesn't support time object.
Deserialized time has 0 usec value, it will fail when compared with original time.

```ruby
time = Time.now
expect { job.perform_later(time) }.to have_enqueued_job.with(time) #=> failed
```

This PR fixes it by to serialize/deserialize arguments before comparing.