### PR TITLE
ActionDispatch::TestProcess needs to access :file_fixture_path on Rails 6.1

### DIFF
--- a/lib/rspec/rails/fixture_file_upload_support.rb
+++ b/lib/rspec/rails/fixture_file_upload_support.rb
@@ -23,6 +23,7 @@ module RSpec
 
         class << self
           attr_accessor :fixture_path
+          attr_reader :file_fixture_path
 
           # Get instance of wrapper
           def instance

--- a/spec/rspec/rails/fixture_file_upload_support_spec.rb
+++ b/spec/rspec/rails/fixture_file_upload_support_spec.rb
@@ -27,7 +27,7 @@ module RSpec::Rails
 
     context 'ActionDispatch::TestProcess on Rails 6.1' do
       it 'can read the file_fixture_path attribute' do
-          expect(FixtureFileUploadSupport::RailsFixtureFileWrapper).to respond_to(:file_fixture_path)
+        expect(FixtureFileUploadSupport::RailsFixtureFileWrapper).to respond_to(:file_fixture_path)
       end
     end
 

--- a/spec/rspec/rails/fixture_file_upload_support_spec.rb
+++ b/spec/rspec/rails/fixture_file_upload_support_spec.rb
@@ -25,6 +25,12 @@ module RSpec::Rails
       end
     end
 
+    context 'ActionDispatch::TestProcess on Rails 6.1' do
+      it 'can read the file_fixture_path attribute' do
+          expect(FixtureFileUploadSupport::RailsFixtureFileWrapper).to respond_to(:file_fixture_path)
+      end
+    end
+
     def fixture_file_upload_resolved(fixture_name, fixture_path = nil)
       RSpec::Core::ExampleGroup.describe do
         include RSpec::Rails::FixtureFileUploadSupport


### PR DESCRIPTION
I had a similar problem to @koenpunt in #2349 where `fixture_file_upload` [stopped working](https://travis-ci.com/github/sudara/alonetone/builds/185469701).

```
     NoMethodError:
       undefined method `file_fixture_path' for RSpec::Rails::FixtureFileUploadSupport::RailsFixtureFileWrapper:Class
       Did you mean?  fixture_path
     # /actionpack/lib/action_dispatch/testing/test_process.rb:25:in `fixture_file_upload'
     # /rspec-rails-dd093928f021/lib/rspec/rails/fixture_file_upload_support.rb:5:in `fixture_file_upload'

```

In my case, it's because I'm on Rails 6.1 alpha. As of [these recent changes]( https://github.com/rails/rails/pull/39086), `ActionController::TestCase` now needs access to `file_fixture_path` within `fixture_file_upload`.

There's not currently any CI for Rails 6.1 (it's not out yet) but I thought I would get a head start. I added the reader on a separate line, as the `fixture_path` reader is turning into an accessor on #2370.
