### PR TITLE
Drop `git` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_from:
   - .rubocop_todo.yml
 
+require:
+  - rubocop-packaging
+
 AllCops:
   Exclude:
     # Templates are really ERB which Rubocop does not parse
@@ -119,6 +122,9 @@ Lint/EmptyExpression:
   Enabled: false
 
 Lint/ImplicitStringConcatenation:
+  Enabled: false
+
+Lint/MissingSuper:
   Enabled: false
 
 Lint/NestedMethodDefinition:
@@ -280,9 +286,6 @@ Style/IfInsideElse:
   Enabled: false
 
 Style/IfUnlessModifier:
-  Enabled: false
-
-Style/MethodMissingSuper:
   Enabled: false
 
 Style/MissingRespondToMissing:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,6 +1,6 @@
 # Over time we'd like to get this down, but this is what we're at now.
 Metrics/CyclomaticComplexity:
-  Max: 9 # default: 6
+  Max: 10 # default: 6
 
 # Over time we'd like to get this down, but this is what we're at now.
 Layout/LineLength:

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ end
 
 gem 'rake', '> 12'
 
-if RUBY_VERSION.to_f >= 2.4
+if RUBY_VERSION.to_f >= 2.4 && RUBY_ENGINE == 'ruby'
   gem 'rubocop', '~> 0.91.0'
   gem 'rubocop-packaging', '~> 0.5'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,9 @@ end
 
 gem 'rake', '> 12'
 
-if RUBY_VERSION.to_f >= 2.3
-  gem 'rubocop', '~> 0.80.1'
+if RUBY_VERSION.to_f >= 2.4
+  gem 'rubocop', '~> 0.91.0'
+  gem 'rubocop-packaging', '~> 0.5'
 end
 
 gem 'capybara'

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require "rspec/rails/version"
+require "rake/file_list"
 
 Gem::Specification.new do |s|
   s.name        = "rspec-rails"
@@ -21,7 +22,7 @@ Gem::Specification.new do |s|
     'source_code_uri'   => 'https://github.com/rspec/rspec-rails',
   }
 
-  s.files            = `git ls-files -- lib/*`.split("\n")
+  s.files            = Rake::FileList["lib/**/{.*,*}"].exclude(*File.read(".gitignore").split).reject { |f| File.directory?(f) }
   s.files           += %w[README.md LICENSE.md Changelog.md Capybara.md .yardopts .document]
   s.test_files       = []
   s.rdoc_options     = ["--charset=UTF-8"]


### PR DESCRIPTION
Hello @JonRowe & @pirj  👋🏻,

Thanks for your work on this again! ❤️ 

As discussed in #2382, we found that `rspec-rails` relies on `git ls-files` to produce a list of files, which could also be achieved using a pure Ruby alternative. Using `git` in gemspec, in general, is a bit problematic.
The rationale behind that can be found here: https://docs.rubocop.org/rubocop-packaging/cops_packaging.html#gemspec-git-rationale

This PR drops the usage of `git` and uses `Rake::FileList` instead w/o changing the output:

```
irb(main):001:0> require "rake/file_list"
=> true
irb(main):002:0> `git ls-files -- lib/*`.split("\n").sort == Rake::FileList["lib/**/{.*,*}"].exclude(*File.read(".gitignore").split).reject { |f| File.directory?(f) }
=> true

```

Also adds the `Packaging` extension to help the downstream maintainers as well! 😄 

Let me know what you think? 💫 

Closes: #2382 