### PR TITLE
Drop some legacy code

### DIFF
--- a/features/controller_specs/anonymous_controller.feature
+++ b/features/controller_specs/anonymous_controller.feature
@@ -51,7 +51,7 @@ Feature: anonymous controller
       RSpec.describe ApplicationController, :type => :controller do
         controller do
           def index
-            raise ApplicationController::AccessDenied
+            raise AccessDenied
           end
         end
 
@@ -86,7 +86,7 @@ Feature: anonymous controller
       RSpec.describe ApplicationController, :type => :controller do
         controller do
           def index
-            raise ApplicationController::AccessDenied
+            raise AccessDenied
           end
         end
 
@@ -121,7 +121,7 @@ Feature: anonymous controller
       RSpec.describe ApplicationController, :type => :controller do
         controller do
           def index
-            raise ApplicationController::AccessDenied
+            raise AccessDenied
           end
         end
 
@@ -147,8 +147,7 @@ Feature: anonymous controller
 
       class FoosController < ApplicationController
 
-        rescue_from ApplicationController::AccessDenied,
-                    :with => :access_denied
+        rescue_from AccessDenied, :with => :access_denied
 
       private
 
@@ -160,7 +159,7 @@ Feature: anonymous controller
       RSpec.describe FoosController, :type => :controller do
         controller(FoosController) do
           def index
-            raise ApplicationController::AccessDenied
+            raise AccessDenied
           end
         end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -53,8 +53,7 @@ Before do
   FileUtils.rm_rf(aruba_dir) if File.exist?(aruba_dir)
 
   # We want fresh `example_app` project with empty `spec` dir except helpers.
-  # FileUtils.cp_r on Ruby 1.9.2 doesn't preserve permissions.
-  system('cp', '-r', example_app_dir, aruba_dir)
+  FileUtils.cp_r(example_app_dir, aruba_dir)
   helpers = %w[spec/spec_helper.rb spec/rails_helper.rb]
   Dir["#{aruba_dir}/spec/*"].each do |path|
     next if helpers.any? { |helper| path.end_with?(helper) }

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -29,18 +29,11 @@ module RSpec
         # `body` in that context. Also sets up implicit routes for this
         # controller, that are separate from those defined in "config/routes.rb".
         #
-        # @note Due to Ruby 1.8 scoping rules in anonymous subclasses, constants
-        #   defined in `ApplicationController` must be fully qualified (e.g.
-        #   `ApplicationController::AccessDenied`) in the block passed to the
-        #   `controller` method. Any instance methods, filters, etc, that are
-        #   defined in `ApplicationController`, however, are accessible from
-        #   within the block.
-        #
         # @example
         #     describe ApplicationController do
         #       controller do
         #         def index
-        #           raise ApplicationController::AccessDenied
+        #           raise AccessDenied
         #         end
         #       end
         #


### PR DESCRIPTION
We don't support Ruby 1.x anymore, so those tricks are no longer necessary.