### PR TITLE
MISC #2161 - update EmptyTemplateHandler::call to support rails 6 tem…

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -102,7 +102,7 @@ module RSpec
 
       # @private
       class EmptyTemplateHandler
-        def self.call(_template)
+        def self.call(*_args)
           ::Rails.logger.info("  Template rendering was prevented by rspec-rails. Use `render_views` to verify rendered view contents if necessary.")
 
           %("")


### PR DESCRIPTION
try to fix this issue https://github.com/rspec/rspec-rails/issues/2161

