### PR TITLE
Improve enqueued_job at specs and warn about precision.

### DIFF
--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -225,10 +225,10 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
       }.to have_enqueued_job.at(time)
     end
 
-    skip_freeze_time = method_defined?(:freeze_time) ? false : "#freeze_time is undefined"
-    it "works with time offsets", skip: skip_freeze_time do
-      freeze_time do
-        time = Time.current
+    it "works with time offsets" do
+      # note that Time.current does not replicate Rails behavior for 5 seconds from now.
+      time = Time.current.change(usec: 0)
+      travel_to time do
         expect { hello_job.set(wait: 5).perform_later }.to have_enqueued_job.at(time + 5)
       end
     end

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -233,6 +233,17 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
       end
     end
 
+    it "warns when time offsets are inprecise" do
+      expect(RSpec).to receive(:warn_with).with(/precision error/)
+
+      time = Time.current.change(usec: 550)
+      travel_to time do
+        expect {
+          expect { hello_job.set(wait: 5).perform_later }.to have_enqueued_job.at(time + 5)
+        }.to raise_error(/expected to enqueue exactly 1 jobs/)
+      end
+    end
+
     it "accepts composable matchers as an at date" do
       future = 1.minute.from_now
       slightly_earlier = 58.seconds.from_now


### PR DESCRIPTION
There is an issue with our time matching for `enqueued_job`, Rails allows microsecond (usec) precision in job queue values, and uses `.to_f` for exact time scheduling, which we replicated in #2157, without this `to_f` you cannot check exact time scheduled jobs.

However when Rails schedules a job in the future using `wait: n` it is doing `n.seconds.from_now` which does not get passed through `to_f`, there is no way for us to detect which is correct so we'll stick with out existing handling, but warn about this precision issue, adding `change(usec: 0)` or switching to `n.seconds.from_now`...

Ironically I found this by trying to remove `freeze_time` from our own specs, it appears that `travel_to` specific time, keeps `usec` precision, but not `freeze_time`?