### PR TITLE
Indent all extra failure lines correctly in system tests

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -114,7 +114,8 @@ module RSpec
             original_after_teardown.bind(self).call
           ensure
             myio = $stdout
-            RSpec.current_example.metadata[:extra_failure_lines] = myio.string
+            myio.rewind
+            RSpec.current_example.metadata[:extra_failure_lines] = myio.readlines
             $stdout = orig_stdout
           end
         end

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -58,6 +58,28 @@ module RSpec::Rails
           expect(example).to have_received(:driven_by).once
         end
       end
+
+      describe '#after' do
+        it 'sets the :extra_failure_lines metadata to an array of STDOUT lines' do
+          group = RSpec::Core::ExampleGroup.describe do
+            include SystemExampleGroup
+
+            before do
+              driven_by(:selenium)
+            end
+
+            def take_screenshot
+              puts 'line 1'
+              puts 'line 2'
+            end
+          end
+          example = group.it('fails') { fail }
+
+          group.run
+
+          expect(example.metadata[:extra_failure_lines]).to eq(["line 1\n", "line 2\n"])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is my first contribution to rspec-rails, so if I've missed anything, or done anything wrong, please let me know!

If the output from Rails' system test teardown is multiple lines, we should try and render all of the lines with proper indentation.

This can happen on `rails/rails@master` now that failure screenshots can include the page HTML (rails/rails@36545), and can actually happen with v6.0.2.2 if the `method_name` ends up being a little too long.