### PR TITLE
Make generated spec/rails_helper.rb file compliant with RuboCop 0.80

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 <% if RSpec::Rails::FeatureCheck.has_active_record_migration? -%>
 # Checks for pending migrations and applies them before tests are run.


### PR DESCRIPTION
- Over in @alphagov, we upgraded to RuboCop 0.80 which includes a new cop - `Lint/NonDeterministicRequireOrder`. This fails when linting this file:

```
spec/rails_helper.rb:20:1: W: Lint/NonDeterministicRequireOrder: Sort files before requiring them.
Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
158 files inspected, 1 offense detected
```

- While this is a generated file, [we decided to fix it in our projects anyway](https://github.com/alphagov/contacts-admin/commit/715383abd85114b5e4fa24ebd620f15ebccf1ae6) everywhere we could, and push this fix upstream so that everyone gets it in hopefully a next release of `rspec-rails`.

Co-authored-by: Issy Long <issy.long@digital.cabinet-office.gov.uk>