### PR TITLE
Fix `WrongScopeError` being thrown on Rails master:

### DIFF
--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -39,6 +39,12 @@ module RSpec
             end
           end
 
+          if ::Rails.version.to_f >= 6.1
+            def name
+              @example
+            end
+          end
+
           fixtures RSpec.configuration.global_fixtures if RSpec.configuration.global_fixtures
         end
       end

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -196,7 +196,9 @@ RSpec.describe "Configuration" do
 
   it "metadata `type: :request` sets up request example groups" do
     a_rails_app = double("Rails application")
-    the_rails_module = Module.new
+    the_rails_module = Module.new {
+      def self.version; end;
+    }
     allow(the_rails_module).to receive(:application) { a_rails_app }
     version = ::Rails::VERSION
     stub_const "Rails", the_rails_module
@@ -230,7 +232,9 @@ RSpec.describe "Configuration" do
 
   it "metadata `type: :feature` sets up feature example groups" do
     a_rails_app = double("Rails application")
-    the_rails_module = Module.new
+    the_rails_module = Module.new {
+      def self.version; end;
+    }
     allow(the_rails_module).to receive(:application) { a_rails_app }
     version = ::Rails::VERSION
     stub_const "Rails", the_rails_module

--- a/spec/rspec/rails/fixture_support_spec.rb
+++ b/spec/rspec/rails/fixture_support_spec.rb
@@ -13,5 +13,16 @@ module RSpec::Rails
         expect(group).to respond_to(:fixture_path=)
       end
     end
+
+    it "will allow #setup_fixture to run successfully", if: Rails.version.to_f > 6.0 do
+
+      group = RSpec::Core::ExampleGroup.describe do
+        include FixtureSupport
+
+        self.use_transactional_tests = false
+      end
+
+      expect { group.new.setup_fixtures }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
Fix `WrongScopeError` being thrown on Rails master:

- ### Problem

  Rails made a change in rails/rails@d4367eb72601f6e5bba3206443e9d141e9753af8
  and TestFixtures don't make use of `method_name` anymore, but simply
  `name`.

  `name` on RSpec raises a `WrongScopeError` when called within an
  example.

  This patch overrides `name` to return the example name instead.