### PR TITLE
fix-finding-extension

### DIFF
--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -150,10 +150,12 @@ module RSpec
           match = path_regex.match(_default_file_to_render)
 
           render_options = {template: match[:template]}
-          render_options[:handlers] = [match[:handler]] if match[:handler]
+
+          # remove stringified parts when dropping rails-4.x support
+          render_options[:handlers] = [match[:handler], match[:handler].to_sym] if match[:handler]
           render_options[:formats] = [match[:format].to_sym] if match[:format]
-          render_options[:locales] = [match[:locale]] if match[:locale]
-          render_options[:variants] = [match[:variant]] if match[:variant]
+          render_options[:locales] = [match[:locale], match[:locale].to_sym] if match[:locale]
+          render_options[:variants] = [match[:variant], match[:variant].to_sym] if match[:variant]
 
           render_options
         end

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -148,19 +148,19 @@ module RSpec::Rails
         it "converts the filename components into render options" do
           allow(view_spec).to receive(:_default_file_to_render) { "widgets/new.en.html.erb" }
           view_spec.render
-          expect(view_spec.received.first).to eq([{template: "widgets/new", locales: ['en'], formats: [:html], handlers: ['erb']}, {}, nil])
+          expect(view_spec.received.first).to eq([{template: "widgets/new", locales: ['en', :en], formats: [:html], handlers: ['erb', :erb]}, {}, nil])
         end
 
         it "converts the filename with variant into render options" do
           allow(view_spec).to receive(:_default_file_to_render) { "widgets/new.en.html+fancy.erb" }
           view_spec.render
-          expect(view_spec.received.first).to eq([{template: "widgets/new", locales: ['en'], formats: [:html], handlers: ['erb'], variants: ['fancy']}, {}, nil])
+          expect(view_spec.received.first).to eq([{template: "widgets/new", locales: ['en', :en], formats: [:html], handlers: ['erb', :erb], variants: ['fancy', :fancy]}, {}, nil])
         end
 
         it "converts the filename without format into render options" do
           allow(view_spec).to receive(:_default_file_to_render) { "widgets/new.en.erb" }
           view_spec.render
-          expect(view_spec.received.first).to eq([{template: "widgets/new", locales: ['en'], handlers: ['erb']}, {}, nil])
+          expect(view_spec.received.first).to eq([{template: "widgets/new", locales: ['en', :en], handlers: ['erb', :erb]}, {}, nil])
         end
       end
 


### PR DESCRIPTION
6.x: https://github.com/rails/rails/blob/v6.0.3/actionview/lib/action_view/template/resolver.rb#L349-L351
5.x: https://github.com/rails/rails/blob/v5.2.4.3/actionview/lib/action_view/template/resolver.rb#L368-L374
4.x: https://github.com/rails/rails/blob/v4.2.11.3/actionview/lib/action_view/template/resolver.rb#L347-L349

Resolver search files and resolve most matched file with **symbolized** string,
so `_default_render_options` must return symbolized values.