### PR TITLE
Get rid of redundant requires

### DIFF
--- a/spec/rspec/rails/assertion_adapter_spec.rb
+++ b/spec/rspec/rails/assertion_adapter_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe RSpec::Rails::MinitestAssertionAdapter do
   include RSpec::Rails::MinitestAssertionAdapter
 

--- a/spec/rspec/rails/assertion_delegator_spec.rb
+++ b/spec/rspec/rails/assertion_delegator_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe RSpec::Rails::AssertionDelegator do
   it "provides a module that delegates assertion methods to an isolated class" do
     klass = Class.new {

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require 'rspec/support/spec/in_sub_process'
 
 RSpec.describe "Configuration" do

--- a/spec/rspec/rails/example/channel_example_group_spec.rb
+++ b/spec/rspec/rails/example/channel_example_group_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rspec/rails/feature_check"
 
 module RSpec::Rails

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 class ::ApplicationController
   def self.abstract?; false; end
 end

--- a/spec/rspec/rails/example/feature_example_group_spec.rb
+++ b/spec/rspec/rails/example/feature_example_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module RSpec::Rails
   describe FeatureExampleGroup do
     it_behaves_like "an rspec-rails example group mixin", :feature,

--- a/spec/rspec/rails/example/helper_example_group_spec.rb
+++ b/spec/rspec/rails/example/helper_example_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module RSpec::Rails
   RSpec.describe HelperExampleGroup do
     module ::FoosHelper

--- a/spec/rspec/rails/example/job_example_group_spec.rb
+++ b/spec/rspec/rails/example/job_example_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module RSpec::Rails
   describe JobExampleGroup do
     if defined?(ActiveJob)

--- a/spec/rspec/rails/example/mailbox_example_group_spec.rb
+++ b/spec/rspec/rails/example/mailbox_example_group_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rspec/rails/feature_check"
 
 class ApplicationMailbox

--- a/spec/rspec/rails/example/mailer_example_group_spec.rb
+++ b/spec/rspec/rails/example/mailer_example_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module RSpec::Rails
   describe MailerExampleGroup do
     module ::Rails; end

--- a/spec/rspec/rails/example/model_example_group_spec.rb
+++ b/spec/rspec/rails/example/model_example_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module RSpec::Rails
   describe ModelExampleGroup do
     it_behaves_like "an rspec-rails example group mixin", :model,

--- a/spec/rspec/rails/example/request_example_group_spec.rb
+++ b/spec/rspec/rails/example/request_example_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module RSpec::Rails
   describe RequestExampleGroup do
     it_behaves_like "an rspec-rails example group mixin", :request,

--- a/spec/rspec/rails/example/routing_example_group_spec.rb
+++ b/spec/rspec/rails/example/routing_example_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module RSpec::Rails
   describe RoutingExampleGroup do
     it_behaves_like "an rspec-rails example group mixin", :routing,

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 module RSpec::Rails
   if ActionPack::VERSION::STRING >= "5.1"
     RSpec.describe SystemExampleGroup do

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module RSpec::Rails
   describe ViewExampleGroup do
     it_behaves_like "an rspec-rails example group mixin", :view,

--- a/spec/rspec/rails/fixture_file_upload_support_spec.rb
+++ b/spec/rspec/rails/fixture_file_upload_support_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module RSpec::Rails
   describe FixtureFileUploadSupport do
     context 'with fixture path set in config' do

--- a/spec/rspec/rails/fixture_support_spec.rb
+++ b/spec/rspec/rails/fixture_support_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module RSpec::Rails
   describe FixtureSupport do
     context "with use_transactional_fixtures set to false" do

--- a/spec/rspec/rails/matchers/action_cable/have_broadcasted_to_spec.rb
+++ b/spec/rspec/rails/matchers/action_cable/have_broadcasted_to_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rspec/rails/feature_check"
 
 if RSpec::Rails::FeatureCheck.has_action_cable_testing?

--- a/spec/rspec/rails/matchers/action_cable/have_stream_spec.rb
+++ b/spec/rspec/rails/matchers/action_cable/have_stream_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rspec/rails/feature_check"
 
 if RSpec::Rails::FeatureCheck.has_action_cable_testing?

--- a/spec/rspec/rails/matchers/action_mailbox_spec.rb
+++ b/spec/rspec/rails/matchers/action_mailbox_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rspec/rails/feature_check"
 
 class ApplicationMailbox

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rspec/rails/feature_check"
 
 if RSpec::Rails::FeatureCheck.has_active_job?

--- a/spec/rspec/rails/matchers/be_a_new_spec.rb
+++ b/spec/rspec/rails/matchers/be_a_new_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "be_a_new matcher" do
   context "new record" do
     let(:record) do

--- a/spec/rspec/rails/matchers/be_new_record_spec.rb
+++ b/spec/rspec/rails/matchers/be_new_record_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "be_new_record" do
   context "a new record" do
     let(:record) { double('record', new_record?: true) }

--- a/spec/rspec/rails/matchers/be_routable_spec.rb
+++ b/spec/rspec/rails/matchers/be_routable_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "be_routable" do
   include RSpec::Rails::Matchers::RoutingMatchers
   attr_reader :routes

--- a/spec/rspec/rails/matchers/be_valid_spec.rb
+++ b/spec/rspec/rails/matchers/be_valid_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require 'rspec/rails/matchers/be_valid'
 
 describe "be_valid matcher" do

--- a/spec/rspec/rails/matchers/has_spec.rb
+++ b/spec/rspec/rails/matchers/has_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class CollectionOwner < ActiveRecord::Base
   connection.execute <<-SQL
     CREATE TABLE collection_owners (

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rspec/rails/feature_check"
 
 if RSpec::Rails::FeatureCheck.has_active_job?

--- a/spec/rspec/rails/matchers/have_http_status_spec.rb
+++ b/spec/rspec/rails/matchers/have_http_status_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe "have_http_status" do
   def create_response(opts = {})
     ActionDispatch::TestResponse.new(opts.fetch(:status)).tap {|x|

--- a/spec/rspec/rails/matchers/have_rendered_spec.rb
+++ b/spec/rspec/rails/matchers/have_rendered_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 %w[have_rendered render_template].each do |template_expectation|
   describe template_expectation do
     include RSpec::Rails::Matchers::RenderTemplate

--- a/spec/rspec/rails/matchers/redirect_to_spec.rb
+++ b/spec/rspec/rails/matchers/redirect_to_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "active_support"
 require "active_support/test_case"
 

--- a/spec/rspec/rails/matchers/relation_match_array_spec.rb
+++ b/spec/rspec/rails/matchers/relation_match_array_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "ActiveSupport::Relation match_array matcher" do
   before { MockableModel.delete_all }
 

--- a/spec/rspec/rails/matchers/route_to_spec.rb
+++ b/spec/rspec/rails/matchers/route_to_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "route_to" do
   include RSpec::Rails::Matchers::RoutingMatchers
   include RSpec::Rails::Matchers::RoutingMatchers::RouteHelpers

--- a/spec/rspec/rails/minitest_lifecycle_adapter_spec.rb
+++ b/spec/rspec/rails/minitest_lifecycle_adapter_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe RSpec::Rails::MinitestLifecycleAdapter do
   it "invokes minitest lifecycle hooks at the appropriate times" do
     invocations = []

--- a/spec/rspec/rails/setup_and_teardown_adapter_spec.rb
+++ b/spec/rspec/rails/setup_and_teardown_adapter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe RSpec::Rails::SetupAndTeardownAdapter do
   describe "::setup" do
     it "registers before hooks in the order setup is received" do

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module RSpec::Rails
   describe ViewRendering do
     let(:group) do

--- a/spec/sanity_check_spec.rb
+++ b/spec/sanity_check_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'pathname'
 
 RSpec.describe "Verify required rspec dependencies" do


### PR DESCRIPTION
We already tell RSpec to require `spec/spec_helper.rb` in `.rspec` with `--require spec_helper`.