### PR TITLE
Avoid deprecation warning with `Bundler.with_clean_env`

### DIFF
--- a/spec/sanity_check_spec.rb
+++ b/spec/sanity_check_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe "Verify required rspec dependencies" do
 
   before{ FileUtils.mkdir_p tmp_root }
 
+  def with_clean_env
+    if Bundler.respond_to?(:with_unbundled_env)
+      Bundler.with_unbundled_env { yield }
+    else
+      Bundler.with_clean_env { yield }
+    end
+  end
+
   it "fails when libraries are not required" do
     script = tmp_root.join("fail_sanity_check")
     File.open(script, "w") do |f|
@@ -17,7 +25,7 @@ RSpec.describe "Verify required rspec dependencies" do
     end
     FileUtils.chmod 0777, script
 
-    Bundler.with_clean_env do
+    with_clean_env do
       expect(`bundle exec #{script} 2>&1`).
         to match(/uninitialized constant RSpec::Support/).
         or match(/undefined method `require_rspec_core' for RSpec::Support:Module/)
@@ -38,7 +46,7 @@ RSpec.describe "Verify required rspec dependencies" do
     end
     FileUtils.chmod 0777, script
 
-    Bundler.with_clean_env do
+    with_clean_env do
       expect(`bundle exec #{script} 2>&1`).to be_empty
       expect($?.exitstatus).to eq(0)
     end


### PR DESCRIPTION
This is a subsection of #2231 to get the other builds working.