### PR TITLE
Reflect latest version (4.0.1) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See the `4-0-maintenance` branch on Github if you want or require the latest sta
    ```ruby
    # Run against the latest stable release
    group :development, :test do
-     gem 'rspec-rails', '~> 4.0.0'
+     gem 'rspec-rails', '~> 4.0.1'
    end
 
    # Or, run against the master branch


### PR DESCRIPTION
Hi, I hope that all of you who keep this gem are doing well.

I noticed that the Readme is not reporting the latest version.

This PR aims to update this information.