### PR TITLE
Update rocket hash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,7 @@ FileName:
     # uses the gem name, things work without user configuration.
     - lib/rspec-rails.rb
 
-HandleExceptions:
+SuppressedException:
   Exclude:
     # RSpec is tightly coupled to capybara right now, this should be
     # re-evaluted in the future. For now we allow the empty rescue
@@ -44,13 +44,19 @@ PerlBackrefs:
     # we can't use named matches in 1.8.7
     - lib/generators/rspec/scaffold/scaffold_generator.rb
 
+HashSyntax:
+  Exclude:
+    # We probably can refactor the backref out, but for now excluding it since
+    # we can't use named matches in 1.8.7
+    - lib/generators/rspec/scaffold/scaffold_generator.rb
+
 Style/AccessModifierDeclarations:
   Enabled: false
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 
 Metrics/PerceivedComplexity:
@@ -65,7 +71,7 @@ Lint/AssignmentInCondition:
 Lint/EmptyExpression:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 Naming/RescuedExceptionsVariableName:

--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -12,7 +12,7 @@ AccessModifierIndentation:
 Alias:
   Enabled: false
 
-AlignParameters:
+ParameterAlignment:
   EnforcedStyle: with_first_parameter
 
 # "Avoid the use of the case equality operator ==="
@@ -135,7 +135,7 @@ Style/ParallelAssignment:
 Layout/EmptyLineBetweenDefs:
   Enabled: false
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: false
 
 Naming/ConstantName:
@@ -258,13 +258,13 @@ Naming/HeredocDelimiterNaming:
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: false
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   Enabled: false
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 Layout/SpaceInsidePercentLiteralDelimiters:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Use **[`rspec-rails` 1.x][]** for Rails 2.x.
    # (requires master-branch versions of all related RSpec libraries)
    group :development, :test do
      %w[rspec-core rspec-expectations rspec-mocks rspec-rails rspec-support].each do |lib|
