### PR TITLE
Be able to feature test action mailbox against our example app

### DIFF
--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -105,6 +105,12 @@ using_source_path(File.expand_path(__dir__)) do
 end
 
 begin
+  require 'action_mailbox'
+  run('rails action_mailbox:install')
+rescue LoadError
+end
+
+begin
   require 'active_job'
   generate('job upload_backups')
 rescue LoadError

--- a/features/mailbox_specs/mailbox_spec.feature
+++ b/features/mailbox_specs/mailbox_spec.feature
@@ -1,0 +1,86 @@
+@rails_post_6
+Feature: action mailbox spec
+
+  Mailbox specs provide alternative assertions to those available in `ActiveMailbox::TestHelper` and help assert behaviour of how the email
+  are routed, delivered, bounced or failed.
+
+  Mailbox specs are marked by `type: :mailbox` or if you have set
+  `config.infer_spec_type_from_file_location!` by placing them in `spec/mailboxes`.
+
+  With mailbox specs you can:
+  * `process(mail_or_attributes)` - send mail directly to the mailbox under test for `process`ing.
+  * `receive_inbound_email(mail_or_attributes)` - matcher for asserting whether incoming email would route to the mailbox under test.
+  * `have_been_delivered` - matcher for asserting whether an incoming email object was delivered.
+  * `have_bounced` - matcher for asserting whether an incoming email object has bounced.
+  * `have_failed` - matcher for asserting whether an incoming email object has failed.
+
+  Background:
+    Given action mailbox is available
+
+  Scenario: Simple testing mail properly routed
+    Given a file named "app/mailboxes/application_mailbox.rb" with:
+      """ruby
+      class ApplicationMailbox < ActionMailbox::Base
+        routing (/^replies@/i) => :inbox
+      end
+      """
+    And a file named "app/maiboxes/inbox_mailbox.rb" with:
+      """ruby
+      class InboxMailbox < ApplicationMailbox
+        def process
+          case mail.subject
+          when (/^\[\d*\]/i)
+            # ok
+          when (/^\[\w*\]/i)
+            bounced!
+          else
+            raise "Invalid email subject"
+          end
+        end
+      end
+      """
+    And a file named "spec/mailboxes/inbox_mailbox_spec.rb" with:
+      """ruby
+      require 'rails_helper'
+
+      RSpec.describe InboxMailbox, type: :mailbox do
+        it "route email to properly mailbox" do
+          expect(InboxMailbox)
+            .to receive_inbound_email(to: "replies@example.com")
+        end
+
+        it "marks email as bounced when number tag in subject is valid" do
+          mail = Mail.new(
+            from: "replies@example.com",
+            subject: "[141982763] support ticket"
+          )
+          mail_processed = process(mail)
+
+          expect(mail_processed).to have_been_delivered
+        end
+
+        it "marks email as bounced when number tag in subject is invalid" do
+          mail = Mail.new(
+            from: "replies@example.com",
+            subject: "[111X] support ticket"
+          )
+          mail_processed = process(mail)
+
+          expect(mail_processed).to have_bounced
+        end
+
+        it "marks email as failed when subject is invalid" do
+          mail = Mail.new(
+            from: "replies@example.com",
+            subject: "INVALID"
+          )
+
+          expect {
+            expect(process(mail)).to have_failed
+          }.to raise_error(/Invalid email subject/)
+        end
+      end
+      """
+
+    When I run `rspec spec/mailboxes/inbox_mailbox_spec.rb`
+    Then the example should pass

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -6,6 +6,11 @@ begin
   require "action_cable"
 rescue LoadError # rubocop:disable Lint/SuppressedException
 end
+begin
+  require "active_storage"
+  require "action_mailbox"
+rescue LoadError # rubocop:disable Lint/SuppressedException
+end
 
 require "rails/version"
 
@@ -30,5 +35,11 @@ end
 Given /action cable testing is available/ do
   unless RSpec::Rails::FeatureCheck.has_action_cable_testing?
     pending "Action Cable testing is not available"
+  end
+end
+
+Given /action mailbox is available/ do
+  unless RSpec::Rails::FeatureCheck.has_action_mailbox?
+    pending "Action Mailbox is not available"
   end
 end


### PR DESCRIPTION
Hello

We need documentation on Relish for Action Mailbox. I choose to make only one feature test file for all matchers. They are straightforward.

I had to create 3 files in my scenario, but find it the clearer to explain what we do. The result can be seen here:
https://relishapp.com/rspec-staging/rspec-rails/docs/mailbox-specs/action-mailbox-spec

Close: https://github.com/rspec/rspec-rails/issues/2341

Tasks pending:
- [x] Working feature flag