### PR TITLE
Support RSpec v3.10.x in rspec-rails v3.x

### DIFF
--- a/lib/rspec/rails/version.rb
+++ b/lib/rspec/rails/version.rb
@@ -3,7 +3,7 @@ module RSpec
     # Version information for RSpec Rails.
     module Version
       # Current version of RSpec Rails, in semantic versioning format.
-      STRING = '3.9.1'
+      STRING = '3.10.0'
     end
   end
 end

--- a/maintenance-branch
+++ b/maintenance-branch
@@ -1,1 +1,1 @@
-3-9-maintenance
+3-10-maintenance


### PR DESCRIPTION
Just updated the version and maintenance branch to enable support for RSpec v3.10.x in rspec-rails v3.x so that it may be used in Rails < v5 and Ruby < v2.3 (which are no longer supported in rspec-rails v4.x).