### PR TITLE
Correct route_to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,17 +187,17 @@ In addition to [the matchers that come standard in RSpec][],
 here are some extras that make it easier
 to test the various parts of a Rails system:
 
-| RSpec matcher            | Delegates to      | Available in                    | Notes                                                    |
-| ------------------------ | ----------------- | ------------------------------- | -------------------------------------------------------- |
-| [`be_a_new`][]           |                   | all                             | primarily intended for controller specs                  |
-| [`render_template`][]    | `assert_template` | request / controller / view     | use with `expect(response).to`                           |
-| [`redirect_to`][]        | `assert_redirect` | request / controller            | use with `expect(response).to`                           |
-| [`route_to`]             | `assert_routing`  | routing / controller            | use with `expect(...).to route_to`                       |
-| [`be_routable`]          |                   | routing / controller            | use with `expect(...).not_to be_routable`                |
-| [`have_http_status`][]   |                   | request / controller / feature  |                                                          |
-| [`match_array`][]        |                   | all                             | for comparing arrays of ActiveRecord objects             |
-| [`have_been_enqueued`][] |                   | all                             | requires config: `ActiveJob::Base.queue_adapter = :test` |
-| [`have_enqueued_job`][]  |                   | all                             | requires config: `ActiveJob::Base.queue_adapter = :test` |
+| RSpec matcher            | Delegates to        | Available in                    | Notes                                                    |
+| ------------------------ | ------------------- | ------------------------------- | -------------------------------------------------------- |
+| [`be_a_new`][]           |                     | all                             | primarily intended for controller specs                  |
+| [`render_template`][]    | `assert_template`   | request / controller / view     | use with `expect(response).to`                           |
+| [`redirect_to`][]        | `assert_redirect`   | request / controller            | use with `expect(response).to`                           |
+| [`route_to`]             | `assert_recognizes` | routing / controller            | use with `expect(...).to route_to`                       |
+| [`be_routable`]          |                     | routing / controller            | use with `expect(...).not_to be_routable`                |
+| [`have_http_status`][]   |                     | request / controller / feature  |                                                          |
+| [`match_array`][]        |                     | all                             | for comparing arrays of ActiveRecord objects             |
+| [`have_been_enqueued`][] |                     | all                             | requires config: `ActiveJob::Base.queue_adapter = :test` |
+| [`have_enqueued_job`][]  |                     | all                             | requires config: `ActiveJob::Base.queue_adapter = :test` |
 
 Follow the links above for examples of how each matcher is used.
 


### PR DESCRIPTION
The `route_to` matcher [delegates to assert_recognizes](https://github.com/rspec/rspec-rails/blob/main/lib/rspec/rails/matchers/routing_matchers.rb#L27). This assertion only tests path=>params, not that the provided params also generate the expected path [as `assert_routing` does](https://api.rubyonrails.org/v6.1.0/classes/ActionDispatch/Assertions/RoutingAssertions.html). 

It would be great to have an rspec matcher for the inverse (`generate_route` perhaps?) but at the very least I figured the readme should be corrected. The full docs on relishapp.com seem to be correct already.