### PR TITLE
Get rid of rack warning

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -1,4 +1,10 @@
 version_file = File.expand_path("../.rails-version", __FILE__)
+
+# FIXME: rack 2.1.0 introduces a deprecation warning that rails is triggering,
+# but in later versions this warning will be removed. Get rid of this hack once
+# rack 2.1.0+ is out.
+gem 'rack', '!= 2.1.0'
+
 case version = ENV['RAILS_VERSION'] || (File.exist?(version_file) && File.read(version_file).chomp) || ''
 when /master/
   gem "rails", :git => "https://github.com/rails/rails.git"


### PR DESCRIPTION
rack 2.1.0 introduces a deprecation warning
https://github.com/rack/rack/commit/626272b2bc6b270bbd3d2aa6aaa64722350f42be#diff-894804c816a11584eb28499cb8bbe396R6

that rails is triggering,
https://github.com/rails/rails/blob/1e14a2405b5e19b6758842dbd6d377c68d7f57ae/actionpack/lib/action_dispatch/middleware/static.rb#L20

but in later versions this warning will be removed
https://github.com/rack/rack/commit/f80e65d5dde251ee446e4c0bd038f8bc4ec30314#diff-894804c816a11584eb28499cb8bbe396L6

This warning was causing CI failures on rack 2.1.0:
rack 2.0.8: https://travis-ci.org/rspec/rspec-rails/jobs/635322909
rack 2.1.0: https://travis-ci.org/rspec/rspec-rails/jobs/635434487