### PR TITLE
Fix JRuby gem installation on CI

### DIFF
--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -5,5 +5,5 @@
 set -e
 source script/functions.sh
 
-yes | gem update --no-document --system
-yes | gem install --no-document bundler
+gem update --no-document --system
+gem install --no-document bundler

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -5,5 +5,5 @@
 set -e
 source script/functions.sh
 
-yes | gem update --system
-yes | gem install bundler
+yes | gem update --no-document --system
+yes | gem install --no-document bundler


### PR DESCRIPTION
Apparently it freezes on doc installation phase:

    $ script/update_rubygems_and_install_bundler

    Updating rubygems-update
    Fetching rubygems-update-3.1.2.gem
    Successfully installed rubygems-update-3.1.2
    Parsing documentation for rubygems-update-3.1.2
    Installing ri documentation for rubygems-update-3.1.2

    No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
    Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

    The build has been terminated

https://travis-ci.org/rspec/rspec-rails/jobs/658127232