### PR TITLE
Support argument matchers in have_enqueued_*

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,14 @@
 ### Development
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.9.0...master)
 
+Enhancements:
+
+* Add argument matcher support to `have_enqueued_*` matchers. (Phil Pirozhkov, #2206)
+
 ### 3.9.0 / 2019-10-08
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.8.2...v3.9.0)
 
-Enhancements
+Enhancements:
 
 * Use `__dir__` instead of `__FILE__` in generated `rails_helper.rb` where
   supported. (OKURA Masafumi, #2048)

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -97,7 +97,7 @@ module RSpec
 
           def check(jobs)
             @matching_jobs, @unmatching_jobs = jobs.partition do |job|
-              if arguments_match?(job) && other_attributes_match?(job)
+              if job_match?(job) && arguments_match?(job) && queue_match?(job) && at_match?(job)
                 args = deserialize_arguments(job)
                 @block.call(*args)
                 true
@@ -134,6 +134,10 @@ module RSpec
             end
           end
 
+          def job_match?(job)
+            @job ? @job == job[:job] : true
+          end
+
           def arguments_match?(job)
             if @args.any?
               deserialized_args = deserialize_arguments(job)
@@ -143,20 +147,18 @@ module RSpec
             end
           end
 
-          def other_attributes_match?(job)
-            serialized_attributes.all? { |key, value| value == job[key] }
+          def queue_match?(job)
+            return true unless @queue
+
+            @queue == job[:queue]
           end
 
-          def serialized_attributes
-            {}.tap do |attributes|
-              attributes[:at]    = serialized_at if @at
-              attributes[:queue] = @queue if @queue
-              attributes[:job]   = @job if @job
-            end
-          end
+          def at_match?(job)
+            return true unless @at
+            return job[:at].nil? if @at == :no_wait
+            return false unless job[:at]
 
-          def serialized_at
-            @at == :no_wait ? nil : @at.to_f
+            values_match?(@at, Time.at(job[:at]))
           end
 
           def set_expected_number(relativity, count)

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -211,10 +211,27 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to have_enqueued_job.at(date)
     end
 
+    it "accepts composable matchers as an at date" do
+      future = 1.minute.from_now
+      slightly_earlier = 58.seconds.from_now
+      expect {
+        hello_job.set(:wait_until => slightly_earlier).perform_later
+      }.to have_enqueued_job.at(a_value_within(5.seconds).of(future))
+    end
+
     it "has an enqueued job when providing at of :no_wait and there is no wait" do
       expect {
         hello_job.perform_later
       }.to have_enqueued_job.at(:no_wait)
+    end
+
+    it "has an enqueued job when providing at and there is no wait" do
+      date = Date.tomorrow.noon
+      expect {
+        expect {
+          hello_job.perform_later
+        }.to have_enqueued_job.at(date)
+      }.to raise_error(/expected to enqueue exactly 1 jobs, at .+ but enqueued 0/)
     end
 
     it "has an enqueued job when not providing at and there is a wait" do
@@ -360,6 +377,13 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       expect {
         expect(heavy_lifting_job).not_to have_been_enqueued
       }.to raise_error(/expected not to enqueue at least 1 jobs, but enqueued 2/)
+    end
+
+    it "accepts composable matchers as an at date" do
+      future = 1.minute.from_now
+      slightly_earlier = 58.seconds.from_now
+      heavy_lifting_job.set(:wait_until => slightly_earlier).perform_later
+      expect(heavy_lifting_job).to have_been_enqueued.at(a_value_within(5.seconds).of(future))
     end
   end
 end

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -201,6 +201,15 @@ RSpec.describe "HaveEnqueuedMail matchers", :skip => !RSpec::Rails::FeatureCheck
       }.to raise_error(/expected to enqueue TestMailer.test_email exactly 1 time at #{send_time.strftime('%F %T')}/)
     end
 
+    it "accepts composable matchers as an at date" do
+      future = 1.minute.from_now
+      slightly_earlier = 58.seconds.from_now
+
+      expect {
+        TestMailer.test_email.deliver_later(:wait_until => slightly_earlier)
+      }.to have_enqueued_email(TestMailer, :test_email).at(a_value_within(5.seconds).of(future))
+    end
+
     it "passes when deliver_later is called with a queue argument" do
       expect {
         TestMailer.test_email.deliver_later(:queue => 'urgent_mail')


### PR DESCRIPTION
Allows for:

```ruby
have_enqueued_job.at(a_value_within(5.seconds).of(future))
have_enqueued_mail.at(a_value_within(5.seconds).of(future))
```

Fixes #2205 for 3.9

`Time.at` seems to be quite fine as per https://github.com/rails/rails/blob/a707072/activejob/lib/active_job/test_helper.rb#L679

This is a backport of #2206 to 3-9-maintenance