### PR TITLE
Use Rails 6 by default when running Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ RSpec::Core::RakeTask.new(:spec) do |t|
 end
 
 Cucumber::Rake::Task.new(:cucumber) do |t|
-  version = ENV.fetch("RAILS_VERSION", "~> 5.2.0")[/\d[\.-]\d/]
+  version = ENV.fetch("RAILS_VERSION", "~> 6.0.0")[/\d[\.-]\d/]
   if version == "master" || version.nil?
     version = Float::INFINITY
   end


### PR DESCRIPTION
This is a follow-up to https://github.com/rspec/rspec-rails/pull/2267