### PR TITLE
Experimental removal of Rubygems workarounds (main branch)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,61 +14,30 @@ group :documentation do
   gem 'relish', '~> 0.7.1'
 end
 
-platforms :jruby do
-  gem "jruby-openssl"
-end
-
-case RAILS_VERSION
-when /main/
-  MAJOR = 6
-  MINOR = 0
-when /5-2-stable/
-  MAJOR = 5
-  MINOR = 2
-when /stable/
-  MAJOR = 6
-  MINOR = 0
-when nil, false, ""
-  MAJOR = 6
-  MINOR = 0
-else
-  match = /(\d+)(\.|-)(\d+)/.match(RAILS_VERSION)
-  MAJOR, MINOR = match.captures.map(&:to_i).compact
-end
-
-if MAJOR >= 6
-  gem 'selenium-webdriver', '~> 3.5', require: false
-  gem 'sqlite3', '~> 1.4', platforms: [:ruby]
-else
-  gem 'sqlite3', '~> 1.3.6', platforms: [:ruby]
-end
-
-gem 'ffi', '~> 1.9.25'
-
 gem 'rake', '~> 12'
-
-gem 'mime-types', "~> 3"
-
-if RUBY_VERSION.to_f < 2.3
-  gem 'capybara', '~> 3.1.0'
-elsif RUBY_VERSION.to_f < 2.4
-  gem 'capybara', '< 3.16'
-elsif RUBY_VERSION.to_f < 2.5
-  gem 'capybara', '< 3.33'
-else
-  gem 'capybara', '>= 2.13', '< 4.0', require: false
-end
-
-if MAJOR < 6
-  gem 'nokogiri', '1.9.1'
-else
-  gem 'nokogiri', '>= 1.10.8'
-end
-
-gem "rubyzip", '~> 1.2'
 
 if RUBY_VERSION.to_f >= 2.3
   gem 'rubocop', '~> 0.80.1'
+end
+
+gem 'capybara'
+
+MAJOR =
+  case RAILS_VERSION
+  when /5-2-stable/
+    5
+  when /main/, /stable/, nil, false, ''
+    6
+  else
+    /(\d+)[\.|-]\d+/.match(RAILS_VERSION).captures.first.to_i
+  end
+
+if MAJOR >= 6
+  # sqlite3 is an optional, unspecified, dependency and Rails 6.0 only supports `~> 1.4`
+  gem 'sqlite3', '~> 1.4', platforms: [:ruby]
+else
+  # Similarly, Rails 5.0 only supports '~> 1.3.6'. Rails 5.1-5.2 support '~> 1.3', '>= 1.3.6'
+  gem 'sqlite3', '~> 1.3.6', platforms: [:ruby]
 end
 
 custom_gemfile = File.expand_path('Gemfile-custom', __dir__)

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :documentation do
   gem 'relish', '~> 0.7.1'
 end
 
-gem 'rake', '~> 12'
+gem 'rake', '> 12'
 
 if RUBY_VERSION.to_f >= 2.3
   gem 'rubocop', '~> 0.80.1'

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -14,11 +14,11 @@ when /main/
   gem 'sprockets-rails', :git => 'https://github.com/rails/sprockets-rails.git', :branch => 'master'
   gem 'puma', "3.12.1"
   gem 'activerecord-jdbcsqlite3-adapter', git: 'https://github.com/jruby/activerecord-jdbc-adapter', platforms: [:jruby]
+  gem 'selenium-webdriver', require: false
 when /stable$/
   gem_list = %w[rails railties actionmailer actionpack activerecord activesupport activejob actionview]
   gem 'puma', "3.12.1" if version > '5-0-stable'
   gem 'activerecord-jdbcsqlite3-adapter', git: 'https://github.com/jruby/activerecord-jdbc-adapter', platforms: [:jruby]
-  gem "sprockets", '~> 3.0' if RUBY_VERSION < '2.5'
 
   gem_list.each do |rails_gem|
     gem rails_gem, :git => "https://github.com/rails/rails.git", :branch => version
@@ -27,14 +27,13 @@ when nil, false, ""
   gem "rails", "~> 6.0.0"
   gem "puma"
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
+  gem 'selenium-webdriver', require: false
 else
   gem "rails", version
   gem "sprockets", '~> 3.0' if RUBY_VERSION < '2.5'
   gem "puma" if version >= '5-1-stable'
-
-  if version.gsub(/[^\d\.]/,'').to_f >= 6.0
-    gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", platforms: [:jruby]
-  else
-    gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
-  end
+  gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
+  gem 'selenium-webdriver', require: false if version >= '5'
 end
+
+gem 'jruby-openssl', platforms: [:jruby]

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -21,54 +21,40 @@ in_root do
   gsub_file 'Gemfile', /^.*\bgem 'rails.*$/, ''
   gsub_file "Gemfile", /.*web-console.*/, ''
   gsub_file "Gemfile", /.*debugger.*/, ''
