### PR TITLE
Avoid installing documentation gems on TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ language: ruby
 # original `cache: bundler` is a better option.
 cache: bundler
 
-bundler_args: "--binstubs --path ../bundle --retry=3 --jobs=3"
+bundler_args: "--binstubs --without documentation --path ../bundle --retry=3 --jobs=3"
 
 before_install:
   - script/update_rubygems_and_install_bundler

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,8 @@ gem 'yard', '~> 0.9.24', :require => false
 group :documentation do
   gem 'github-markup', '~> 3.0.3'
   gem 'redcarpet', '~> 3.4.0', platforms: [:ruby]
-  gem 'relish', '~> 0.7.1'
 end
+gem 'relish', '~> 0.7.1'
 
 platforms :jruby do
   gem "jruby-openssl"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'yard', '~> 0.9.24', :require => false
 
 group :documentation do
   gem 'github-markup', '~> 3.0.3'
-  gem 'redcarpet', '~> 3.4.0', platforms: [:ruby]
+  gem 'redcarpet', '~> 3.5.0', platforms: [:ruby]
 end
 gem 'relish', '~> 0.7.1'
 


### PR DESCRIPTION
Probably only relish is needed

Related:
- https://github.com/rspec/rspec-rails/commit/e9949e7b9321d1062ed358202654afa754bd27e8
- https://github.com/rspec/rspec-expectations/pull/1152#issuecomment-596233253