### PR TITLE
Consider the multibyte value in the method name of system test

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -41,7 +41,7 @@ module RSpec
         @method_name ||= [
           self.class.name.underscore,
           RSpec.current_example.description.underscore
-        ].join("_").tr(CHARS_TO_TRANSLATE.join, "_")[0...200] + "_#{rand(1000)}"
+        ].join("_").tr(CHARS_TO_TRANSLATE.join, "_").byteslice(0...200).scrub("") + "_#{rand(1000)}"
       end
 
       # Delegates to `Rails.application`.

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -16,6 +16,15 @@ module RSpec::Rails
             expect(example.send(:method_name)).to start_with('method_name')
           end
         end
+
+        it "slices long method name - #{'あ'*100}" do
+          group = RSpec::Core::ExampleGroup.describe do
+            include SystemExampleGroup
+          end
+          example = group.new
+          group.hooks.run(:before, :example, example)
+          expect(example.send(:method_name).bytesize).to be <= 210
+        end
       end
 
       describe '#driver' do


### PR DESCRIPTION
`String#[]` returns a value that considers multibyte value. But maximum filename length use bytes. So if applications use multibyte value to a method name, currently check doesn't work expected.

This PR fixes to use `String#byteslice` instead of `String#[]`. Also, added `String#scrub` to avoid generating an invalid byte sequence.