### PR TITLE
Drop 'main' from conditional as it's unrelated to Rails versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ MAJOR =
   case RAILS_VERSION
   when /5-2-stable/
     5
-  when /main/, /stable/, nil, false, ''
+  when /stable/, nil, false, ''
     6
   else
     /(\d+)[\.|-]\d+/.match(RAILS_VERSION).captures.first.to_i


### PR DESCRIPTION
We probably meant 'master', but we don't run against Rails edge.