### PR TITLE
Update yard version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 rspec_dependencies_gemfile = File.expand_path("../Gemfile-rspec-dependencies", __FILE__)
 eval_gemfile rspec_dependencies_gemfile
 
-gem 'yard', '~> 0.8.7', :require => false
+gem 'yard', :require => false
 
 ### deps for rdoc.info
 group :documentation do


### PR DESCRIPTION
0.8.x is a bit old. Reference to https://rubygems.org/gems/yard.

Moreover, if 0.8.x is installed and it's latest version in my local environment, following error happen because yard version corresponding to rubygems version is old. Reference to https://github.com/rubygems/rubygems/commit/c20b3b56df14c86c70a6670735c0bba1e3704079.
```
$ gem --version
Error loading RubyGems plugin "/Users/tnakata/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/yard-0.8.7.6/lib/rubygems_plugin.rb": can't modify frozen Hash (FrozenError)
3.0.3
$ gem list yard
Error loading RubyGems plugin "/Users/tnakata/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/yard-0.8.7.6/lib/rubygems_plugin.rb": can't modify frozen Hash (FrozenError)

*** LOCAL GEMS ***

yard (0.8.7.6)
```