### PR TITLE
Fix Rails version env var format in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,13 @@ matrix:
     - rvm: jruby-head
       jdk: oraclejdk11
       env:
-        - RAILS_VERSION='~>6.0'
+        - RAILS_VERSION='~> 6.0.0'
         - JRUBY_OPT=--dev
         - JAVA_OPTS="--add-opens java.base/sun.nio.ch=org.jruby.dist --add-opens java.base/java.io=org.jruby.dist --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.security.cert=ALL-UNNAMED --add-opens=java.base/java.util.zip=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/javax.crypto=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED"
     - rvm: 2.6.3
-      env: RAILS_VERSION='~>6.0'
+      env: RAILS_VERSION='~> 6.0.0'
     - rvm: 2.5.5
-      env: RAILS_VERSION='~>6.0'
+      env: RAILS_VERSION='~> 6.0.0'
 
     # Rails 5.2 builds >= 2.2.2
     - rvm: jruby-head


### PR DESCRIPTION
[`downgrade_bundler_on_old_rails`](https://github.com/rspec/rspec-rails/blob/d401812/script/downgrade_bundler_on_old_rails#L8) has a check for Rails < 5, and it false triggered for builds where RAILS_VERSION had two digits.

Example builds: [before](https://travis-ci.org/rspec/rspec-rails/jobs/620832476), [after](https://travis-ci.org/rspec/rspec-rails/jobs/623433099).