### PR TITLE
Work around RubyGems TTY detection

### DIFF
--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -6,7 +6,7 @@ set -e
 source script/functions.sh
 
 if is_ruby_23_plus; then
-  gem update --system
+  yes | gem update --system
   gem install bundler
 else
   echo "Warning installing older versions of Rubygems / Bundler"


### PR DESCRIPTION
Bundler is installed along with latest versions of `rubygems-update` and binaries seem to clash.
[Example](https://travis-ci.org/rspec/rspec-rails/jobs/625945527) [failures](https://travis-ci.org/rspec/rspec-rails/jobs/625945517):
```
Installing RubyGems 3.1.1
  Successfully built RubyGem
  Name: bundler
  Version: 2.1.0
  File: bundler-2.1.0.gem
bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-2.6.3/bin/bundle
Overwrite the executable? [yN]

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.

Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
```

Presumably, RubyGems [incorrectly detect](https://github.com/rubygems/rubygems/blob/15706d3e853f9d1fd7b6ddbdcf38cf9a83a345b9/lib/rubygems/user_interaction.rb#L2530) that it's a [non-interactive shell](https://github.com/rubygems/rubygems/blob/15706d3e853f9d1fd7b6ddbdcf38cf9a83a345b9/lib/rubygems/user_interaction.rb#L210) and don't fall back to [default `false`](https://github.com/rubygems/rubygems/blob/cc3a02724b28fcd7d32f77c8cea837218cd975cc/lib/rubygems/installer.rb#L264).

[RubyGems issue](https://github.com/rubygems/rubygems/issues/3036).
[Recommended workaround](https://github.com/rubygems/rubygems/issues/3036#issuecomment-566132226).