### PR TITLE
Update documentation about avaliable generators in v4

### DIFF
--- a/features/Generators.md
+++ b/features/Generators.md
@@ -25,8 +25,5 @@ The same generator pattern is available for all specs:
 * feature
 * job
 * channel
-* generator
 * mailbox
-* plugin
-* policy
 * system

--- a/features/Generators.md
+++ b/features/Generators.md
@@ -20,10 +20,11 @@ The same generator pattern is available for all specs:
 * helper
 * view
 * mailer
-* observer
 * integration
 * feature
 * job
 * channel
+* generator
 * mailbox
+* request
 * system

--- a/features/Generators.md
+++ b/features/Generators.md
@@ -24,3 +24,9 @@ The same generator pattern is available for all specs:
 * integration
 * feature
 * job
+* channel
+* generator
+* mailbox
+* plugin
+* policy
+* system


### PR DESCRIPTION
Add missing entries to the list in generator documentation.

Channel generator was introduced with version rspec 4, so patch for previous pages needs to be a little bit changed

Related with #2265 

* [x] double checked 