### PR TITLE
Prevent sprocket install failure when we are using Ruby below 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,10 @@ end
 
 gem "rubyzip", '~> 1.2'
 
+if RUBY_VERSION.to_f < 2.5
+  gem 'sprockets', '~> 3.7.0'
+end
+
 if RUBY_VERSION.to_f >= 2.3
   gem 'rubocop', '~> 0.80.1'
 end


### PR DESCRIPTION
Randomly sprocket 4 can be installed on the CI on Ruby version below 2.5.

We should not have this behavior. 

This change prevent this kind of random issue on the CI.

Related:
* https://github.com/rails/sprockets/pull/604