### PR TITLE
FIx broken list items appearance on `Directory Structure` page

### DIFF
--- a/features/directory_structure.feature
+++ b/features/directory_structure.feature
@@ -4,10 +4,8 @@ Feature: Directory Structure
   their purpose:
 
   - [Model specs](model-specs) reside in the `spec/models` directory
-  - [Controller specs](controller-specs) reside in the `spec/controllers`
-    directory
-  - [Request specs](request-specs) reside in the `spec/requests` directory. The
-    directory can also be named `integration` or `api`.
+  - [Controller specs](controller-specs) reside in the `spec/controllers` directory
+  - [Request specs](request-specs) reside in the `spec/requests` directory. The directory can also be named `integration` or `api`.
   - [Feature specs](feature-specs) reside in the `spec/features` directory
   - [View specs](view-specs) reside in the `spec/views` directory
   - [Helper specs](helper-specs) reside in the `spec/helpers` directory


### PR DESCRIPTION
I realized broken apperance on `Directory Structure` page so tried to fix it.

![image](https://user-images.githubusercontent.com/7892834/81395511-bb16ac00-915e-11ea-8856-7bf9f478ba13.png)
