### PR TITLE
Patch api_request_spec template PATCH/update

### DIFF
--- a/lib/generators/rspec/scaffold/templates/api_request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/api_request_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
       it "updates the requested <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         patch <%= show_helper.tr('@', '') %>,
-              params: { <%= singular_table_name %>: invalid_attributes }, headers: valid_headers, as: :json
+              params: { <%= singular_table_name %>: new_attributes }, headers: valid_headers, as: :json
         <%= file_name %>.reload
         skip("Add assertions for updated state")
       end
@@ -102,9 +102,9 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
       it "renders a JSON response with the <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         patch <%= show_helper.tr('@', '') %>,
-              params: { <%= singular_table_name %>: invalid_attributes }, headers: valid_headers, as: :json
+              params: { <%= singular_table_name %>: new_attributes }, headers: valid_headers, as: :json
         expect(response).to have_http_status(:ok)
-        expect(response.content_type).to eq("application/json")
+        expect(response.content_type).to match(a_string_including("application/json"))
       end
     end
 


### PR DESCRIPTION
Generating api request specs using `rails g scaffold` creates invalid default test cases for PATCH/update.

new_attributes should be used in place of invalid_attributes in the template