### PR TITLE
Bump sqlite3 dependency for Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,11 @@ platforms :jruby do
   gem "jruby-openssl"
 end
 
-gem 'sqlite3', '~> 1.3.6'
+if RAILS_VERSION >= '6.0.0'
+  gem 'sqlite3', '~> 1.4.0'
+else
+  gem 'sqlite3', '~> 1.3.6'
+end
 
 if RUBY_VERSION >= '2.4.0'
   gem 'json', '>= 2.0.2'


### PR DESCRIPTION
https://github.com/rails/rails/commit/0908184e4c2dca5b941030bbd0d5eb2dfcfed120#diff-8b7db4d5cc4b8f6dc8feb7030baa2478L121
updated the minimum required version of `sqlite3` gem to 1.4

Without this:

    export RAILS_VERSION=6.0.0
    bundle
    rspec

fails with:

    An error occurred while loading spec_helper. - Did you mean?
                        rspec ./spec/spec_helper.rb

    Failure/Error:
      ActiveRecord::Base.establish_connection(
        :adapter => 'sqlite3',
        :database => ':memory:'
      )

    LoadError:
      Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-1.3.13. Make sure all dependencies are added to Gemfile.