### PR TITLE
Backport config changes from 4-0-maintenance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### Development
+[Full Changelog](https://github.com/rspec/rspec-rails/compare/v3.9.1...3-9-maintenance)
+
+Bug Fixes:
+
+* Return `true`/`false` from predicate methods in config rather than raw values.
+  (Phil Pirozhkov, Jon Rowe, #2353, #2354)
+
 ### 3.9.1 / 2020-03-10
 [Full Changelog](http://github.com/rspec/rspec-rails/compare/v3.9.0...v3.9.1)
 

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -1,3 +1,4 @@
+# rubocop: disable Metrics/ModuleLength
 module RSpec
   module Rails
     # Fake class to document RSpec Rails configuration options. In practice,
@@ -53,8 +54,7 @@ module RSpec
     end
 
     # @private
-    # rubocop:disable Style/MethodLength
-    def self.initialize_configuration(config)
+    def self.initialize_configuration(config) # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity
       config.backtrace_exclusion_patterns << /vendor\//
       config.backtrace_exclusion_patterns << %r{lib/rspec/rails}
 
@@ -103,7 +103,41 @@ module RSpec
         end
 
         def render_views?
-          rendering_views
+          rendering_views?
+        end
+
+        undef :rendering_views? if respond_to?(:rendering_views?)
+        def rendering_views?
+          !!rendering_views
+        end
+
+        # Define boolean predicates rather than relying on rspec-core due
+        # to the bug fix in rspec/rspec-core#2736, note some of these
+        # predicates are a bit nonsensical, but they exist for backwards
+        # compatibility, we can tidy these up in `rspec-rails` 5.
+        undef :fixture_path? if respond_to?(:fixture_path?)
+        def fixture_path?
+          !!fixture_path
+        end
+
+        undef :global_fixtures? if respond_to?(:global_fixtures?)
+        def global_fixtures?
+          !!global_fixtures
+        end
+
+        undef :infer_base_class_for_anonymous_controllers? if respond_to?(:infer_base_class_for_anonymous_controllers?)
+        def infer_base_class_for_anonymous_controllers?
+          !!infer_base_class_for_anonymous_controllers
+        end
+
+        undef :use_instantiated_fixtures? if respond_to?(:use_instantiated_fixtures?)
+        def use_instantiated_fixtures?
+          !!use_instantiated_fixtures
+        end
+
+        undef :use_transactional_fixtures? if respond_to?(:use_transactional_fixtures?)
+        def use_transactional_fixtures?
+          !!use_transactional_fixtures
         end
 
         def infer_spec_type_from_file_location!
@@ -146,3 +180,4 @@ module RSpec
     initialize_configuration RSpec.configuration
   end
 end
+# rubocop: enable Metrics/ModuleLength

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -24,18 +24,28 @@ RSpec.describe "Configuration" do
     opts ||= {}
     default_value = opts[:default]
     alias_setting = opts[:alias_with]
-    query_method = "#{accessor}?".to_sym
+    predicate_method = "#{accessor}?".to_sym
     command_method = "#{accessor}=".to_sym
 
-    specify "`##{query_method}` is `#{default_value.inspect}` by default" do
-      expect(config.send(query_method)).to be(default_value)
+    specify "`##{accessor}` is `#{default_value.inspect}` by default" do
+      expect(config.send(accessor)).to eq default_value
+    end
+
+    specify "`##{predicate_method}` is `#{!!default_value}` by default" do
+      expect(config.send(predicate_method)).to be !!default_value
+    end
+
+    specify "`##{predicate_method}` is `#{!!default_value}` by default" do
+      expect(config.send(predicate_method)).to be !!default_value
     end
 
     describe "`##{command_method}`" do
-      it "changes `#{query_method}` to the provided value" do
+      it "changes `#{predicate_method}` to the true for a truthy value" do
+        config.send(command_method, nil)
+        expect(config.send(predicate_method)).to be false
         expect {
           config.send(command_method, :a_value)
-        }.to change { config.send(query_method) }.to(:a_value)
+        }.to change { config.send(predicate_method) }.to(true)
       end
 
       it "sets `#{accessor}` to the provided value" do
@@ -73,8 +83,8 @@ RSpec.describe "Configuration" do
 
     include_examples "adds setting", :rendering_views
 
-    specify "`#render_views?` is falsey by default" do
-      expect(config.render_views?).to be_falsey
+    specify "`#render_views?` is false by default" do
+      expect(config.render_views?).to be false
     end
 
     specify "`#render_views` sets `render_views?` to `true`" do
@@ -84,16 +94,14 @@ RSpec.describe "Configuration" do
     end
 
     describe "`#render_views=`" do
-      it "sets `render_views?` to the provided value" do
-        expect {
-          config.render_views = false
-        }.to change { config.render_views? }.from(nil).to(false)
-      end
-
-      it "sets `render_views` to the provided value" do
+      it "sets `render_views?` to the truthyness of the provided value" do
         expect {
           config.render_views = :a_value
-        }.to change { config.render_views? }.to(:a_value)
+        }.to change { config.render_views? }.from(false).to(true)
+        # this is repeated to put the value back to false
+        expect {
+          config.render_views = false
+        }.to change { config.render_views? }.from(true).to(false)
       end
     end
   end


### PR DESCRIPTION
Backports the change the expectation for predicate methods so the build passes.