### PR TITLE
Fix sanity check specs warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ language: ruby
 # original `cache: bundler` is a better option.
 cache: bundler
 
-bundler_args: "--binstubs --path ../bundle --retry=3 --jobs=3"
+bundler_args: "--retry=3 --jobs=3"
 
 before_install:
   - script/update_rubygems_and_install_bundler
@@ -29,6 +29,8 @@ before_script:
   # Rails 4.x complains with a bundler rails binstub in PROJECT_ROOT/bin/
   - rm -f bin/rails
   - bundle exec rails --version
+  - bundle config set path ../bundle
+  - bundle binstubs --force --all
 
 script: "script/run_build 2>&1"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ language: ruby
 # original `cache: bundler` is a better option.
 cache: bundler
 
-bundler_args: "--retry=3 --jobs=3"
+bundler_args: "--binstubs --path ../bundle --retry=3 --jobs=3"
 
 before_install:
   - script/update_rubygems_and_install_bundler
@@ -29,8 +29,6 @@ before_script:
   # Rails 4.x complains with a bundler rails binstub in PROJECT_ROOT/bin/
   - rm -f bin/rails
   - bundle exec rails --version
-  - bundle config set path ../bundle
-  - bundle binstubs --force --all
 
 script: "script/run_build 2>&1"
 

--- a/Gemfile
+++ b/Gemfile
@@ -42,10 +42,6 @@ else
   gem 'sqlite3', '~> 1.3.6', platforms: [:ruby]
 end
 
-if RUBY_VERSION >= '2.4.0'
-  gem 'json', '>= 2.0.2'
-end
-
 gem 'ffi', '~> 1.9.25'
 
 gem 'rake', '~> 12'

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -33,10 +33,6 @@ else
     gem "puma"
   end
 
-  if RUBY_VERSION < "2.5"
-    gem "sprockets", "~> 3.0"
-  end
-
   if version.gsub(/[^\d\.]/,'').to_f >= 6.0
     gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", platforms: [:jruby]
   else

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,21 +2,23 @@ require 'aruba/cucumber'
 require 'fileutils'
 
 module ArubaExt
-  def run_command(cmd, timeout = nil)
+  def run(cmd, timeout = nil)
     exec_cmd = cmd =~ /^rspec/ ? "bin/#{cmd}" : cmd
-    # Ensure bundler env vars are unset
-    unset_bundler_env_vars
-    # Ensure the correct Gemfile is found
-    in_current_directory do
-      super(exec_cmd, timeout)
+    super(exec_cmd, timeout)
+  end
+  # This method over rides Aruba 0.5.4 implementation so that we can reset Bundler to use the sample app Gemfile
+  def in_current_dir(&block)
+    Bundler.with_clean_env do
+      _mkdir(current_dir)
+      Dir.chdir(current_dir, &block)
     end
   end
 end
 
 World(ArubaExt)
 
-Aruba.configure do |config|
-  config.exit_timeout = 30
+Before do
+  @aruba_timeout_seconds = 30
 end
 
 unless File.directory?('./tmp/example_app')

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  version_string = ['>= 4.2']
+  version_string = ['>= 4.2', '< 7.0']
 
   s.add_runtime_dependency %q<activesupport>, version_string
   s.add_runtime_dependency %q<actionpack>,    version_string

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -55,6 +55,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency 'cucumber', '~> 1.3.5'
-  s.add_development_dependency 'aruba',    '~> 0.14.12'
+  s.add_development_dependency 'aruba',    '~> 0.5.4'
   s.add_development_dependency 'ammeter',  '~> 1.1.2'
 end

--- a/script/custom_build_functions.sh
+++ b/script/custom_build_functions.sh
@@ -1,6 +1,6 @@
 function run_cukes {
   if is_mri_192_plus; then
-    bin/rake acceptance --trace
+    (unset RUBYOPT; bin/rake acceptance --trace)
     return $?
   elif is_jruby; then
     bin/rake smoke:app

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -7,6 +7,9 @@ source script/functions.sh
 
 if is_ruby_23_plus; then
   yes | gem update --system
+  echo "Current bundler versions installed: `gem list | grep '^bundler ('`"
+  gem uninstall -aIx bundler || echo "Warning error occured removing bundler via gem"
+  rvm @global do gem uninstall -aIx bundler || echo "Warning error occured removing bundler via rvm"
   gem install bundler
 else
   echo "Warning installing older versions of Rubygems / Bundler"

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -10,7 +10,8 @@ if is_ruby_23_plus; then
   echo "Current bundler versions installed: `gem list | grep '^bundler ('`"
   gem uninstall -aIx bundler || echo "Warning error occured removing bundler via gem"
   rvm @global do gem uninstall -aIx bundler || echo "Warning error occured removing bundler via rvm"
-  gem install bundler
+  gem install bundler --default -v "2.1.1"
+  echo "Current bundler versions installed after 'gem install bundler': `gem list | grep '^bundler ('`"
 else
   echo "Warning installing older versions of Rubygems / Bundler"
   gem update --system '2.7.8'

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -6,7 +6,7 @@ set -e
 source script/functions.sh
 
 if is_ruby_23_plus; then
-  yes | gem update --system
+  yes | gem update --system '3.0.6'
   yes | gem install bundler
   echo "Current bundler versions installed after 'gem install bundler': `gem list | grep '^bundler ('`"
 else

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -7,10 +7,7 @@ source script/functions.sh
 
 if is_ruby_23_plus; then
   yes | gem update --system
-  echo "Current bundler versions installed: `gem list | grep '^bundler ('`"
-  gem uninstall -aIx bundler || echo "Warning error occured removing bundler via gem"
-  rvm @global do gem uninstall -aIx bundler || echo "Warning error occured removing bundler via rvm"
-  yes | gem install --force bundler
+  yes | gem install bundler
   echo "Current bundler versions installed after 'gem install bundler': `gem list | grep '^bundler ('`"
 else
   echo "Warning installing older versions of Rubygems / Bundler"

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -10,7 +10,7 @@ if is_ruby_23_plus; then
   echo "Current bundler versions installed: `gem list | grep '^bundler ('`"
   gem uninstall -aIx bundler || echo "Warning error occured removing bundler via gem"
   rvm @global do gem uninstall -aIx bundler || echo "Warning error occured removing bundler via rvm"
-  gem install bundler --default -v "2.1.1"
+  yes | gem install --force bundler
   echo "Current bundler versions installed after 'gem install bundler': `gem list | grep '^bundler ('`"
 else
   echo "Warning installing older versions of Rubygems / Bundler"


### PR DESCRIPTION
Fix build errors on sanity check specs.

1. `Bundler.with_clean_env` is deprecated
2. Avoid warning with `open-ended dependency`

```
WARNING:  open-ended dependency on activesupport (>= 4.2) is not recommended
  if activesupport is semantically versioned, use:
    add_runtime_dependency 'activesupport', '~> 4.2'
WARNING:  open-ended dependency on actionpack (>= 4.2) is not recommended
  if actionpack is semantically versioned, use:
    add_runtime_dependency 'actionpack', '~> 4.2'
WARNING:  open-ended dependency on railties (>= 4.2) is not recommended
  if railties is semantically versioned, use:
    add_runtime_dependency 'railties', '~> 4.2'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```