### PR TITLE
Remove Ruby version constraint workarounds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,42 +18,6 @@ group :documentation do
   end
 end
 
-platforms :jruby do
-  gem "jruby-openssl"
-end
-
-gem 'sqlite3', '~> 1.3.6'
-
-if RUBY_VERSION >= '2.4.0'
-  gem 'json', '>= 2.0.2'
-end
-
-if RUBY_VERSION < '1.9'
-  gem 'ffi', '< 1.9.19' # ffi dropped Ruby 1.8 support in 1.9.19
-elsif RUBY_VERSION < '2.0'
-  gem 'ffi', '< 1.11.0' # ffi dropped Ruby 2.0 support in 1.11.0
-elsif RUBY_VERSION < '2.3'
-  gem 'ffi', '< 1.13.0'
-end
-
-if RUBY_VERSION >= '2.0.0'
-  gem 'rake', '>= 10.0.0'
-elsif RUBY_VERSION >= '1.9.3'
-  gem 'rake', '< 12.0.0' # rake 12 requires Ruby 2.0.0 or later
-else
-  gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later
-end
-
-# Version 3 of mime-types 3 requires Ruby 2.0
-if RUBY_VERSION < '2.0.0'
-  gem 'mime-types', '< 3'
-end
-
-# Version 5.12 of minitest requires Ruby 2.4
-if RUBY_VERSION < '2.4.0'
-  gem 'minitest', '< 5.12.0'
-end
-
 # Capybara versions that support RSpec 3 only support RUBY_VERSION >= 1.9.3
 if RUBY_VERSION >= '1.9.3'
   if /5(\.|-)[1-9]\d*/ === RAILS_VERSION || "master" == RAILS_VERSION
@@ -63,28 +27,14 @@ if RUBY_VERSION >= '1.9.3'
   end
 end
 
-# Rack::Cache 1.3.0 requires Ruby >= 2.0.0
-gem 'rack-cache', '< 1.3.0' if RUBY_VERSION < '2.0.0'
+# Minitest version 5.12.0 rely on Ruby 2.4 features and doesn't specify a Ruby version constraint
+gem 'minitest', '!= 5.12.0'
 
-if RUBY_VERSION < '1.9.2'
-  gem 'nokogiri', '~> 1.5.0'
-elsif RUBY_VERSION < '1.9.3'
-  gem 'nokogiri', '1.5.2'
-elsif RUBY_VERSION < '2.1.0'
-  gem 'nokogiri', '1.6.8.1'
-elsif RUBY_VERSION < '2.3.0'
-  gem 'nokogiri', '1.8.5'
-else
-  gem 'nokogiri', '~> 1.10'
-end
-
-if RUBY_VERSION <= '1.8.7'
-  # cucumber and gherkin require rubyzip as a runtime dependency on 1.8.7
-  # Only < 1.0 supports 1.8.7
-  gem 'rubyzip', '< 1.0'
-elsif RUBY_VERSION < '2.4'
-  gem 'rubyzip', '>= 1.2.2', '< 2.0.0'
-end
+gem 'mime-types'
+gem 'nokogiri'
+gem 'rake'
+gem 'rack-cache'
+gem 'rubyzip'
 
 if RUBY_VERSION >= '2.0.0' && RUBY_VERSION < '2.2.0'
   # our current rubocop version doesn't support the json version required by Ruby 2.4

--- a/Gemfile
+++ b/Gemfile
@@ -27,14 +27,14 @@ if RUBY_VERSION >= '1.9.3'
   end
 end
 
+# Nokogiri is required by Capybara, but we require Capybara only on Ruby 1.9.3+,
+# so we need to explicitly specify Nokogiri dependency on Ruby 1.9.2 to run cukes
+gem 'nokogiri' if RUBY_VERSION == '1.9.2'
+
 # Minitest version 5.12.0 rely on Ruby 2.4 features and doesn't specify a Ruby version constraint
 gem 'minitest', '!= 5.12.0'
 
-gem 'mime-types'
-gem 'nokogiri'
 gem 'rake'
