### PR TITLE
Prevent travis build from failing to install properly Google chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
   chrome: stable
   apt:
     packages:
+      - dpkg
       - chromium-chromedriver
 
 # We deviate from the rspec-dev cache setting here.

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -32,11 +32,3 @@ Given /action cable testing is available/ do
     pending "Action Cable testing is not available"
   end
 end
-
-Then "the exit status should be 0 (ignoring CI failure)" do
-  begin
-    step "the exit status should be 0"
-  rescue Exception => e # rubocop:disable Lint/RescueException
-    raise e unless ENV['CI']
-  end
-end

--- a/features/system_specs/system_specs.feature
+++ b/features/system_specs/system_specs.feature
@@ -106,4 +106,4 @@ Feature: System spec
         When I run `rspec spec/system/widget_system_spec.rb`
         Then the output should contain "1 example, 0 failures"
         And the output should not contain "starting Puma"
-        And the exit status should be 0 (ignoring CI failure)
+        And the exit status should be 0


### PR DESCRIPTION
Hello

I was upset with the failing build with selenium and wrong exit status. I compared the last green version or our build for a specific rails version against one failing build. I _diffed_ the travis output for hours.. then spotted this difference:

![Capture d’écran 2020-05-16 à 10 27 00](https://user-images.githubusercontent.com/8417720/82114914-d174c700-975f-11ea-8b4d-bf1e0fa89857.png)

`chromedriver` was not properly installed. I still don't know what is an exit status 9, and from who. But I think that's good enough.

To fix this error. Simply add `dpkg` package when we start our travis build.

Related: https://github.com/travis-ci/travis-ci/issues/9361