### PR TITLE
Add log when downgrading bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,10 +87,10 @@ matrix:
     - rvm: 2.4.6
       env: RAILS_VERSION='~> 4.2.0'
     - rvm: 2.4.6
-      env: RAILS_VERSION=4-2-stable
+      env: RAILS_VERSION='~> 4.2.0'
     - rvm: 2.3.8
       env: RAILS_VERSION='~> 4.2.0'
     - rvm: 2.3.8
-      env: RAILS_VERSION=4-2-stable
+      env: RAILS_VERSION='~> 4.2.0'
 
   fast_finish: true

--- a/script/downgrade_bundler_on_old_rails
+++ b/script/downgrade_bundler_on_old_rails
@@ -8,13 +8,13 @@ source script/functions.sh
 if ruby -e "exit(ENV['RAILS_VERSION'].scan(/\d+\.\d+.\d+/)[0].to_f < 5)"; then
   # On Rails versions less than 5, Bundler 2.0 is not supported
   echo "Warning dowgrading to older version of Bundler"
+  echo "Current bundler versions installed: `gem list | grep '^bundler ('`"
 
   gem uninstall -aIx bundler || echo "Warning error occured removing bundler via gem"
 
-  # this only works on Ruby 2.3 which is luckily the version we need to fix
-  if is_ruby_23; then
-    rvm @global do gem uninstall -aIx bundler || echo "Warning error occured removing bundler via rvm"
-  fi
+  rvm @global do gem uninstall -aIx bundler || echo "Warning error occured removing bundler via rvm"
+
+  echo "Bundler version list after uninstall: `gem list | grep '^bundler ('`"
 
   gem install bundler -v '1.17.3'
 fi


### PR DESCRIPTION
Sometimes we can have inconsistent behavior with the CI when we uninstall Bundler gem. This can lead to one version that is not properly uninstalled. To have a better understanding of the situation, this PR ad a log point and switch back to old behavior of uninstalling as much as possible bundler version before installing bundler 1.17.3 in case of Rails below 5.

Old behavior commit : https://github.com/rspec/rspec-rails/pull/2071/commits/753f5bc78a865aed5a878dfc9f854f67d782642a
Related: https://github.com/rspec/rspec-rails/pull/2071