-gem 'rack-cache'
-gem 'rubyzip'
 
 if RUBY_VERSION >= '2.0.0' && RUBY_VERSION < '2.2.0'
   # our current rubocop version doesn't support the json version required by Ruby 2.4

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -14,9 +14,9 @@ when /master/
   gem 'i18n', :git => 'https://github.com/svenfuchs/i18n.git', :branch => 'master'
   gem 'sprockets', :git => 'https://github.com/rails/sprockets.git', :branch => 'master'
   gem 'sprockets-rails', :git => 'https://github.com/rails/sprockets-rails.git', :branch => 'master'
-  if RUBY_VERSION  >= "2.2"
-    gem 'puma', :git => 'https://github.com/puma/puma', :branch => 'master'
-  end
+  gem 'puma', :git => 'https://github.com/puma/puma', :branch => 'master'
+  # sqlite3 is an optional, unspecified, dependency and Rails 6.0 only supports `~> 1.4`
+  gem 'sqlite3', '~> 1.4', :platforms => [:ruby]
 when /stable$/
   gem_list = %w[rails railties actionmailer actionpack activerecord activesupport]
   gem_list << 'activejob'  if version > '4-1-stable'
@@ -26,65 +26,31 @@ when /stable$/
     gem rails_gem, :git => "https://github.com/rails/rails.git", :branch => version
   end
 
-  gem 'puma' if RUBY_VERSION  >= '2.2' && version > '5-0-stable'
-
-  gem "sprockets", '~> 3.0' if RUBY_VERSION < '2.5' && version >= '4-0-stable'
+  gem 'puma' if version > '5-0-stable'
+  # Similarly, Rails 5.0 only supports '~> 1.3.6'. Rails 5.1-5.2 support '~> 1.3', '>= 1.3.6'
+  gem 'sqlite3', '~> 1.3.6', :platforms => [:ruby]
 when nil, false, ""
-  if RUBY_VERSION < '1.9.3'
-    # Rails 4+ requires 1.9.3+, so on earlier versions default to the last 3.x release.
-    gem "rails", "~> 3.2.17"
-  elsif RUBY_VERSION < '2.2.0'
-    # Rails 5+ requires 2.2+, so on earlier versions default to the last 4.x release.
-    gem "rails", "~> 4.2.0"
-  else
-    gem "rails", "~> 5.0.0"
-  end
+  gem "rails"
+  gem 'sqlite3', '~> 1.4', :platforms => [:ruby]
 else
   gem "rails", version
 
   major_minor_version = version.gsub(/[^\d\.]/,'').to_f
 
-  if major_minor_version >= 5.1 && RUBY_VERSION  >= "2.2"
-    gem "puma"
-  end
+  gem "puma" if major_minor_version >= 5.1
 
-  gem "sprockets", '~> 3.0' if RUBY_VERSION < '2.5' && major_minor_version >= 4.0
+  gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
 
-  if major_minor_version >= 6.0
-    gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", :platforms => [:jruby]
+  if major_minor_version >= 6
+    # sqlite3 is an optional, unspecified, dependency and Rails 6.0 only supports `~> 1.4`
+    gem 'sqlite3', '~> 1.4', :platforms => [:ruby]
   else
-    gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
+    # Similarly, Rails 5.0 only supports '~> 1.3.6'. Rails 5.1-5.2 support '~> 1.3', '>= 1.3.6'
+    gem 'sqlite3', '~> 1.3.6', :platforms => [:ruby]
   end
 end
 
-gem "childprocess", '< 2.0.0' if RUBY_VERSION < '2.3'
+# `test-unit` was removed from the core in Ruby 2.2
+gem 'test-unit' if RUBY_VERSION >= '2.2.0' && version =~ /3[.-]2[.-]/
 
