### PR TITLE
Make version check work if version is not from ENV

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -33,7 +33,7 @@ else
     gem "puma"
   end
 
-  if ENV['RAILS_VERSION'].gsub(/[^\d\.]/,'').to_f >= 6.0
+  if version.gsub(/[^\d\.]/,'').to_f >= 6.0
     gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", platforms: [:jruby]
   else
     gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]


### PR DESCRIPTION
This fixes an issue where setting the Rails version in the `.rails-version` file would cause an "undefined method \`gsub' for nil:NilClass" error, because `gsub` was called on the `nil` value of the `RAILS_VERSION` env var.