### PR TITLE
Delete last pending spec in internal test suite

### DIFF
--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -199,8 +199,6 @@ module RSpec::Rails
           expect(controller_class.name).to eq "AnonymousController"
         end
       end
-
-      pending "sets up resourceful routes on the example"
     end
   end
 end


### PR DESCRIPTION
Running `bundle exec rspec` returned yellow and not green, that was a bit sad.

Context: https://github.com/rspec/rspec-rails/commit/8dd3a3333646798448fa22d3b2d49bc34f5561af#r6343673

Since controller tests are deprecated I don't think we need to worry too much about the lack of testing here.