-  gsub_file "Gemfile", /.*byebug.*/, "gem 'byebug', '~> 9.0.6'"
-  gsub_file "Gemfile", /.*puma.*/, ""
-  gsub_file "Gemfile", /.*gem..sqlite3.*/, "gem 'sqlite3', '~> 1.3.6'"
-  gsub_file "Gemfile", /.*bootsnap.*/, ""
+  gsub_file "Gemfile", /.*puma.*/, ''
+  gsub_file "Gemfile", /.*bootsnap.*/, ''
 
-  if Rails::VERSION::STRING >= '5.0.0'
-    append_to_file('Gemfile', "gem 'rails-controller-testing'\n")
+  # We soft-support Rails 4.2. `rails-controller-testing` only supports Rails 5+.
+  # This conditional is to facilitate local testing against Rails 4.2.
+  if Rails::VERSION::STRING >= '5'
+    append_to_file 'Gemfile', "gem 'rails-controller-testing'\n"
   end
 
   if Rails::VERSION::STRING >= '6'
-    gsub_file "Gemfile", /.*gem..sqlite3.*/, "gem 'sqlite3', '~> 1.4'"
     gsub_file "Gemfile", /.*rails-controller-testing.*/, "gem 'rails-controller-testing', git: 'https://github.com/rails/rails-controller-testing'"
   end
 
-  if RUBY_VERSION < "2.3.0"
-    gsub_file "Gemfile", /.*childprocess.*/, "gem 'childprocess', '< 2.0.0'"
-    gsub_file "Gemfile", /.*i18n.*/, "gem 'i18n', '< 1.5.2'"
-    gsub_file "Gemfile", /.*nio4r.*/, "gem 'nio4r', '< 2.4.0'"
-    gsub_file "Gemfile", /.*public_suffix.*/, "gem 'public_suffix', '< 4.0.0'"
-    gsub_file "Gemfile", /.*rack.*/, "gem 'rack', '< 2.2.0', '!= 2.1.0'"
-    gsub_file "Gemfile", /.*xpath.*/, "gem 'xpath', '< 3.2.0'"
+  if Rails::VERSION::STRING >= '6'
+    # sqlite3 is an optional, unspecified, dependency and Rails 6.0 only supports `~> 1.4`
+    gsub_file "Gemfile", /.*gem..sqlite3.*/, "gem 'sqlite3', '~> 1.4'"
+  else
+    # Similarly, Rails 5.0 only supports '~> 1.3.6'. Rails 5.1-5.2 support '~> 1.3', '>= 1.3.6'
+    gsub_file "Gemfile", /.*gem..sqlite3.*/, "gem 'sqlite3', '~> 1.3.6'"
   end
 
   if Rails::VERSION::STRING >= "5.1.0"
-    if RUBY_VERSION < "2.3"
-      gsub_file "Gemfile", /.*capybara.*/, "gem 'capybara', '~> 3.1.0'"
-    elsif RUBY_VERSION < "2.4"
-      gsub_file "Gemfile", /.*capybara.*/, "gem 'capybara', '~> 3.15.0'"
-    elsif RUBY_VERSION < "2.5"
-      gsub_file "Gemfile", /.*capybara.*/, "gem 'capybara', '~> 3.32.0'"
-    end
-    if Rails::VERSION::STRING >= "5.2.0"
-      gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers', '< 4.0.0'"
-    else
-      gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers'"
-    end
+    # webdrivers 4 up until 4.3.0 don't specify `required_ruby_version`, but contain
+    # Ruby 2.2-incompatible syntax (safe navigation).
+    # That basically means we use pre-4.0 for Ruby 2.2, and 4.3+ for newer Rubies.
+    gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers', '!= 4.0.0', '!= 4.0.1', '!= 4.1.0', '!= 4.1.1', '!= 4.1.2', '!= 4.1.3', '!= 4.2.0'"
   end
 
   if Rails::VERSION::STRING >= '5.2.0' && Rails::VERSION::STRING < '6'
     copy_file sqlite_initializer, 'config/initializers/sqlite3_fix.rb'
   end
 
-  # Nokogiri version is pinned in rspec-rails' Gemfile since it tend to cause installation problems
-  # on Travis CI, so we pin nokogiri in this example app also.
-  if RUBY_ENGINE != "jruby"
-    append_to_file 'Gemfile', "gem 'nokogiri', '#{Nokogiri::VERSION}'\n"
-  else
-    gsub_file "Gemfile", /.*jdbc.*/, ""
+  if RUBY_ENGINE == "jruby"
+    gsub_file "Gemfile", /.*jdbc.*/, ''
   end
 
   # Use our version of RSpec and Rails


### PR DESCRIPTION
Due to unstable version resolution and lack of Ruby version constraints on older gemspecs in the Rubygems database, we had to manually declare versions to be used.

This has seemingly been fixed.

Related:
https://github.com/rubygems/rubygems/issues/3463
https://github.com/rubygems/rubygems.org/pull/2474
https://github.com/rubygems/rubygems/pull/2662

Let's see if it works now, and if the issue with IPv6 fallback is still the case.