### PR TITLE
Revert "Suspend jruby temporarily" because it is working now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,6 @@ script: "script/run_build 2>&1"
 dist: trusty
 
 matrix:
-  # temporary
-  allow_failures:
-    rvm: jruby-head
-
   include:
     # Rails 6 builds
     - rvm: jruby-head


### PR DESCRIPTION
This reverts commit 3e36b8f8120a0d05f49a456318033cab1db94af6.

Related:
- https://github.com/rspec/rspec-rails/pull/2294#issuecomment-603893576