### PR TITLE
Remove explicit jruby-openssl dependency

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -35,5 +35,3 @@ else
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
   gem 'selenium-webdriver', require: false if version >= '5'
 end
-
-gem 'jruby-openssl', platforms: [:jruby]


### PR DESCRIPTION
To fix broken JRuby jobs, e.g. https://travis-ci.org/github/rspec/rspec-rails/jobs/734533081

Something has changed, and it seems that the explicit requirement now
fails.

Probably related: https://twitter.com/headius/status/1313249103367876608