### PR TITLE
Fix Mocha compatibility

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,7 @@ Bug Fixes:
   (Takumi Shotoku, #2188)
 * Prevent a `WrongScopeError` being thrown during loading fixtures on Rails
   6.1 development version. (Edouard Chin, #2215)
+* Fix Mocha mocking support with `should`. (Phil Pirozhkov, #2256)
 
 Breaking Changes:
 

--- a/lib/rspec/rails/matchers/have_enqueued_mail.rb
+++ b/lib/rspec/rails/matchers/have_enqueued_mail.rb
@@ -1,4 +1,7 @@
-require "rspec/mocks"
+# We require the minimum amount of rspec-mocks possible to avoid
+# conflicts with other mocking frameworks.
+# See: https://github.com/rspec/rspec-rails/issues/2252
+require "rspec/mocks/argument_matchers"
 require "rspec/rails/matchers/active_job"
 
 module RSpec
@@ -11,7 +14,7 @@ module RSpec
       class HaveEnqueuedMail < ActiveJob::HaveEnqueuedJob
         MAILER_JOB_METHOD = 'deliver_now'.freeze
 
-        include RSpec::Mocks::ExampleMethods
+        include RSpec::Mocks::ArgumentMatchers
 
         def initialize(mailer_class, method_name)
           super(nil)


### PR DESCRIPTION
RSpec Mocks happened to load its configuration, use the default syntax and define `any_instance` on `Class` before Mocha had a chance to in case `rspec/rails` was required in `spec/spec_helper.rb` before `rspec/core` and configuring Mocha as `mock_with`.

This is not something typical, as usually `rails_helper.rb` requires `rspec-rails`, and `spec_helper.rb` requires `rspec-core` and configures `mock_with`, but not something that is a complete no-no.

fixes #2252

- [x] add changelog