### PR TITLE
Update docs: :all => :context, :each => :example

### DIFF
--- a/features/Transactions.md
+++ b/features/Transactions.md
@@ -23,15 +23,15 @@ simply tell RSpec to tell Rails not to manage transactions:
       config.use_transactional_fixtures = false
     end
 
-### Data created in `before(:each)` are rolled back
+### Data created in `before(:example)` are rolled back
 
-Any data you create in a `before(:each)` hook will be rolled back at the end of
+Any data you create in a `before(:example)` hook will be rolled back at the end of
 the example. This is a good thing because it means that each example is
 isolated from state that would otherwise be left around by the examples that
 already ran. For example:
 
     describe Widget do
-      before(:each) do
+      before(:example) do
         @widget = Widget.create
       end
 
@@ -48,34 +48,34 @@ The `@widget` is recreated in each of the two examples above, so each example
 has a different object, _and_ the underlying data is rolled back so the data
 backing the `@widget` in each example is new.
 
-### Data created in `before(:all)` are _not_ rolled back
+### Data created in `before(:context)` are _not_ rolled back
 
-`before(:all)` hooks are invoked before the transaction is opened. You can use
+`before(:context)` hooks are invoked before the transaction is opened. You can use
 this to speed things up by creating data once before any example in a group is
 run, however, this introduces a number of complications and you should only do
 this if you have a firm grasp of the implications. Here are a couple of
 guidelines:
 
-1.  Be sure to clean up any data in an `after(:all)` hook:
+1.  Be sure to clean up any data in an `after(:context)` hook:
 
-        before(:all) do
+        before(:context) do
           @widget = Widget.create!
         end
 
-        after(:all) do
+        after(:context) do
           @widget.destroy
         end
 
     If you don't do that, you'll leave data lying around that will eventually
     interfere with other examples.
 
-2.  Reload the object in a `before(:each)` hook.
+2.  Reload the object in a `before(:example)` hook.
 
-        before(:all) do
+        before(:context) do
           @widget = Widget.create!
         end
 
-        before(:each) do
+        before(:example) do
           @widget.reload
         end
 


### PR DESCRIPTION
This documentation page is very important but the code is a bit outdated.
I just replaced `:all` by `:context`, and `:each` by `:example`