### PR TITLE
Add rake command to generate yard documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -231,9 +231,9 @@ end
 task build: :verify_private_key_present
 
 desc "Updates the rspec.github.io docs"
-task :update_docs, [:version, :branch, :website_path] do |t, args|
+task :update_docs, [:version, :branch, :website_path] do |_t, args|
   abort "You must have ag installed to generate docs" if `which ag` == ""
-  args.with_defaults(:website_path => "../rspec.github.io")
+  args.with_defaults(website_path: "../rspec.github.io")
   sh "git checkout #{args[:branch]} && git pull --rebase"
   cmd = "bundle install && \
          RUBYOPT='-I#{args[:website_path]}/lib' bundle exec yard \
@@ -249,6 +249,20 @@ task :update_docs, [:version, :branch, :website_path] do |t, args|
       "-i''"
     end
 
-  Bundler.clean_system %Q{pushd #{args[:website_path]}; ag -l src=\\"\\\(?:..\/\\\)*js | xargs -I{} sed #{in_place} 's/src="\\\(..\\\/\\\)*js/src="\\\/documentation\\\/#{args[:version]}\\\/rspec-rails\\\/js/' {}; popd}
-  Bundler.clean_system %Q{pushd #{args[:website_path]}; ag -l href=\\"\\\(?:..\/\\\)*css | xargs -I{} sed #{in_place} 's/href="\\\(..\\\/\\\)*css/href="\\\/documentation\\\/#{args[:version]}\\\/rspec-rails\\\/css/' {}; popd}
+  Bundler.clean_system(
+    %w(
+      pushd #{args[:website_path]};ag -l src=\\"\\\(?:..\/\\\)*js |
+      xargs -I{}
+      sed #{in_place} 's/src="\\\(..\\\/\\\)*js/src="\\\/documentation\\\/#{args[:version]}\\\/rspec-rails\\\/js/' {};
+      popd
+    ).join(" ")
+  )
+  Bundler.clean_system(
+    %w(
+      pushd #{args[:website_path]}; ag -l href=\\"\\\(?:..\/\\\)*css |
+      xargs -I{}
+      sed #{in_place} 's/href="\\\(..\\\/\\\)*css/href="\\\/documentation\\\/#{args[:version]}\\\/rspec-rails\\\/css/' {};
+      popd
+    ).join(" ")
+  )
 end

--- a/Rakefile
+++ b/Rakefile
@@ -249,20 +249,8 @@ task :update_docs, [:version, :branch, :website_path] do |_t, args|
       "-i''"
     end
 
-  Bundler.clean_system(
-    %w(
-      pushd #{args[:website_path]};ag -l src=\\"\\\(?:..\/\\\)*js |
-      xargs -I{}
-      sed #{in_place} 's/src="\\\(..\\\/\\\)*js/src="\\\/documentation\\\/#{args[:version]}\\\/rspec-rails\\\/js/' {};
-      popd
-    ).join(" ")
-  )
-  Bundler.clean_system(
-    %w(
-      pushd #{args[:website_path]}; ag -l href=\\"\\\(?:..\/\\\)*css |
-      xargs -I{}
-      sed #{in_place} 's/href="\\\(..\\\/\\\)*css/href="\\\/documentation\\\/#{args[:version]}\\\/rspec-rails\\\/css/' {};
-      popd
-    ).join(" ")
-  )
+  # rubocop: disable Layout/LineLength
+  Bundler.clean_system %{pushd #{args[:website_path]};ag -l src=\\"\\\(?:..\/\\\)*js | xargs -I{} sed #{in_place} 's/src="\\\(..\\\/\\\)*js/src="\\\/documentation\\\/#{args[:version]}\\\/rspec-rails\\\/js/' {}; popd}
+  Bundler.clean_system %{pushd #{args[:website_path]}; ag -l href=\\"\\\(?:..\/\\\)*css | xargs -I{} sed #{in_place} 's/href="\\\(..\\\/\\\)*css/href="\\\/documentation\\\/#{args[:version]}\\\/rspec-rails\\\/css/' {}; popd}
+  # rubocop: enable Layout/LineLength
 end


### PR DESCRIPTION
We are now unsynced from other rspec gems versions so I moved (a little simpler version) of the rspec-dev function to the repo.

- [x] https://github.com/rspec/rspec-rails/pull/2297 is merged

Use it like:
- `bundle exec rake "update_docs[4.0, 4-0-maintenance]"`


![Capture d’écran 2020-03-24 à 23 11 16](https://user-images.githubusercontent.com/8417720/77482006-362d3880-6e25-11ea-8a1b-338eb68582ac.png)
