### PR TITLE
Fix comparison of times for `#at` in job matchers.

### DIFF
--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -30,8 +30,12 @@ module RSpec
             self
           end
 
-          def at(date)
-            @at = date
+          def at(time_or_date)
+            case time_or_date
+            when Time then @at = Time.at(time_or_date.to_f)
+            else
+              @at = time_or_date
+            end
             self
           end
 

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -216,6 +216,13 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
       }.to have_enqueued_job.at(date)
     end
 
+    it "passes with provided at time" do
+      time = Time.now + 1.day
+      expect {
+        hello_job.set(wait_until: time).perform_later
+      }.to have_enqueued_job.at(time)
+    end
+
     it "accepts composable matchers as an at date" do
       future = 1.minute.from_now
       slightly_earlier = 58.seconds.from_now


### PR DESCRIPTION
Prior to 4.0.0 we used `to_f` to ensure parity of precision with Rails internals this was lost when we added support for date matching, but this restores it for Time objects only.

Thanks to @doits for the work on this, fixes #2299 #2301.