### PR TITLE
Restore respond_to? check for default_url_options

### DIFF
--- a/lib/rspec/rails/example/feature_example_group.rb
+++ b/lib/rspec/rails/example/feature_example_group.rb
@@ -15,7 +15,9 @@ module RSpec
           include app.routes.url_helpers     if app.routes.respond_to?(:url_helpers)
           include app.routes.mounted_helpers if app.routes.respond_to?(:mounted_helpers)
 
-          default_url_options[:host] ||= ::RSpec::Rails::FeatureExampleGroup::DEFAULT_HOST
+          if respond_to?(:default_url_options)
+            default_url_options[:host] ||= ::RSpec::Rails::FeatureExampleGroup::DEFAULT_HOST
+          end
         end
       end
 

--- a/spec/rspec/rails/example/feature_example_group_spec.rb
+++ b/spec/rspec/rails/example/feature_example_group_spec.rb
@@ -18,6 +18,23 @@ module RSpec::Rails
       expect(group.new.foo_url).to eq("http://www.example.com/foo")
     end
 
+    context "when nested inside a request example group" do
+      it "includes Rails route helpers" do
+        Rails.application.routes.draw do
+          get "/foo", :as => :foo, :to => "foo#bar"
+        end
+
+        group = RSpec::Core::ExampleGroup.describe do
+          include RequestExampleGroup
+        end.describe do
+          include FeatureExampleGroup
+        end
+
+        expect(group.new.foo_path).to eq("/foo")
+        expect(group.new.foo_url).to eq("http://www.example.com/foo")
+      end
+    end
+
     describe "#visit" do
       it "raises an error informing about missing Capybara" do
         group = RSpec::Core::ExampleGroup.describe do


### PR DESCRIPTION
Fixes https://github.com/rspec/rspec-rails/issues/2276.
Reverts part of https://github.com/rspec/rspec-rails/pull/2226.

Feature example groups usually have a `default_url_options` class attribute, but it's not added if the method is already defined:

https://github.com/rails/rails/blob/v6.0.2.1/actionpack/lib/action_dispatch/routing/url_for.rb#L92

Request example groups have a `default_url_options` instance method:

https://github.com/rails/rails/blob/v6.0.2.1/actionpack/lib/action_dispatch/testing/integration.rb#L388

This means that when a feature example group is defined inside a request example group, it will only have the instance method, and trying to call `default_url_options` on the example group will fail.