### PR TITLE
Check if TestCase responds to the fixture_path setter

### DIFF
--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -18,6 +18,10 @@ module ExampleAppHooks
       copy_file 'app/views/some_templates/bar.html'
       copy_file 'spec/verify_custom_renderers_spec.rb'
       copy_file 'spec/verify_fixture_warning_spec.rb'
+      copy_file 'spec/verify_fixture_file_upload_spec.rb'
+      File.open('spec/fixtures/file_upload.txt', 'w') do |f|
+        f.write('Hello World')
+      end
       run('bin/rake db:migrate')
     end
 

--- a/example_app_generator/spec/verify_fixture_file_upload_spec.rb
+++ b/example_app_generator/spec/verify_fixture_file_upload_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe 'Example App' do
+  it 'fixture_file_upload correctly resolves' do
+    expect(fixture_file_upload('file_upload.txt', 'plain/text').tempfile.read).to eq('Hello World')
+  end
+end

--- a/lib/rspec/rails/fixture_file_upload_support.rb
+++ b/lib/rspec/rails/fixture_file_upload_support.rb
@@ -28,7 +28,7 @@ module RSpec
           # to support Rails 3.0->3.1 using ActionController::TestCase class to resolve fixture_path
           # see https://apidock.com/rails/v3.0.0/ActionDispatch/TestProcess/fixture_file_upload
           def fixture_path=(value)
-            if ActionController::TestCase.respond_to?(:fixture_path)
+            if ActionController::TestCase.respond_to?(:fixture_path=)
               ActionController::TestCase.fixture_path = value
             end
             @fixture_path = value


### PR DESCRIPTION
The existence of the getter doesn't mean there's also a setter, so this resulted in failures like the following:

```
1) Admin::CollectionsController POST #create creates a record
     Failure/Error: banner_image: fixture_file_upload('alpaca.jpg', 'image/jpg')

     NoMethodError:
       undefined method `fixture_path=' for ActionController::TestCase:Class
       Did you mean?  fixture_path
```