### PR TITLE
Let the user choose active job queue in system test

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -75,6 +75,7 @@ module RSpec
         original_after_teardown =
           ::ActionDispatch::SystemTesting::TestHelpers::SetupAndTeardown.instance_method(:after_teardown)
 
+        other.include ::ActionDispatch::IntegrationTest::Behavior
         other.include ::ActionDispatch::SystemTesting::TestHelpers::SetupAndTeardown
         other.include ::ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper
         other.include BlowAwayTeardownHooks
@@ -102,6 +103,7 @@ module RSpec
 
         before do
           @routes = ::Rails.application.routes
+          ActiveJob::Base.disable_test_adapter
         end
 
         after do


### PR DESCRIPTION
This reverts commit 3e4c770f529237dbaa5877ff80aa0d0b4594b0d1.

Do not remove ::ActionDispatch::IntegrationTest::Behavior because this
lead to unwanted behavior like uncleaned queue for
ActionMailer::Base.deliveries between tests.

As suggested in https://github.com/rails/rails/issues/37270 there is
many other way to implement this. At the moment this line seems to be
enough for our case.

Fix: https://github.com/rspec/rspec-rails/issues/2290

Related:
  - https://github.com/rails/rails/issues/37270