### PR TITLE
Set RSpec version from env

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   # get released.
   %w[core expectations mocks support].each do |name|
     if ENV['RSPEC_CI']
-      s.add_runtime_dependency "rspec-#{name}", "= 4.0.0.pre"
+      s.add_runtime_dependency "rspec-#{name}", ENV.fetch('RSPEC_VERSION', '3.11.0.pre')
     elsif RSpec::Rails::Version::STRING =~ /pre/ # prerelease builds
       expected_rspec_version = "3.11.0.pre"
       s.add_runtime_dependency "rspec-#{name}", "= #{expected_rspec_version}"


### PR DESCRIPTION
@benoittgt and @pirj the intent here is to set RSpec's desired version from the other repos, and then drop the `pre` check in the line below.

This will then allow people to install pre-release versions of `rspec-rails` from Github directly, without other gems. We can always bump up the minimum required version, or otherwise alter this check should be we need to pin, but with `rspec-rails` being independent now I think this is an improvement.