### PR TITLE
Update the default version of rails used in builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,13 +21,19 @@ platforms :jruby do
 end
 
 RAILS_VERSION ||= ""
-match = /(\d+)(\.|-)(\d+)/.match(RAILS_VERSION)
-if match.nil?
-  # will be nil if master
+case RAILS_VERSION
+when /master/
   MAJOR = 6
   MINOR = 0
+when /stable/
+  MAJOR = 6
+  MINOR = 0
+when nil, false, ""
+  MAJOR = 5
+  MINOR = 1
 else
-  MAJOR,MINOR = match.captures.map(&:to_i).compact
+  match = /(\d+)(\.|-)(\d+)/.match(RAILS_VERSION)
+  MAJOR, MINOR = match.captures.map(&:to_i).compact
 end
 
 if MAJOR >= 6

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -25,7 +25,7 @@ when /stable$/
     gem rails_gem, :git => "https://github.com/rails/rails.git", :branch => version
   end
 when nil, false, ""
-  gem "rails", "~> 5.0.0"
+  gem "rails", "~> 5.1.0"
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
 else
   gem "rails", version


### PR DESCRIPTION
There is a mis-match in the versioning strategy in the gemfile's, where the rails version gemfile assume 5.x on a "nil" version, yet the main gemfile assumings 6.

This pins the default to 5.1 due to compatibility with older rubies, if we remove the rspec-rails specs from the other repos after the release of rspec-rails 4 then we can consider upgrading this to 6.