### PR TITLE
Fix fixture_file_upload for active record not present

### DIFF
--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -45,6 +45,7 @@ module ExampleAppHooks
     def final_tasks
       copy_file 'spec/verify_no_active_record_spec.rb'
       copy_file 'spec/verify_no_fixture_setup_spec.rb'
+      copy_file 'spec/verify_fixture_file_upload_spec.rb'
     end
 
     def skip_active_record?

--- a/example_app_generator/no_active_record/spec/verify_fixture_file_upload_spec.rb
+++ b/example_app_generator/no_active_record/spec/verify_fixture_file_upload_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe 'Example App', :use_fixtures, type: :model do
+  it 'supports fixture file upload' do
+    file = fixture_file_upload(__FILE__)
+    expect(file.read).to match(/RSpec\.describe 'Example App'/im)
+  end
+end

--- a/lib/rspec/rails/fixture_file_upload_support.rb
+++ b/lib/rspec/rails/fixture_file_upload_support.rb
@@ -8,7 +8,12 @@ module RSpec
 
       def rails_fixture_file_wrapper
         RailsFixtureFileWrapper.fixture_path = nil
-        resolved_fixture_path = (fixture_path || RSpec.configuration.fixture_path || '').to_s
+        resolved_fixture_path =
+          if respond_to?(:fixture_path) && !fixture_path.nil?
+            fixture_path.to_s
+          else
+            (RSpec.configuration.fixture_path || '').to_s
+          end
         RailsFixtureFileWrapper.fixture_path = File.join(resolved_fixture_path, '') unless resolved_fixture_path.strip.empty?
         RailsFixtureFileWrapper.instance
       end


### PR DESCRIPTION
In the process of reviewing #2349 I found that currently, fixture_file_upload breaks in a non active record app due to the lack of fixture_path, this rectifies that.