### PR TITLE
Fix other builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ platforms :jruby do
   gem "jruby-openssl"
 end
 
-RAILS_VERSION ||= ""
 case RAILS_VERSION
 when /master/
   MAJOR = 6

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ when /stable/
   MINOR = 0
 when nil, false, ""
   MAJOR = 5
-  MINOR = 1
+  MINOR = 0
 else
   match = /(\d+)(\.|-)(\d+)/.match(RAILS_VERSION)
   MAJOR, MINOR = match.captures.map(&:to_i).compact

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -25,9 +25,8 @@ when /stable$/
     gem rails_gem, :git => "https://github.com/rails/rails.git", :branch => version
   end
 when nil, false, ""
-  gem "rails", "~> 5.1.0"
+  gem "rails", "~> 5.0.0"
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
-  gem "puma"
 else
   gem "rails", version
 


### PR DESCRIPTION
Continuing on work trying to fix the other builds, I mistakenly assumed 5.1 supported the same Ruby versions as 5.0.