### PR TITLE
Temporarily allow jruby-head failures on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ script: "script/run_build 2>&1"
 dist: trusty
 
 matrix:
+  # temporary
+  allow_failures:
+    rvm: jruby-head
+
   include:
     # Rails 6 builds
     - rvm: jruby-head


### PR DESCRIPTION
There's a pull request pending to fix JRuby's deprecation messages, however some specs there fail, and there's no certainty when it will be merged.
https://github.com/jruby/jruby/pull/6166