### PR TITLE
Make rspec-rails compatible with Rails v6.1.0.rc2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,17 @@ jobs:
        include:
          # Rails 6.1 builds >= 2.5
          - ruby: ruby-3.0.0-preview1
-           allow_failure: true
            env:
-             RAILS_VERSION: 'master'
+             RAILS_VERSION: '6.1.0.rc2'
          - ruby: 2.7.1
            env:
-             RAILS_VERSION: 'master'
+             RAILS_VERSION: '6.1.0.rc2'
          - ruby: 2.6.6
            env:
-             RAILS_VERSION: 'master'
+             RAILS_VERSION: '6.1.0.rc2'
          - ruby: 2.5.8
            env:
-             RAILS_VERSION: 'master'
+             RAILS_VERSION: '6.1.0.rc2'
 
          # Rails 6.0 builds >= 2.5.0
          - ruby: 3.0.0-preview1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,19 @@ jobs:
        include:
          # Rails Master builds >= 2.5
          - ruby: ruby-3.0.0-preview1
+           allow_failure: true
            env:
              RAILS_VERSION: 'master'
          - ruby: 2.7.1
+           allow_failure: true
            env:
              RAILS_VERSION: 'master'
          - ruby: 2.6.6
+           allow_failure: true
            env:
              RAILS_VERSION: 'master'
          - ruby: 2.5.8
+           allow_failure: true
            env:
              RAILS_VERSION: 'master'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,19 +34,19 @@ jobs:
            env:
              RAILS_VERSION: 'master'
 
-         # Rails 6.1.0.rc2 builds >= 2.5
+         # Rails 6.1.0 builds >= 2.5
          - ruby: ruby-3.0.0-preview1
            env:
-             RAILS_VERSION: '6.1.0.rc2'
+             RAILS_VERSION: '~> 6.1.0'
          - ruby: 2.7.1
            env:
-             RAILS_VERSION: '6.1.0.rc2'
+             RAILS_VERSION: '~> 6.1.0'
          - ruby: 2.6.6
            env:
-             RAILS_VERSION: '6.1.0.rc2'
+             RAILS_VERSION: '~> 6.1.0'
          - ruby: 2.5.8
            env:
-             RAILS_VERSION: '6.1.0.rc2'
+             RAILS_VERSION: '~> 6.1.0'
 
          # Rails 6.0 builds >= 2.5.0
          - ruby: 3.0.0-preview1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,21 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         # Rails 6.1 builds >= 2.5
+         # Rails Master builds >= 2.5
+         - ruby: ruby-3.0.0-preview1
+           env:
+             RAILS_VERSION: 'master'
+         - ruby: 2.7.1
+           env:
+             RAILS_VERSION: 'master'
+         - ruby: 2.6.6
+           env:
+             RAILS_VERSION: 'master'
+         - ruby: 2.5.8
+           env:
+             RAILS_VERSION: 'master'
+
+         # Rails 6.1.0.rc2 builds >= 2.5
          - ruby: ruby-3.0.0-preview1
            env:
              RAILS_VERSION: '6.1.0.rc2'

--- a/example_app_generator/generate_action_mailer_specs.rb
+++ b/example_app_generator/generate_action_mailer_specs.rb
@@ -14,15 +14,10 @@ using_source_path(File.expand_path(__dir__)) do
       end
     end
   CODE
-  gsub_file 'config/initializers/action_mailer.rb',
-            /ExampleApp/,
-            Rails.application.class.parent.to_s
 
   copy_file 'spec/support/default_preview_path'
   chmod 'spec/support/default_preview_path', 0755
-  gsub_file 'spec/support/default_preview_path',
-            /ExampleApp/,
-            Rails.application.class.parent.to_s
+
   if skip_active_record?
     comment_lines 'spec/support/default_preview_path', /active_record/
     comment_lines 'spec/support/default_preview_path', /active_storage/

--- a/features/controller_specs/anonymous_controller.feature
+++ b/features/controller_specs/anonymous_controller.feature
@@ -101,6 +101,8 @@ Feature: anonymous controller
     When I run `rspec spec`
     Then the examples should all pass
 
+  # Deprecated support removed in https://github.com/rails/rails/commit/d52d7739468153bd6cb7c629f60bd5cd7ebea3eb
+  @rails_pre_6
   Scenario: Specify error handling in `ApplicationController` with render :file
     Given a file named "spec/controllers/application_controller_spec.rb" with:
       """ruby

--- a/lib/rspec/rails/matchers/action_mailbox.rb
+++ b/lib/rspec/rails/matchers/action_mailbox.rb
@@ -22,11 +22,20 @@ module RSpec
             @inbound_email = create_inbound_email(message)
           end
 
-          def matches?(mailbox)
-            @mailbox  = mailbox
-            @receiver = ApplicationMailbox.router.send(:match_to_mailbox, inbound_email)
+          if defined?(::ApplicationMailbox) && ::ApplicationMailbox.router.respond_to?(:mailbox_for)
+            def matches?(mailbox)
+              @mailbox  = mailbox
+              @receiver = ApplicationMailbox.router.mailbox_for(inbound_email)
 
-            @receiver == @mailbox
+              @receiver == @mailbox
+            end
+          else
+            def matches?(mailbox)
+              @mailbox  = mailbox
+              @receiver = ApplicationMailbox.router.send(:match_to_mailbox, inbound_email)
+
+              @receiver == @mailbox
+            end
           end
 
           def failure_message
@@ -41,7 +50,7 @@ module RSpec
             "expected #{describe_inbound_email} not to route to #{mailbox}"
           end
 
-        private
+          private
 
           attr_reader :inbound_email, :mailbox, :receiver
 


### PR DESCRIPTION
This PR add:

* Rails v6.1.0.rc2 to the CI build
* Fix 3 errors encountered when running the CI

Answer: https://github.com/rspec/rspec-rails/pull/2398#issuecomment-737757306