### PR TITLE
Remove IntegrationTest::Behavior from SystemExampleGroup

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -71,7 +71,6 @@ module RSpec
         original_after_teardown =
           ::ActionDispatch::SystemTesting::TestHelpers::SetupAndTeardown.instance_method(:after_teardown)
 
-        other.include ActionDispatch::IntegrationTest::Behavior
         other.include ::ActionDispatch::SystemTesting::TestHelpers::SetupAndTeardown
         other.include ::ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper
         other.include BlowAwayTeardownHooks


### PR DESCRIPTION
To better mirror current Rails ActionDispatch::SystemTestCase. And resolve problems with inability to set ActiveJob queue type in systems example group, closing #2232 

This one-line change has a lot of background to explain, that was a bit tricky to figure out...

## Background

The Rspec `SystemExampleGroup` was based on the Rails `ActionDispatch::SystemTestCase`, which originally sub-classed Rails `ActionDispatch::IntegrationTest`. 

However, in Rails6, it was noticed that System tests now refused to respect your `ActiveJob::Base.queue_adapter` settings, reported to Rails at https://github.com/rails/rails/issues/37270

It was [noted in a comment there](https://github.com/rails/rails/issues/37270#issuecomment-536230076) that this had already been fixed in Rails master https://github.com/rails/rails/pull/36283 , but needed to be backported to Rails 6-0-stable. 

The relevant backport commit ended up at https://github.com/rails/rails/commit/ea77dbffdc81d6e40bbde155961ab57f1450d1e4, and that's the easiest place to read what the fix was -- basically changing `ActionDispatch::TestCase` to inherit from the basic `ActiveSupport::TestCase` instead of `ActionDispatch::IntegrationTest`, cause the `IntegrationTest` stuff was messing with things. 

That resolved things in Rails (I think in  6.0.1 release, although not sure why that backport commit doesn't show up as being in `v6.0.1`). 

But a very similar problem still existed in rspec-rails, reported at #2232, still present with Rails 6.0.1 or 6.0.2. 

Finding the Rails history, I wondered if making the analogous change -- removing the Rails `IntegrationTest::Behavior` from the rspec-rails `SystemExampleGroup` -- would resolve the problem in rspec-rails. 

It seemed to!

## The url_options business

The [original rails commit](https://github.com/rails/rails/commit/ea77dbffdc81d6e40bbde155961ab57f1450d1e4) in addition to changing the superclass, also _adds_ a `url_options` method to `SystemTestCase`, intended to make it so Rails urls generated from a `system` test will default to `host: Capybara.app_host`. 

Apparently this was the only behavior from Rails `ActionDispatch::IntegrationTest` that was of use, so it was copied over manually. 

This PR does not do that for rspec. It _would_ be nice to have this behavior in rspec-rails system tests. I have run into confusion and problems from not having it before myself. 

However, I was unable to succesfully implement this in rspec-rails -- the default host to Capybara.app_host behavior.  And I believe rspec-rails system tests did *not* have this behavior even prior to the change in this PR, it is not a regression to lose it, it was never there, even when including `IntegrationTest::Behavior`. It looks like default url options behavior is really hard for rspec-rails to handle consistently with rails minitest, [this isn't the first time](https://github.com/rspec/rspec-rails/issues/1275) it's come up. I tried, but couldn't figure out how to get it this particular behavior, default host to `Capybara.app_host` to work in rspec-rails, before or after this PR. 

## The sadly missing tests. 

It's not great that this one-liner change has no tests. 

It seems maybe not a great sign that making this change did not cause any existing tests to fail. (Or maybe it means we're on the right path?). 

But ideally I would have added a test that _failed_ prior to this change, and was green after this change. But I was unable to write an automated test around setting `ActiveJob::Base.queue_adapter` to fail prior to this change. 

So how do I know it works at all? Well, in my own real app, system tests involving manually changing `ActiveJob::Base.queue_adapter` were failing with Rails 6.0.2 and rspec-rails `4.0.0.beta3`.  And they pass in 4.0.0.beta3 with this one change. (They also pass in Rails 5.2.4 and rspec-rails 4.0.0.beta3, both with and without this change). 

I'm not sure why I couldn't reproduce in a test what I'm seeing in my own app. This stuff is *tricky*. But maybe since all existing tests still pass, it's good enough to merge without a new test, with just the evidence of "matching what Rails is doing" and my report? 

Otherwise, I'm probably going to need some help, I'm not sure I'm going to be able to come up with a failing test, although I can spend a few more hours trying. 