### PR TITLE
Experimental removal of Rubygems workarounds (3-9-maintenance)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,73 +24,9 @@ end
 
 gem 'sqlite3', '~> 1.3.6'
 
-if RUBY_VERSION >= '2.4.0'
-  gem 'json', '>= 2.0.2'
-end
+gem 'ffi'
 
-if RUBY_VERSION < '1.9'
-  gem 'ffi', '< 1.9.19' # ffi dropped Ruby 1.8 support in 1.9.19
-elsif RUBY_VERSION < '2.0'
-  gem 'ffi', '< 1.11.0' # ffi dropped Ruby 2.0 support in 1.11.0
-elsif RUBY_VERSION < '2.3'
-  gem 'ffi', '< 1.13.0'
-end
-
-if RUBY_VERSION >= '2.0.0'
-  gem 'rake', '>= 10.0.0'
-elsif RUBY_VERSION >= '1.9.3'
-  gem 'rake', '< 12.0.0' # rake 12 requires Ruby 2.0.0 or later
-else
-  gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later
-end
-
-# Version 3 of mime-types 3 requires Ruby 2.0
-if RUBY_VERSION < '2.0.0'
-  gem 'mime-types', '< 3'
-end
-
-# Version 5.12 of minitest requires Ruby 2.4
-if RUBY_VERSION < '2.4.0'
-  gem 'minitest', '< 5.12.0'
-end
-
-# Capybara versions that support RSpec 3 only support RUBY_VERSION >= 1.9.3
-if RUBY_VERSION >= '1.9.3'
-  if /5(\.|-)[1-9]\d*/ === RAILS_VERSION || "master" == RAILS_VERSION
-    gem 'capybara', '~> 2.13', :require => false
-  else
-    gem 'capybara', '~> 2.2.0', :require => false
-  end
-end
-
-# Rack::Cache 1.3.0 requires Ruby >= 2.0.0
-gem 'rack-cache', '< 1.3.0' if RUBY_VERSION < '2.0.0'
-
-if RUBY_VERSION < '1.9.2'
-  gem 'nokogiri', '~> 1.5.0'
-elsif RUBY_VERSION < '1.9.3'
-  gem 'nokogiri', '1.5.2'
-elsif RUBY_VERSION < '2.1.0'
-  gem 'nokogiri', '1.6.8.1'
-elsif RUBY_VERSION < '2.3.0'
-  gem 'nokogiri', '1.8.5'
-else
-  gem 'nokogiri', '~> 1.10'
-end
-
-if RUBY_VERSION <= '1.8.7'
-  # cucumber and gherkin require rubyzip as a runtime dependency on 1.8.7
-  # Only < 1.0 supports 1.8.7
-  gem 'rubyzip', '< 1.0'
-elsif RUBY_VERSION < '2.4'
-  gem 'rubyzip', '>= 1.2.2', '< 2.0.0'
-end
-
-if RUBY_VERSION >= '2.0.0' && RUBY_VERSION < '2.2.0'
-  # our current rubocop version doesn't support the json version required by Ruby 2.4
-  # our rails rubocop setup only supports 2.0 and 2.1
-  gem 'rubocop', "~> 0.23.0"
-end
+gem 'capybara', :require => false
 
 custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)
 eval_gemfile custom_gemfile if File.exist?(custom_gemfile)

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -14,9 +14,7 @@ when /master/
   gem 'i18n', :git => 'https://github.com/svenfuchs/i18n.git', :branch => 'master'
   gem 'sprockets', :git => 'https://github.com/rails/sprockets.git', :branch => 'master'
   gem 'sprockets-rails', :git => 'https://github.com/rails/sprockets-rails.git', :branch => 'master'
-  if RUBY_VERSION  >= "2.2"
-    gem 'puma', :git => 'https://github.com/puma/puma', :branch => 'master'
-  end
+  gem 'puma', :git => 'https://github.com/puma/puma', :branch => 'master'
 when /stable$/
   gem_list = %w[rails railties actionmailer actionpack activerecord activesupport]
   gem_list << 'activejob'  if version > '4-1-stable'
@@ -30,15 +28,7 @@ when /stable$/
 
   gem "sprockets", '~> 3.0' if RUBY_VERSION < '2.5' && version >= '4-0-stable'
 when nil, false, ""
-  if RUBY_VERSION < '1.9.3'
-    # Rails 4+ requires 1.9.3+, so on earlier versions default to the last 3.x release.
-    gem "rails", "~> 3.2.17"
-  elsif RUBY_VERSION < '2.2.0'
-    # Rails 5+ requires 2.2+, so on earlier versions default to the last 4.x release.
-    gem "rails", "~> 4.2.0"
-  else
-    gem "rails", "~> 5.0.0"
-  end
+  gem "rails"
 else
   gem "rails", version
 
@@ -48,43 +38,7 @@ else
     gem "puma"
   end
 
-  gem "sprockets", '~> 3.0' if RUBY_VERSION < '2.5' && major_minor_version >= 4.0
+  gem "sprockets"
 
-  if major_minor_version >= 6.0
-    gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", :platforms => [:jruby]
-  else
-    gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
-  end
+  gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
 end
-
-gem "childprocess", '< 2.0.0' if RUBY_VERSION < '2.3'
-
-if RUBY_VERSION < '1.9.3'
-  gem "i18n", '< 0.7.0'
-elsif RUBY_VERSION < '2.3.0'
-  gem "i18n", '< 1.5.2'
-end
-
-gem "nio4r", '< 2.4.0' if RUBY_VERSION < '2.3'
-
-if RUBY_VERSION < '1.9.3'
-  gem "public_suffix", '< 1.4.0'
-elsif RUBY_VERSION < '2.0'
-  gem "public_suffix", '< 2.0.0'
-elsif RUBY_VERSION < '2.1'
-  gem "public_suffix", '< 3.0.0'
-elsif RUBY_VERSION < '2.3'
-  gem "public_suffix", '< 4.0.0'
-end
-
-# rack 2.1.0 introduces a deprecation warning that rails is triggering,
-# but in later versions this warning is removed.
-if RUBY_VERSION < '2.2'
-  gem "rack", '< 2.0.0', '!= 2.1.0'
-elsif RUBY_VERSION < '2.3'
-  gem "rack", '< 2.2.0', '!= 2.1.0'
-end
-
-gem "test-unit" if RUBY_VERSION >= '2.2.0' && version =~ /3[.-]2[.-]/
-
-gem "xpath", '< 3.2.0' if RUBY_VERSION < '2.3'


### PR DESCRIPTION
Due to unstable version resolution and lack of Ruby version constraints on older gemspecs in the Rubygems database, we had to manually declare versions to be used.

This has seemingly been fixed.

Related:
https://github.com/rubygems/rubygems/issues/3463
https://github.com/rubygems/rubygems.org/pull/2474
https://github.com/rubygems/rubygems/pull/2662

Let's see if it works now, and if the issue with IPv6 fallback is still the case.