### PR TITLE
Fix an issue where driven_by(:selenium) is always called

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -78,6 +78,12 @@ module RSpec
         def initialize(*args, &blk)
           super(*args, &blk)
           @driver = nil
+
+          self.class.before do
+            # A user may have already set the driver, so only default if driver
+            # is not set
+            driven_by(:selenium) unless @driver
+          end
         end
 
         def driven_by(*args, &blk)
@@ -85,9 +91,6 @@ module RSpec
         end
 
         before do
-          # A user may have already set the driver, so only default if driver
-          # is not set
-          driven_by(:selenium) unless @driver
           @routes = ::Rails.application.routes
         end
 

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -18,6 +18,47 @@ module RSpec::Rails
           end
         end
       end
+
+      describe '#driver' do
+        it 'uses :selenium driver by default' do
+          group = RSpec::Core::ExampleGroup.describe do
+            include SystemExampleGroup
+          end
+          example = group.new
+          group.hooks.run(:before, :example, example)
+
+          expect(Capybara.current_driver).to eq :selenium
+        end
+
+        it 'sets :rack_test driver using by before_action' do
+          group = RSpec::Core::ExampleGroup.describe do
+            include SystemExampleGroup
+
+            before do
+              driven_by(:rack_test)
+            end
+          end
+          example = group.new
+          group.hooks.run(:before, :example, example)
+
+          expect(Capybara.current_driver).to eq :rack_test
+        end
+
+        it 'calls :driven_by method only once' do
+          group = RSpec::Core::ExampleGroup.describe do
+            include SystemExampleGroup
+
+            before do
+              driven_by(:rack_test)
+            end
+          end
+          example = group.new
+          allow(example).to receive(:driven_by).and_call_original
+          group.hooks.run(:before, :example, example)
+
+          expect(example).to have_received(:driven_by).once
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Because the before process defined in SystemExampleGroup is executed
before the use defined before process, driven_by(:selenium) is always
executed.

This commit fixes the driver configuration to be lazy.