### PR TITLE
Add selenium to avoid loading issue in 'action_dispatch/system_test_case'

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
+# This file was generated on 2019-07-24T15:33:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # This file contains defaults for RSpec projects. Individual projects

--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # This file contains defaults for RSpec projects. Individual projects
@@ -135,7 +135,7 @@ Style/ParallelAssignment:
 Layout/EmptyLineBetweenDefs:
   Enabled: false
 
-Layout/IndentFirstArgument:
+Layout/FirstParameterIndentation:
   Enabled: false
 
 Naming/ConstantName:
@@ -258,7 +258,7 @@ Naming/HeredocDelimiterNaming:
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
-Layout/IndentFirstArrayElement:
+Layout/IndentArray:
   Enabled: false
 
 Layout/IndentAssignment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ before_script:
 
 script: "script/run_build 2>&1"
 
+# In order to install old Rubies, we need to use old Ubuntu distibution.
+dist: trusty
+
 matrix:
   include:
     # Rails 6 builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,12 @@ matrix:
     # Rails 6 builds
     - rvm: jruby-head
       env:
-        - RAILS_VERSION=6-0-stable
+        - RAILS_VERSION='~>6.0'
         - JRUBY_OPT=--dev
     - rvm: 2.6.3
-      env: RAILS_VERSION=6-0-stable
-    - rvm: 2.5.3
-      env: RAILS_VERSION=6-0-stable
+      env: RAILS_VERSION='~>6.0'
+    - rvm: 2.5.5
+      env: RAILS_VERSION='~>6.0'
 
     # Rails 5.2 builds >= 2.2.2
     - rvm: jruby-head
@@ -51,43 +51,43 @@ matrix:
         - JRUBY_OPT=--dev
     - rvm: 2.6.3
       env: RAILS_VERSION='~> 5.2.0'
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       env: RAILS_VERSION='~> 5.2.0'
-    - rvm: 2.4.4
+    - rvm: 2.4.6
       env: RAILS_VERSION='~> 5.2.0'
-    - rvm: 2.3.7
+    - rvm: 2.3.8
       env: RAILS_VERSION='~> 5.2.0'
 
     # Rails 5.1 Builds >= 2.2.2
     - rvm: 2.6.3
       env: RAILS_VERSION='~> 5.1.0'
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       env: RAILS_VERSION='~> 5.1.0'
-    - rvm: 2.4.4
+    - rvm: 2.4.6
       env: RAILS_VERSION='~> 5.1.0'
-    - rvm: 2.3.7
+    - rvm: 2.3.8
       env: RAILS_VERSION='~> 5.1.0'
 
     # Rails 5.0 Builds >= 2.2.2
     - rvm: 2.6.3
       env: RAILS_VERSION='~> 5.0.0'
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       env: RAILS_VERSION='~> 5.0.0'
-    - rvm: 2.4.4
+    - rvm: 2.4.6
       env: RAILS_VERSION='~> 5.0.0'
-    - rvm: 2.3.7
+    - rvm: 2.3.8
       env: RAILS_VERSION='~> 5.0.0'
 
     # Rails 4.2 Builds >= 1.9.3
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       env: RAILS_VERSION='~> 4.2.0'
-    - rvm: 2.4.4
+    - rvm: 2.4.6
       env: RAILS_VERSION='~> 4.2.0'
-    - rvm: 2.4.4
+    - rvm: 2.4.6
       env: RAILS_VERSION=4-2-stable
-    - rvm: 2.3.7
+    - rvm: 2.3.8
       env: RAILS_VERSION='~> 4.2.0'
-    - rvm: 2.3.7
+    - rvm: 2.3.8
       env: RAILS_VERSION=4-2-stable
 
   fast_finish: true

