### PR TITLE
Updates rubocop to 0.79.0

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,7 +7,7 @@ Metrics/CyclomaticComplexity:
   Max: 9 # default: 6
 
 # Over time we'd like to get this down, but this is what we're at now.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 186 # default: 80
 
 # Over time we'd like to get this down, but this is what we're at now.

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ end
 
 gem "rubyzip", '~> 1.2'
 
-gem 'rubocop', '~> 0.77.0'
+gem 'rubocop', '~> 0.79.0'
 
 custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)
 eval_gemfile custom_gemfile if File.exist?(custom_gemfile)


### PR DESCRIPTION
Updating to rubocop 0.79.0, had to change the namespace from Metrics to Layout in LineLength