### PR TITLE
Fix RUBYOPT usages

### DIFF
--- a/example_app_generator/travis_retry_bundle_install.sh
+++ b/example_app_generator/travis_retry_bundle_install.sh
@@ -5,7 +5,7 @@ source FUNCTIONS_SCRIPT_FILE
 
 echo "Starting bundle install using shared bundle path"
 if is_mri_192_plus; then
-  travis_retry eval "RUBYOPT=$RUBYOPT:' --enable rubygems' bundle install --gemfile ./Gemfile --path REPLACE_BUNDLE_PATH --retry=3 --jobs=3"
+  travis_retry eval "RUBYOPT=$RUBYOPT' --enable gems' bundle install --gemfile ./Gemfile --path REPLACE_BUNDLE_PATH --retry=3 --jobs=3"
 else
   travis_retry eval "bundle install --gemfile ./Gemfile --path REPLACE_BUNDLE_PATH --retry=3 --jobs=3"
 fi

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -14,7 +14,7 @@ MAINTENANCE_BRANCH=`cat maintenance-branch`
 # Don't allow rubygems to pollute what's loaded. Also, things boot faster
 # without the extra load time of rubygems. Only works on MRI Ruby 1.9+
 if is_mri_192_plus; then
-  export RUBYOPT="--disable=gem"
+  export RUBYOPT="--disable=gems"
 fi
 
 function clone_repo {


### PR DESCRIPTION
There's a warning regarding an unknown argument to `--disable`, and it seems that `--disable=gem` is not entirely correct, should be `--disable=gems`.
[Documentation](https://docs.ruby-lang.org/ja/latest/doc/spec=2frubycmd.html) (in Japanese).

[Example output](https://travis-ci.org/rspec/rspec-rails/jobs/625710994):
```
ruby: warning: unknown argument for --disable: `gem:'
ruby: warning: features are [gems, did_you_mean, rubyopt, frozen_string_literal].
ruby: warning: unknown argument for --enable: `rubygems'
ruby: warning: features are [gems, did_you_mean, rubyopt, frozen_string_literal].
```