### PR TITLE
Prevent internal ActiveSupport test helpers to call assert_nothing_raised

### DIFF
--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -297,4 +297,16 @@ RSpec.describe "Configuration" do
   it "has a default #file_fixture_path of 'spec/fixtures/files'" do
     expect(config.file_fixture_path).to eq("spec/fixtures/files")
   end
+
+  if Rails.version.to_f >= 6.0
+    describe 'ActiveSupport::Testing::Assertions requirements' do
+      it 'does not raise that "assert_nothing_raised" is undefined' do
+        expect {
+          assert_nothing_raised do
+            :foo
+          end
+        }.to_not raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
This method has been moved in https://github.com/rails/rails/commit/3cece0b6574c496605df055a2ebf77177f5b6e7f
We do not include ActiveSupport::Testing::Assertion at the moment.

To avoid having to deal with complicated scenarios like Minitest errors. We redefine our own methods in rspec-rails.

----
I am really not sure about the approach. 

Few questions:
- Do we want to include all of `ActiveSupport::Testing::Assertions`? I was not tempted because:
  1. Minitest error to handle like https://github.com/rails/rails/blob/master/activesupport/lib/active_support/testing/assertions.rb#L36
  2. Also I do not want to encourage people to use ActiveSupport assertions methods when they can use rspec ones.
- Is it the right way do to it. I dig a little bit into https://github.com/rspec/rspec-rails/blob/main/lib/rspec/rails/adapters.rb#L30-L36 but found it was not probably the best place to put the code.
- I do not understand why it does not work on previous versions ATM. I should have access to `ActiveSupport::TestCase` and "assert_not_raised"
----

As always feel free to push on this branch and amend my commit.

Fix: https://github.com/rspec/rspec-rails/issues/2410