-       gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => 'master'
+       gem lib, git: "https://github.com/rspec/#{lib}.git", branch: 'master'
      end
    end
    ```

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -1,10 +1,10 @@
 begin
   require "active_job"
-rescue LoadError # rubocop:disable Lint/HandleExceptions
+rescue LoadError # rubocop:disable Lint/SuppressedException
 end
 begin
   require "action_cable"
-rescue LoadError # rubocop:disable Lint/HandleExceptions
+rescue LoadError # rubocop:disable Lint/SuppressedException
 end
 
 require "rails/version"

--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -7,17 +7,17 @@ module Rspec
     class ScaffoldGenerator < Base
       include ::Rails::Generators::ResourceHelpers
       source_paths << File.expand_path('../helper/templates', __dir__)
-      argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
+      argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
-      class_option :orm, :desc => "ORM used to generate the controller"
-      class_option :template_engine, :desc => "Template engine to generate view files"
-      class_option :singleton, :type => :boolean, :desc => "Supply to create a singleton controller"
-      class_option :api, :type => :boolean, :desc => "Skip specs unnecessary for API-only apps"
+      class_option :orm, desc: "ORM used to generate the controller"
+      class_option :template_engine, desc: "Template engine to generate view files"
+      class_option :singleton, type: :boolean, desc: "Supply to create a singleton controller"
+      class_option :api, type: :boolean, desc: "Skip specs unnecessary for API-only apps"
 
-      class_option :controller_specs, :type => :boolean, :default => true,  :desc => "Generate controller specs"
-      class_option :view_specs,       :type => :boolean, :default => true,  :desc => "Generate view specs"
-      class_option :helper_specs,     :type => :boolean, :default => true,  :desc => "Generate helper specs"
-      class_option :routing_specs,    :type => :boolean, :default => true,  :desc => "Generate routing specs"
+      class_option :controller_specs, type: :boolean, default: true, desc: "Generate controller specs"
+      class_option :view_specs,       type: :boolean, default: true, desc: "Generate view specs"
+      class_option :helper_specs,     type: :boolean, default: true, desc: "Generate helper specs"
+      class_option :routing_specs,    type: :boolean, default: true, desc: "Generate routing specs"
 
       def initialize(*args, &blk)
         @generator_args = args.first
@@ -60,7 +60,7 @@ module Rspec
         template 'routing_spec.rb', template_file
       end
 
-      hook_for :integration_tool, :as => :integration
+      hook_for :integration_tool, as: :integration
 
     protected
 

--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -14,10 +14,10 @@ module Rspec
       class_option :singleton, type: :boolean, desc: "Supply to create a singleton controller"
       class_option :api, type: :boolean, desc: "Skip specs unnecessary for API-only apps"
 
-      class_option :controller_specs, type: :boolean, default: true, desc: "Generate controller specs"
-      class_option :view_specs,       type: :boolean, default: true, desc: "Generate view specs"
-      class_option :helper_specs,     type: :boolean, default: true, desc: "Generate helper specs"
-      class_option :routing_specs,    type: :boolean, default: true, desc: "Generate routing specs"
+      class_option :controller_specs, type: :boolean, default: true,  desc: "Generate controller specs"
+      class_option :view_specs,       type: :boolean, default: true,  desc: "Generate view specs"
+      class_option :helper_specs,     type: :boolean, default: true,  desc: "Generate helper specs"
+      class_option :routing_specs,    type: :boolean, default: true,  desc: "Generate routing specs"
 
       def initialize(*args, &blk)
         @generator_args = args.first

--- a/lib/generators/rspec/scaffold/templates/routing_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/routing_spec.rb
@@ -5,41 +5,41 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:routing
   describe "routing" do
 <% unless options[:singleton] -%>
     it "routes to #index" do
-      expect(:get => "/<%= ns_table_name %>").to route_to("<%= ns_table_name %>#index")
+      expect(get: "/<%= ns_table_name %>").to route_to("<%= ns_table_name %>#index")
     end
 
 <% end -%>
 <% unless options[:api] -%>
     it "routes to #new" do
-      expect(:get => "/<%= ns_table_name %>/new").to route_to("<%= ns_table_name %>#new")
+      expect(get: "/<%= ns_table_name %>/new").to route_to("<%= ns_table_name %>#new")
     end
 
 <% end -%>
     it "routes to #show" do
-      expect(:get => "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#show", :id => "1")
+      expect(get: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#show", :id => "1")
     end
 
 <% unless options[:api] -%>
     it "routes to #edit" do
-      expect(:get => "/<%= ns_table_name %>/1/edit").to route_to("<%= ns_table_name %>#edit", :id => "1")
+      expect(get: "/<%= ns_table_name %>/1/edit").to route_to("<%= ns_table_name %>#edit", :id => "1")
     end
 
 <% end -%>
 
     it "routes to #create" do
-      expect(:post => "/<%= ns_table_name %>").to route_to("<%= ns_table_name %>#create")
+      expect(post: "/<%= ns_table_name %>").to route_to("<%= ns_table_name %>#create")
     end
 
     it "routes to #update via PUT" do
-      expect(:put => "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#update", :id => "1")
+      expect(put: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#update", :id => "1")
     end
 
     it "routes to #update via PATCH" do
-      expect(:patch => "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#update", :id => "1")
+      expect(patch: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#update", :id => "1")
     end
 
     it "routes to #destroy" do
-      expect(:delete => "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#destroy", :id => "1")
+      expect(delete: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#destroy", :id => "1")
     end
   end
 end

--- a/lib/generators/rspec/scaffold/templates/routing_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/routing_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:routing
 
 <% end -%>
     it "routes to #show" do
-      expect(get: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#show", :id => "1")
+      expect(get: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#show", id: "1")
     end
 
 <% unless options[:api] -%>
     it "routes to #edit" do
-      expect(get: "/<%= ns_table_name %>/1/edit").to route_to("<%= ns_table_name %>#edit", :id => "1")
+      expect(get: "/<%= ns_table_name %>/1/edit").to route_to("<%= ns_table_name %>#edit", id: "1")
     end
 
 <% end -%>
@@ -31,15 +31,15 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:routing
     end
 
     it "routes to #update via PUT" do
-      expect(put: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#update", :id => "1")
+      expect(put: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#update", id: "1")
     end
 
     it "routes to #update via PATCH" do
-      expect(patch: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#update", :id => "1")
+      expect(patch: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#update", id: "1")
     end
 
     it "routes to #destroy" do
-      expect(delete: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#destroy", :id => "1")
+      expect(delete: "/<%= ns_table_name %>/1").to route_to("<%= ns_table_name %>#destroy", id: "1")
     end
   end
 end


### PR DESCRIPTION
Use latest rocket hash, removing old rocket hash from routing spec template.
Previous: #2198 