### PR TITLE
Switch from Trusty to Xenial on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ before_script:
 
 script: "script/run_build 2>&1"
 
-# In order to install old Rubies, we need to use old Ubuntu distibution.
-dist: trusty
-
 matrix:
   # temporary
   allow_failures:


### PR DESCRIPTION
Hello

First: https://github.com/rspec/rspec-rails/pull/2332

While I was searching for https://github.com/rspec/rspec-rails/pull/2336. Hiro from TravisCI mentioned that we should switch to Xenial. https://travis-ci.community/t/travisci-chrome-version-has-regressed-back-to-v62/8603/2?u=banzaiman
