### PR TITLE
Missing minimal Ruby version

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/rspec/rspec-rails"
   s.summary     = "RSpec for Rails"
   s.description = "rspec-rails is a testing framework for Rails 5+."
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = ">= 2.2.0"
 
   s.metadata = {
     'bug_tracker_uri'   => 'https://github.com/rspec/rspec-rails/issues',

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/rspec/rspec-rails"
   s.summary     = "RSpec for Rails"
   s.description = "rspec-rails is a testing framework for Rails 5+."
+  s.required_ruby_version = ">= 2.3.0"
 
   s.metadata = {
     'bug_tracker_uri'   => 'https://github.com/rspec/rspec-rails/issues',


### PR DESCRIPTION
Please use `required_ruby_version`...

It's too bad that 4.0 is out without this, as anyone using/testing older Rubies will have to specify manually a "<4" version in their Gemfile.

I wish [Rubygems made that mandatory](https://github.com/rubygems/rubygems/issues/3515)