-if RUBY_VERSION < '1.9.3'
-  gem "i18n", '< 0.7.0'
-elsif RUBY_VERSION < '2.3.0'
-  gem "i18n", '< 1.5.2'
-end
-
-gem "nio4r", '< 2.4.0' if RUBY_VERSION < '2.3'
-
-if RUBY_VERSION < '1.9.3'
-  gem "public_suffix", '< 1.4.0'
-elsif RUBY_VERSION < '2.0'
-  gem "public_suffix", '< 2.0.0'
-elsif RUBY_VERSION < '2.1'
-  gem "public_suffix", '< 3.0.0'
-elsif RUBY_VERSION < '2.3'
-  gem "public_suffix", '< 4.0.0'
-end
-
-# rack 2.1.0 introduces a deprecation warning that rails is triggering,
-# but in later versions this warning is removed.
-if RUBY_VERSION < '2.2'
-  gem "rack", '< 2.0.0', '!= 2.1.0'
-elsif RUBY_VERSION < '2.3'
-  gem "rack", '< 2.2.0', '!= 2.1.0'
-end
-
-gem "test-unit" if RUBY_VERSION >= '2.2.0' && version =~ /3[.-]2[.-]/
-
-gem "xpath", '< 3.2.0' if RUBY_VERSION < '2.3'
+gem 'jruby-openssl', :platforms => [:jruby]

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -21,23 +21,18 @@ in_root do
   gsub_file 'Gemfile', /^.*\bgem 'rails.*$/, ''
   gsub_file "Gemfile", /.*web-console.*/, ''
   gsub_file "Gemfile", /.*debugger.*/, ''
-  gsub_file "Gemfile", /.*byebug.*/, "gem 'byebug', '~> 9.0.6'"
   gsub_file "Gemfile", /.*puma.*/, ""
-  gsub_file "Gemfile", /.*sqlite3.*/, "gem 'sqlite3', '~> 1.3.6'"
-  if RUBY_VERSION < '2.2.2'
-    gsub_file "Gemfile", /.*rdoc.*/, "gem 'rdoc', '< 6'"
-  end
+  gsub_file "Gemfile", /.*sqlite3.*/, ""
 
   if Rails::VERSION::STRING >= '5.0.0'
     append_to_file('Gemfile', "gem 'rails-controller-testing', :git => 'https://github.com/rails/rails-controller-testing'\n")
   end
 
   if Rails::VERSION::STRING >= "5.1.0"
-    if Rails::VERSION::STRING >= "5.2.0" && RUBY_VERSION < '2.3.0'
-      gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers', '< 4.0.0'"
-    else
-      gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers'"
-    end
+    # webdrivers 4 up until 4.3.0 don't specify `required_ruby_version`, but contain
+    # Ruby 2.2-incompatible syntax (safe navigation).
+    # That basically means we use pre-4.0 for Ruby 2.2, and 4.3+ for newer Rubies.
+    gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers', '!= 4.0.0', '!= 4.0.1', '!= 4.1.0', '!= 4.1.1', '!= 4.1.2', '!= 4.1.3', '!= 4.2.0'"
   end
 
   if Rails::VERSION::STRING >= '5.2.0' && Rails::VERSION::STRING < '6'
@@ -50,22 +45,6 @@ in_root do
 
   # Use our version of RSpec and Rails
   append_to_file 'Gemfile', <<-EOT.gsub(/^ +\|/, '')
-    |# Rack::Cache 1.3.0 requires Ruby >= 2.0.0
-    |gem 'rack-cache', '< 1.3.0' if RUBY_VERSION < '2.0.0'
-    |
-    |if RUBY_VERSION >= '2.0.0'
-    |  gem 'rake', '>= 10.0.0'
-    |elsif RUBY_VERSION >= '1.9.3'
-    |  gem 'rake', '< 12.0.0' # rake 12 requires Ruby 2.0.0 or later
-    |else
-    |  gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later
-    |end
-    |
-    |# Version 3 of mime-types 3 requires Ruby 2.0
-    |if RUBY_VERSION < '2.0.0'
-    |  gem 'mime-types', '< 3'
-    |end
-    |
     |gem 'rspec-rails',
     |    :path => '#{rspec_rails_repo_path}',
     |    :groups => [:development, :test]


### PR DESCRIPTION
The point of this PR is to remove workaround previously needed to work around Rubygems API not providing necessary gem Ruby constraints under certain conditions.

The problem was presumably fixed in Rubygems.
A couple of passed builds have no odd gem version resolutions resulting in Ruby version incompatibility.

Follow-up to https://github.com/rspec/rspec-rails/pull/2380

Related to https://github.com/rubygems/rubygems/issues/3463