### PR TITLE
Add a check to support both RSpec 3 & 4

### DIFF
--- a/lib/rspec/rails/matchers/relation_match_array.rb
+++ b/lib/rspec/rails/matchers/relation_match_array.rb
@@ -1,3 +1,3 @@
-if defined?(ActiveRecord::Relation)
+if defined?(ActiveRecord::Relation) && defined?(RSpec::Matchers::BuiltIn::OperatorMatcher) # RSpec 4 removed OperatorMatcher
   RSpec::Matchers::BuiltIn::OperatorMatcher.register(ActiveRecord::Relation, '=~', RSpec::Matchers::BuiltIn::ContainExactly)
 end


### PR DESCRIPTION
RSpec 4 has removed OperatorMatcher, as it was only supported by the should syntax, and not expect syntax.

See:
 - https://github.com/rspec/rspec-core/pull/2803
 - https://github.com/rspec/rspec-expectations/pull/1245