--- a/Changelog.md
+++ b/Changelog.md
@@ -45,6 +45,7 @@ Enhancements
   making it easier to match on `ActiveJob` delivered emails. (Joel Lubrano, #2047)
 * Add generator for system specs on Rails 5.1 and above. (Andrzej Sliwa, #1933)
 * Add generator for generator specs. (@ConSou, #2085)
+* Add option to generate routes when generating controller specs. (David Revelo, #2134)
 
 ### 3.8.2 / 2019-01-13
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.8.1...v3.8.2)

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ end
 
 if MAJOR >= 6
   gem 'sqlite3', '~> 1.4', platforms: [:ruby]
+  gem 'selenium-webdriver', '~> 3.5', :require => false
 else
   gem 'sqlite3', '~> 1.3.6', platforms: [:ruby]
 end

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use **[`rspec-rails` 1.x][]** for Rails 2.x.
 
 [Build Status]: https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=master
 [travis-ci]: https://travis-ci.org/rspec/rspec-rails
-[Code Climate]: https://img.shields.io/codeclimate/github/rspec/rspec-rails.svg
+[Code Climate]: https://codeclimate.com/github/rspec/rspec-rails.svg
 [code-climate]: https://codeclimate.com/github/rspec/rspec-rails
 [Gem Version]: https://badge.fury.io/rb/rspec-rails.svg
 [gem-version]: https://badge.fury.io/rb/rspec-rails

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
+# This file was generated on 2019-07-24T15:33:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 version: "{build}"
@@ -39,3 +39,4 @@ environment:
     - ruby_version: 23-x64
     - ruby_version: 24-x64
     - ruby_version: 25-x64
+    - ruby_version: 26-x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 version: "{build}"

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -42,7 +42,11 @@ in_root do
     if RUBY_VERSION < "2.4"
       gsub_file "Gemfile", /.*capybara.*/, "gem 'capybara', '~> 3.15.0'"
     end
-    gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers'"
+    if Rails::VERSION::STRING >= "5.2.0" && RUBY_VERSION < '2.3.0'
+      gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers', '< 4.0.0'"
+    else
+      gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers'"
+    end
   end
 
   if Rails::VERSION::STRING >= '5.2.0' && Rails::VERSION::STRING < '6'

--- a/rfcs/versioning-strategy.md
+++ b/rfcs/versioning-strategy.md
@@ -1,4 +1,3 @@
-
 # RFC: RSpec Rails new versioning strategy
 
 Hi Folks,

--- a/rfcs/versioning-strategy.md
+++ b/rfcs/versioning-strategy.md
@@ -1,0 +1,119 @@
+
+# RFC: RSpec Rails new versioning strategy
+
+Hi Folks,
+
+This RFC captures a proposal for RSpec Rails' new versioning strategy. Specifically, this represents two things:
+* A change in representation of what we use SemVer for, in RSpec Rails
+* A departure from RSpec Rails having the same versioning as RSpec's other gems (-core, -mocks, -expectations, and, internally, -support).
+
+## Need
+
+Currently, the RSpec Rails [build matrix](https://travis-ci.org/rspec/rspec-rails)
+has 63 entries. This permutes rubies since 1.8.7 and Rails versions since 3.0.
+As of right now the full build takes over an hour to run, and this makes cycling
+for PRs and quick iterative development very difficult.
+
+RSpec Rails's code itself also is damaged by this. Everything from the Gemfile
+setup[1](https://github.com/rspec/rspec-rails/blob/1d2935861c89246236b46f77de753cda5ea67d61/Gemfile)
+[2](https://github.com/rspec/rspec-rails/blob/1d2935861c89246236b46f77de753cda5ea67d61/Gemfile-rails-dependencies)
+[3](https://github.com/rspec/rspec-rails/blob/1d2935861c89246236b46f77de753cda5ea67d61/Gemfile-rspec-dependencies),
+to the [library code](https://github.com/rspec/rspec-rails/blob/1d2935861c89246236b46f77de753cda5ea67d61/lib/rspec/rails/configuration.rb#L128-L143),
+to the [test setup](https://github.com/rspec/rspec-rails/blob/1d2935861c89246236b46f77de753cda5ea67d61/Rakefile#L29-L53),
+to the [tests themselves](https://github.com/rspec/rspec-rails/blob/1d2935861c89246236b46f77de753cda5ea67d61/spec/rspec/rails/example/job_example_group_spec.rb)
+contain conditional execution based on which Rails version is currently loaded.
+This makes ongoing maintenance difficult, as it requires that RSpec Rails'
+maintainers be conscious of every Rails version that might be loaded.
+Acknowledging that, patches still sometimes break people's suites, due to the
+number of permutations of gems that can be loaded.
+
+Our need is therefore best characterised by cost of maintenance. Having to
+maintain several versions of Rails and Ruby costs us a lot. It makes our
+development slower, and forces us to write against Rails versions that most
+people no longer use. I want RSpec Rails development to be fast, and
+lightweight, much like it was when I joined the RSpec project.
+
+## Approach
+
+The approach to fix this is an adjustment of versioning strategy. RSpec Rails
+will still continue to maintain a SemVer strategy, that is:
+
+* Breaking changes in Majors
+* New features in Minors
+* Bug Fixes in Patchlevels
+
+For the purposes of this versioning strategy, we consider removing a Rails or
+Ruby version to be a breaking change. We consider adding a Ruby or Rails version
+to be a Minor, along with normal feature releases.
+
+The intent, however, is to change the cycle of these releases to align with
+Rails. Specifically, a Rails release cycle typically looks like:
+
+* Release a Major X.0, (X-2).0 is no longer supported, all but the most recent
+  (X--1) series are unsupported, introduces deprecation warnings for many
+  features
+* Release a Minor X.1, deprecation warnings from X.0 are now errors
+* Release a Minor X.2, new features are added, some further deprecation warnings
+  from X.1 may now be broken.
+
+As such, RSpec Rails's new versioning strategy will be:
+
+* Release a major with any Rails Major, removing support for any newly
+  unsupported versions of Rails, and adding support for the new major.
+* Release a minor with any Rails Minor, adding support for the new features
+  * Additionally, release minors for any new RSpec features
+*  Release patchlevels frequently, as bugfixes occur.
+
+As to the transition to this strategy: it is my intent to move to this strategy
+along with releasing support for Rails 5.2 for RSpec Rails, so relatively soon,
+dropping support for anything below Rails 4.2, and any Rubies below 2.2. This
+means that RSpec Rails 4.0.0 will be released within a handful of months from
+this RFC being accepted.
+
+I do expect this to mean that the major version of RSpec Rails will increment
+relatively quickly with comparison to the rest of RSpec. I do not think that is
+necessarily a bad thing, it does not mean that the library is unstable as such,
+but rather that we are tracking our dependencies accurately.
+
+Traditionally, RSpec Rails has been versioned at the same version number as
+RSpec. This will represent a departure from that. In order to maintain
+compatibility, RSpec Rails will continue to support the RSpec 3 series, and will
+probably add support for RSpec 4 without breaking changes. To do this, I intend
+to move off RSpec Rails using any private APIs from RSpec.
+
+## Benefits
+
+Execution of this strategy will greatly increase our ability to maintain RSpec,
+and release against modern Rails versions. While RSpec has been very stable and
+essentially continuously expanded Rails version support for the last few years,
+this has now become unsustainable and we want to take this tradeoff to best
+serve the needs of the community.
+
+## Competition
+
+### Do nothing
+
+If we do this, it will become deeply unsustainable for us to maintain RSpec
+Rails in the future. We have too many Rails versions today, and we expect the
+rate of Rails releases to increase as time goes on. As such, it is our intent to
+start dropping Rails versions inline with Rails, in order to continue to improve
+the RSpec Rails gem.
+
+### Keep inline versioning with RSpec
+
+RSpec has a materially different versioning need to Rails. Specifically, RSpec
+as of today is a mostly entirely stable library. It's development needs are
+largely as feature proposals occur, or as bugs are found. RSpec has no external
+forces pushing versioning pressure on it (other than say, ruby and bundler,
+which are themselves, relatively stable). This is not true of RSpec Rails, which
+is popular, and there is a general expectation that RSpec will work with Rails
+applications, as of right now, we typically lag behind a Rails release by weeks
+when a Rails version gets released.
+
+## Conclusions
+
+It is my intent to ship this change relatively soon, inline with Rails 5.2
+support in the next few months. I really do think this represents the best
+future tradeoff for RSpec. If you strongly believe that dropping support for
+Rails versions lower than 4.2 will affect your needs, please do let us know so
+that we can consider the full weight of your use case.

--- a/script/clone_all_rspec_repos
+++ b/script/clone_all_rspec_repos
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
+# This file was generated on 2019-07-24T15:33:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/clone_all_rspec_repos
+++ b/script/clone_all_rspec_repos
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/downgrade_bundler_on_old_rails
+++ b/script/downgrade_bundler_on_old_rails
@@ -5,7 +5,7 @@
 set -e
 source script/functions.sh
 
-if ruby -e "exit(ENV['RAILS_VERSION'].to_f < 5)"; then
+if ruby -e "exit(ENV['RAILS_VERSION'].scan(/\d+\.\d+.\d+/)[0].to_f < 5)"; then
   # On Rails versions less than 5, Bundler 2.0 is not supported
   echo "Warning dowgrading to older version of Bundler"
   gem uninstall -aIx bundler

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
+# This file was generated on 2019-07-24T15:33:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 function is_mri {

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
+# This file was generated on 2019-07-24T15:33:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 function is_mri {

--- a/script/run_build
+++ b/script/run_build
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
+# This file was generated on 2019-07-24T15:33:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/run_build
+++ b/script/run_build
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/travis_functions.sh
+++ b/script/travis_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # Taken from:

--- a/script/travis_functions.sh
+++ b/script/travis_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
+# This file was generated on 2019-07-24T15:33:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # Taken from:

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
+# This file was generated on 2019-07-24T15:33:53+02:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2019-04-01T20:23:57+02:00 from the rspec-dev repo.
+# This file was generated on 2019-07-08T14:21:40+01:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e


### PR DESCRIPTION
On Rails 6 we add error in test suite like:
```
LoadError: cannot load such file -- selenium/webdriver System test integration requires Rails >= 5.1 and has a hard dependency on a webserver and `capybara`, please add capybara to your Gemfile and configure a webserver (e.g. `Capybara.server = :webrick`) before attempting to use system specs.
```

This error come from
`lib/rspec/rails/example/system_example_group.rb#L51`:

```
2.6.3 :002 > require 'action_dispatch/system_test_case'
Traceback (most recent call last):
       16: from /Users/bti/code/rspec-dev/repos/rspec-rails/spec/rspec/rails/example/system_example_group_spec.rb:11:in `block (4 levels) in <module:Rails>'
       15: from /Users/bti/code/rspec-dev/repos/rspec-rails/spec/rspec/rails/example/system_example_group_spec.rb:11:in `include'
       14: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/concern.rb:122:in `append_features'
       13: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/concern.rb:122:in `class_eval'
       12: from /Users/bti/code/rspec-dev/repos/rspec-rails/lib/rspec/rails/example/system_example_group.rb:50:in `block in <module:SystemExampleGroup>'
       11: from <internal:prelude>:145:in `irb'
       10: from (irb):2:in `block in <module:SystemExampleGroup>'
        9: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
        8: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:291:in `load_dependency'
        7: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `block in require'
        6: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
        5: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0/lib/action_dispatch/system_test_case.rb:7:in `<top (required)>'
        4: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
        3: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:291:in `load_dependency'
        2: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `block in require'
        1: from /Users/bti/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
LoadError (cannot load such file -- selenium/webdriver)
```

This is probably related to:
> rails/rails#36592

We need to load selenium-driver if we are in Rails 6

Also I bump last Rubies

