### PR TITLE
Clear test mailbox from ActionMailer::Base between each example

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ Bug Fixes:
   (Jonathan Rochkind, #2242)
 * `rails generate generator` command now creates related spec file (Joel Azemar, #2217)
 * Relax upper `capybara` version constraint to allow for Capybara 3.x (Phil Pirozhkov, #2281)
+* Leans ActionMailer test mailbox after each example (Benoit Tigeot, #2293)
 
 ### 4.0.0.beta4
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v4.0.0.beta3...v4.0.0.beta4)

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -137,6 +137,7 @@ module RSpec
 
       if RSpec::Rails::FeatureCheck.has_action_mailer?
         config.include RSpec::Rails::MailerExampleGroup, type: :mailer
+        config.after { ActionMailer::Base.deliveries.clear }
       end
 
       if RSpec::Rails::FeatureCheck.has_active_job?

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -258,25 +258,28 @@ RSpec.describe "Configuration" do
     end
 
     describe 'leans test mailbox after each example' do
-      class BaseMailer < ActionMailer::Base
-        default from: 'from@example.com'
+      let(:base_mailer) do
+        Class.new(ActionMailer::Base) do
+          default from: 'from@example.com'
 
-        def welcome(to:)
-          mail(to: to, subject: 'subject', body: render(inline: "Hello", layout: false))
+          def welcome(to:)
+            mail(to: to, subject: 'subject', body: render(inline: "Hello", layout: false))
+          end
         end
       end
+
       before do
         ActionMailer::Base.delivery_method = :test
       end
 
       it 'send to email@' do
-        BaseMailer.welcome(to: 'email@example.com').deliver_now
+        base_mailer.welcome(to: 'email@example.com').deliver_now
 
         expect(ActionMailer::Base.deliveries.map(&:to).flatten.sort).to eq(['email@example.com'])
       end
 
       it 'send to email_2@' do
-        BaseMailer.welcome(to: 'email_2@example.com').deliver_now
+        base_mailer.welcome(to: 'email_2@example.com').deliver_now
 
         expect(ActionMailer::Base.deliveries.map(&:to).flatten.sort).to eq(['email_2@example.com'])
       end

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe "Configuration" do
       expect(group.new).to be_a(RSpec::Rails::MailerExampleGroup)
     end
 
-    describe 'cleans test mailbox between each example in all rspec-rails example' do
+    describe 'leans test mailbox after each example' do
       class BaseMailer < ActionMailer::Base
         default from: 'from@example.com'
 

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -256,6 +256,31 @@ RSpec.describe "Configuration" do
       expect(group.mailer_class).to be(a_mailer_class)
       expect(group.new).to be_a(RSpec::Rails::MailerExampleGroup)
     end
+
+    describe 'cleans test mailbox between each example in all rspec-rails example' do
+      class BaseMailer < ActionMailer::Base
+        default from: 'from@example.com'
+
+        def welcome(to:)
+          mail(to: to, subject: 'subject', body: render(inline: "Hello", layout: false))
+        end
+      end
+      before do
+        ActionMailer::Base.delivery_method = :test
+      end
+
+      it 'send to email@' do
+        BaseMailer.welcome(to: 'email@example.com').deliver_now
+
+        expect(ActionMailer::Base.deliveries.map(&:to).flatten.sort).to eq(['email@example.com'])
+      end
+
+      it 'send to email_2@' do
+        BaseMailer.welcome(to: 'email_2@example.com').deliver_now
+
+        expect(ActionMailer::Base.deliveries.map(&:to).flatten.sort).to eq(['email_2@example.com'])
+      end
+    end
   end
 
   it "has a default #file_fixture_path of 'spec/fixtures/files'" do


### PR DESCRIPTION
We notice in https://github.com/rspec/rspec-rails/issues/2290 that
ActionMailer::Base.deliveries mailbox is not cleaned between example.

Fix: https://github.com/rspec/rspec-rails/issues/2290