### PR TITLE
Support symbol argument in #on_queue

### DIFF
--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -26,7 +26,7 @@ module RSpec
           end
 
           def on_queue(queue)
-            @queue = queue
+            @queue = queue.to_s
             self
           end
 

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -197,10 +197,16 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to raise_error(/expected to enqueue at most 1 jobs, but enqueued 2/)
     end
 
-    it "passes with provided queue name" do
+    it "passes with provided queue name as string" do
       expect {
         hello_job.set(:queue => "low").perform_later
       }.to have_enqueued_job.on_queue("low")
+    end
+
+    it "passes with provided queue name as symbol" do
+      expect {
+        hello_job.set(:queue => "low").perform_later
+      }.to have_enqueued_job.on_queue(:low)
     end
 
     it "passes with provided at date" do
@@ -531,10 +537,16 @@ RSpec.describe "ActiveJob matchers", :skip => !RSpec::Rails::FeatureCheck.has_ac
       }.to raise_error(/expected to perform at most 1 jobs, but performed 2/)
     end
 
-    it "passes with provided queue name" do
+    it "passes with provided queue name as string" do
       expect {
         hello_job.set(:queue => "low").perform_later
       }.to have_performed_job.on_queue("low")
+    end
+
+    it "passes with provided queue name as symbol" do
+      expect {
+        hello_job.set(:queue => "low").perform_later
+      }.to have_performed_job.on_queue(:low)
     end
 
     it "passes with provided at date" do


### PR DESCRIPTION
Discovered today that expectations fail when using `#on_queue` with symbol args instead of strings, which surprised me, especially given that `queue_as` in active job classes is usually used with a symbol, too. Not sure if you have any philosophy around this, let me know if I can improve anything.