### PR TITLE
Lock gems that fail to install on certain Ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,8 +49,12 @@ gem 'rake', '~> 12'
 
 gem 'mime-types', "~> 3"
 
-if RUBY_VERSION.to_f == 2.2
+if RUBY_VERSION.to_f < 2.3
   gem 'capybara', '~> 3.1.0'
+elsif RUBY_VERSION.to_f < 2.4
+  gem 'capybara', '< 3.16'
+elsif RUBY_VERSION.to_f < 2.5
+  gem 'capybara', '< 3.33'
 else
   gem 'capybara', '>= 2.13', '< 4.0', require: false
 end

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -18,6 +18,7 @@ when /stable$/
   gem_list = %w[rails railties actionmailer actionpack activerecord activesupport activejob actionview]
   gem 'puma', "3.12.1" if version > '5-0-stable'
   gem 'activerecord-jdbcsqlite3-adapter', git: 'https://github.com/jruby/activerecord-jdbc-adapter', platforms: [:jruby]
+  gem "sprockets", '~> 3.0' if RUBY_VERSION < '2.5'
 
   gem_list.each do |rails_gem|
     gem rails_gem, :git => "https://github.com/rails/rails.git", :branch => version
@@ -28,7 +29,7 @@ when nil, false, ""
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
 else
   gem "rails", version
-
+  gem "sprockets", '~> 3.0' if RUBY_VERSION < '2.5'
   gem "puma" if version >= '5-1-stable'
 
   if version.gsub(/[^\d\.]/,'').to_f >= 6.0

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -35,11 +35,22 @@ in_root do
     gsub_file "Gemfile", /.*rails-controller-testing.*/, "gem 'rails-controller-testing', git: 'https://github.com/rails/rails-controller-testing'"
   end
 
+  if RUBY_VERSION < "2.3.0"
+    gsub_file "Gemfile", /.*childprocess.*/, "gem 'childprocess', '< 2.0.0'"
+    gsub_file "Gemfile", /.*i18n.*/, "gem 'i18n', '< 1.5.2'"
+    gsub_file "Gemfile", /.*nio4r.*/, "gem 'nio4r', '< 2.4.0'"
+    gsub_file "Gemfile", /.*public_suffix.*/, "gem 'public_suffix', '< 4.0.0'"
+    gsub_file "Gemfile", /.*rack.*/, "gem 'rack', '< 2.2.0', '!= 2.1.0'"
+    gsub_file "Gemfile", /.*xpath.*/, "gem 'xpath', '< 3.2.0'"
+  end
+
   if Rails::VERSION::STRING >= "5.1.0"
     if RUBY_VERSION < "2.3"
       gsub_file "Gemfile", /.*capybara.*/, "gem 'capybara', '~> 3.1.0'"
     elsif RUBY_VERSION < "2.4"
       gsub_file "Gemfile", /.*capybara.*/, "gem 'capybara', '~> 3.15.0'"
+    elsif RUBY_VERSION < "2.5"
+      gsub_file "Gemfile", /.*capybara.*/, "gem 'capybara', '~> 3.32.0'"
     end
     if Rails::VERSION::STRING >= "5.2.0"
       gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers', '< 4.0.0'"


### PR DESCRIPTION
Bundler fails to install several gems. It seems that Ruby version constraint is ignored.

E.g. Sprockets 4.0 depend on Ruby >= 2.5 https://rubygems.org/gems/sprockets/versions/4.0.0
This results in build failures (https://travis-ci.org/github/rspec/rspec-rails/jobs/713253057):

    Installing sprockets 4.0.2
    Gem::RuntimeRequirementNotMetError: sprockets requires Ruby version >= 2.5.0.
    The current ruby version is 2.4.10.364.

Surprisingly, Ruby 2.3.8 and Ruby 2.2.10 builds don't fail, and install sprockets 3.7.2.

This is a forgotten forward-port from https://github.com/rspec/rspec-rails/pull/2360/files#diff-8c3955be04b733dbd31e54e50844fb84R31