### PR TITLE
Renable cache because we set env variables before the steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - run: script/clone_all_rspec_repos
       - run: bundle install --binstubs
       - run: script/run_build


### PR DESCRIPTION
See: https://github.com/ruby/setup-ruby/issues/112#issuecomment-731607162