### PR TITLE
Remove redundant check

### DIFF
--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -33,7 +33,7 @@ if RSpec::Rails::FeatureCheck.has_active_job?
 end
 
 RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_active_job? do
-  include ActiveSupport::Testing::TimeHelpers if defined?(ActiveSupport::Testing::TimeHelpers)
+  include ActiveSupport::Testing::TimeHelpers
 
   around do |example|
     original_logger = ActiveJob::Base.logger


### PR DESCRIPTION
TimeHelpers are there starting from 4.2 at least.