### PR TITLE
Stop using globally exposed DSL

### DIFF
--- a/lib/rspec/rails/extensions/active_record/proxy.rb
+++ b/lib/rspec/rails/extensions/active_record/proxy.rb
@@ -1,7 +1,10 @@
 RSpec.configure do |rspec|
   # Delay this in order to give users a chance to configure `expect_with`...
   rspec.before(:suite) do
-    if defined?(RSpec::Matchers) && RSpec::Matchers.configuration.syntax.include?(:should) && defined?(ActiveRecord::Associations)
+    if defined?(RSpec::Matchers) &&
+        RSpec::Matchers.configuration.respond_to?(:syntax) && # RSpec 4 dropped support for monkey-patching `should` syntax
+        RSpec::Matchers.configuration.syntax.include?(:should) &&
+        defined?(ActiveRecord::Associations)
       RSpec::Matchers.configuration.add_should_and_should_not_to ActiveRecord::Associations::CollectionProxy
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,8 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-  config.disable_monkey_patching!
+  # Zero monkey patching mode is the default and only mode in RSpec 4
+  config.disable_monkey_patching! if config.respond_to?(:disable_monkey_patching!)
 
   config.warnings = true
   config.raise_on_warning = true

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -20,7 +20,7 @@ module RSpec
           klass.include(RSpec::Rails::FeatureCheck)
         end
 
-        shared_examples_for 'a model generator with fixtures' do |name, class_name|
+        RSpec.shared_examples_for 'a model generator with fixtures' do |name, class_name|
           before { run_generator [name, '--fixture'] }
 
           describe 'the spec' do
@@ -38,7 +38,7 @@ module RSpec
           end
         end
 
-        shared_examples_for "a request spec generator" do
+        RSpec.shared_examples_for "a request spec generator" do
           describe 'generated with flag `--no-request-specs`' do
             before do
               run_generator %w[posts --no-request-specs]

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-shared_examples_for "an rspec-rails example group mixin" do |type, *paths|
+RSpec.shared_examples_for "an rspec-rails example group mixin" do |type, *paths|
   let(:mixin) { described_class }
 
   def define_group_in(path, group_definition)


### PR DESCRIPTION
~I find it puzzling to explain why DSL was exposed~

This PR is a prerequisite for:
 - https://github.com/rspec/rspec-expectations/pull/1245
 - https://github.com/rspec/rspec-core/pull/2803
 - https://github.com/rspec/rspec-mocks/pull/1365