### PR TITLE
Use latest Rails by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ when /stable/
   MAJOR = 6
   MINOR = 0
 when nil, false, ""
-  MAJOR = 5
+  MAJOR = 6
   MINOR = 0
 else
   match = /(\d+)(\.|-)(\d+)/.match(RAILS_VERSION)

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -1,10 +1,5 @@
 version_file = File.expand_path("../.rails-version", __FILE__)
 
-# FIXME: rack 2.1.0 introduces a deprecation warning that rails is triggering,
-# but in later versions this warning will be removed. Get rid of this hack once
-# rack 2.1.0+ is out.
-gem 'rack', '!= 2.1.0'
-
 case version = ENV['RAILS_VERSION'] || (File.exist?(version_file) && File.read(version_file).chomp) || ''
 when /master/
   gem "rails", :git => "https://github.com/rails/rails.git"

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -28,7 +28,7 @@ when /stable$/
     gem rails_gem, :git => "https://github.com/rails/rails.git", :branch => version
   end
 when nil, false, ""
-  gem "rails", "~> 5.0.0"
+  gem "rails", "~> 6.0.0"
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
 else
   gem "rails", version


### PR DESCRIPTION
Latest Rails includes ActionCable tests, that are otherwise skipped when testing the compatibility of other RSpec projects, e.g. `rspec-expectation` on CI.

Related pull request that was expected to fail, but didn't https://github.com/rspec/rspec-expectations/pull/1157

Originally found here https://github.com/rspec/rspec-expectations/pull/1155#issuecomment-573457208