### PR TITLE
Fix Ruby 2.7 deprecation in have_broadcasted_to

### DIFF
--- a/lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb
+++ b/lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb
@@ -13,10 +13,10 @@ module RSpec
             set_expected_number(:exactly, 1)
           end
 
-          def with(data = nil)
+          def with(data = nil, &block)
             @data = data
             @data = @data.with_indifferent_access if @data.is_a?(Hash)
-            @block = Proc.new if block_given?
+            @block = block if block
             self
           end
 


### PR DESCRIPTION
In Ruby 2.7:

```
  lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb:19:
    warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```