### PR TITLE
Change the expectation for predicate methods

### DIFF
--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -1,3 +1,4 @@
+# rubocop: disable Metrics/ModuleLength
 module RSpec
   module Rails
     # Fake class to document RSpec Rails configuration options. In practice,
@@ -184,3 +185,4 @@ module RSpec
     initialize_configuration RSpec.configuration
   end
 end
+# rubocop: enable Metrics/ModuleLength

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -105,7 +105,35 @@ module RSpec
         end
 
         def render_views?
-          rendering_views
+          rendering_views?
+        end
+
+        def rendering_views?
+          !!rendering_views
+        end
+
+        # Define boolean predicates rather than relying on rspec-core due
+        # to the bug fix in rspec/rspec-core#2736, note some of these
+        # predicates are a bit nonsensical, but they exist for backwards
+        # compatibility, we can tidy these up in `rspec-rails` 5.
+        def fixture_path?
+          !!fixture_path
+        end
+
+        def global_fixtures?
+          !!global_fixtures
+        end
+
+        def infer_base_class_for_anonymous_controllers?
+          !!infer_base_class_for_anonymous_controllers
+        end
+
+        def use_instantiated_fixtures?
+          !!use_instantiated_fixtures
+        end
+
+        def use_transactional_fixtures?
+          !!use_transactional_fixtures
         end
 
         def infer_spec_type_from_file_location!

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -23,18 +23,28 @@ RSpec.describe "Configuration" do
     opts ||= {}
     default_value = opts[:default]
     alias_setting = opts[:alias_with]
-    query_method = "#{accessor}?".to_sym
+    predicate_method = "#{accessor}?".to_sym
     command_method = "#{accessor}=".to_sym
 
-    specify "`##{query_method}` is `#{default_value.inspect}` by default" do
-      expect(config.send(query_method)).to be(default_value)
+    specify "`##{accessor}` is `#{default_value.inspect}` by default" do
+      expect(config.send(accessor)).to eq default_value
+    end
+
+    specify "`##{predicate_method}` is `#{!!default_value}` by default" do
+      expect(config.send(predicate_method)).to be !!default_value
+    end
+
+    specify "`##{predicate_method}` is `#{!!default_value}` by default" do
+      expect(config.send(predicate_method)).to be !!default_value
     end
 
     describe "`##{command_method}`" do
-      it "changes `#{query_method}` to the provided value" do
+      it "changes `#{predicate_method}` to the true for a truthy value" do
+        config.send(command_method, nil)
+        expect(config.send(predicate_method)).to be false
         expect {
           config.send(command_method, :a_value)
-        }.to change { config.send(query_method) }.to(:a_value)
+        }.to change { config.send(predicate_method) }.to(true)
       end
 
       it "sets `#{accessor}` to the provided value" do
@@ -72,8 +82,8 @@ RSpec.describe "Configuration" do
 
     include_examples "adds setting", :rendering_views
 
-    specify "`#render_views?` is falsey by default" do
-      expect(config.render_views?).to be_falsey
+    specify "`#render_views?` is false by default" do
+      expect(config.render_views?).to be false
     end
 
     specify "`#render_views` sets `render_views?` to `true`" do
@@ -83,16 +93,14 @@ RSpec.describe "Configuration" do
     end
 
     describe "`#render_views=`" do
-      it "sets `render_views?` to the provided value" do
-        expect {
-          config.render_views = false
-        }.to change { config.render_views? }.from(nil).to(false)
-      end
-
-      it "sets `render_views` to the provided value" do
+      it "sets `render_views?` to the truthyness of the provided value" do
         expect {
           config.render_views = :a_value
-        }.to change { config.render_views? }.to(:a_value)
+        }.to change { config.render_views? }.from(false).to(true)
+        # this is repeated to put the value back to false
+        expect {
+          config.render_views = false
+        }.to change { config.render_views? }.from(true).to(false)
       end
     end
   end


### PR DESCRIPTION
Predicate methods typically return true or false, and should only exist for the uncountable and discrete, e.g. `use_transactional_fixtures?`, but not `max_formatted_output_length?`.

This relates to the changes made in https://github.com/rspec/rspec-core/pull/2736