### PR TITLE
fix docs matcher links

### DIFF
--- a/features/job_specs/job_spec.feature
+++ b/features/job_specs/job_spec.feature
@@ -15,10 +15,10 @@ Feature: job spec
   * specify the queue which the job was enqueued to
 
   Check the documentation on
-  [`have_been_enqueued`](matchers/have-been-enqueued-matcher),
-  [`have_enqueued_job`](matchers/have-enqueued-job-matcher),
-  [`have_been_performed`](matchers/have-been-performed-matcher), and
-  [`have_performed_job`](matchers/have-performed-job-matcher)
+  [`have_been_enqueued`](../matchers/have-been-enqueued-matcher),
+  [`have_enqueued_job`](../matchers/have-enqueued-job-matcher),
+  [`have_been_performed`](../matchers/have-been-performed-matcher), and
+  [`have_performed_job`](../matchers/have-performed-job-matcher)
   for more information.
 
   Background:


### PR DESCRIPTION
Fix links to matchers in the job specs description