### PR TITLE
No need to add rspec-rails to :development group

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,22 @@ Use **[`rspec-rails` 1.x][]** for Rails 2.x.
 **IMPORTANT** This README / branch refers to the current development build.
 See the `4-0-maintenance` branch on Github if you want or require the latest stable release.
 
-1. Add `rspec-rails` to **both** the `:development` and `:test` groups
-   of your app’s `Gemfile`:
+1. Add `rspec-rails` to the `:test` group of your app’s `Gemfile`:
 
    ```ruby
    # Run against the latest stable release
-   group :development, :test do
+   group :test do
      gem 'rspec-rails', '~> 4.0.0'
    end
 
    # Or, run against the master branch
    # (requires master-branch versions of all related RSpec libraries)
-   group :development, :test do
+   group test do
      %w[rspec-core rspec-expectations rspec-mocks rspec-rails rspec-support].each do |lib|
        gem lib, git: "https://github.com/rspec/#{lib}.git", branch: 'master'
      end
    end
    ```
-
-   (Adding it to the `:development` group is not strictly necessary,
-   but without it, generators and rake tasks must be preceded by `RAILS_ENV=test`.)
 
 2. Then, in your project directory:
 

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -66,7 +66,7 @@ in_root do
     |
     |gem 'rspec-rails',
     |    :path => '#{rspec_rails_repo_path}',
-    |    :groups => [:development, :test]
+    |    :groups => [:test]
     |eval_gemfile '#{rspec_dependencies_gemfile}'
     |eval_gemfile '#{rails_dependencies_gemfile}'
   EOT

--- a/features/GettingStarted.md
+++ b/features/GettingStarted.md
@@ -9,7 +9,7 @@ Install Rails 6
 
 ### Add rspec-rails to the Gemfile
 
-    $ echo 'gem "rspec-rails", group: [:development, :test]' >> Gemfile
+    $ echo 'gem "rspec-rails", group: :test' >> Gemfile
 
 ### Install the bundle
 

--- a/features/README.md
+++ b/features/README.md
@@ -21,14 +21,11 @@ This installs the following gems:
 
 ## Configure
 
-Add rspec-rails to the :test and :development groups in the Gemfile:
+Add rspec-rails to the :test group in the Gemfile:
 
-    group :test, :development do
+    group :test do
       gem 'rspec-rails', '~> 4.0.0'
     end
-
-It needs to be in the :development group to expose generators and rake tasks
-without having to type RAILS_ENV=test.
 
 Now you can run:
 


### PR DESCRIPTION
Because rails generator works fine without it.

I confirmed by running the following command with rails 6.0.3.2 and rspec-rails 4.0.1:

```sh
rails new my_app
cd my_app
echo "gem 'rspec-rails', group: :test" >> Gemfile
bundle install
yarn install --check-files
rails g rspec:install
```