### PR TITLE
Repro name scope error in a Rails file app

### DIFF
--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -9,6 +9,12 @@ module RSpec
         include RSpec::Rails::MinitestAssertionAdapter
         include ActiveRecord::TestFixtures
 
+        if ::Rails.version.to_f >= 6.1
+          def name
+            @example
+          end
+        end
+
         included do
           if RSpec.configuration.use_active_record?
             include Fixtures
@@ -51,12 +57,6 @@ module RSpec
             end
           end
 
-          if ::Rails.version.to_f >= 6.1
-            # @private return the example name for TestFixtures
-            def name
-              @example
-            end
-          end
         end
       end
     end

--- a/spec/rspec/rails/features/rails_app/partial_active_record_false.rb
+++ b/spec/rspec/rails/features/rails_app/partial_active_record_false.rb
@@ -1,0 +1,31 @@
+require "bundler/inline"
+
+gemfile(true) do
+  source "https://rubygems.org"
+
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+  gem "rails", (ENV["RAILS_VERSION"] || "~> 6.0.0")
+  gem "rspec-rails", path: "./"
+  gem "sqlite3"
+  gem "ammeter"
+end
+
+require "active_record/railtie"
+
+require "ammeter"
+require "rspec/autorun"
+require "rspec/rails"
+
+class Command
+end
+
+RSpec.configure do |config|
+  config.use_active_record = false
+end
+
+RSpec.describe Command do
+  it 'should not break' do
+    Command.new
+  end
+end

--- a/spec/rspec/rails/features/rails_app/partial_active_record_false_spec.rb
+++ b/spec/rspec/rails/features/rails_app/partial_active_record_false_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe 'Rails app with use_active_record = false but active record railties loaded' do
+  it 'properly handles name scope in fixture_support' do
+    cmd = 'ruby spec/rspec/rails/features/rails_app/partial_active_record_false.rb'
+    cmd_status = ruby_script_runner(cmd)
+    expect(cmd_status[:stdout].last&.chomp).to eq("1 example, 0 failures")
+    expect(cmd_status[:exitstatus]).to eq(0)
+  end
+
+  def ruby_script_runner(cmd)
+    require 'open3'
+    cmd_status = { stdout: [], exitstatus: nil }
+    Open3.popen2(cmd) do |_stdin, stdout, wait_thr|
+      frame_stdout do
+        while line = stdout.gets
+          puts "|  #{line}"
+          cmd_status[:stdout] << line if line =~ /\d+ (example|examples), \d+ failure/
+        end
+      end
+      cmd_status[:exitstatus] = wait_thr.value.exitstatus
+    end
+    cmd_status
+  end
+
+  def frame_stdout
+    puts
+    puts '-' * 50
+    yield
+    puts '-' * 50
+  end
+end


### PR DESCRIPTION
Next proposal for https://github.com/rspec/rspec-rails/pull/2423

From @pirj 
> Fixes #2417
> Related: #2215, rails/rails#37770
>
> See #2417 (comment) for an explanation of at least one of the possible causes

---

This is a draft proposal. I was not able to easily fetch existing gem and logic from our current Gemfiles. 

  In [the source code](https://github.com/rubygems/bundler/blob/master/lib/bundler/inline.rb) of bundler inline:
  ```ruby
  # Allows for declaring a Gemfile inline in a ruby script, optionally installing
  # any gems that aren't already installed on the user's system.
  ```
  So we should  not have any issue reloading existing gems from existing Gemfile.

I tried to use `eval_gemfile` the `Gemfile`:

  ```ruby
  require "bundler/inline"
  
  gemfile(true) do
    eval_gemfile('Gemfile')
  end
  
  require "active_record/railtie"
  
  require "ammeter"
  require "rspec/autorun"
  require "rspec/rails"
  
  class Command
  end
  
  RSpec.configure do |config|
    config.use_active_record = false
  end
  
  RSpec.describe Command do
    it 'should not break' do
      Command.new
    end
  end
  ```
  
  ```
  ...
  |  Using actioncable 6.1.0
  |  Using activestorage 6.1.0
  |  Using actionmailer 6.1.0
  |  Using railties 6.1.0
  |  Using sprockets-rails 3.2.2
  |  Using rspec 3.11.0.pre from source at `/Users/bti/code/rspec-dev/repos/rspec`
  |  Using actionmailbox 6.1.0
  |  Using actiontext 6.1.0
  |  Using rspec-rails 4.1.0.pre from source at `.`
  |  Using rails 6.1.0
  |  Using ammeter 1.1.4
  /Users/bti/code/rspec-dev/repos/rspec-rails/lib/rspec-rails.rb:8:in `<module:Rails>': uninitialized constant Rails (NameError)
	  from /Users/bti/code/rspec-dev/repos/rspec-rails/lib/rspec-rails.rb:6:in `<module:RSpec>'
	  from /Users/bti/code/rspec-dev/repos/rspec-rails/lib/rspec-rails.rb:4:in `<top (required)>'
	  from /Users/bti/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:66:in `require'
	  from /Users/bti/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:66:in `block (2 levels) in require'
	  from /Users/bti/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:61:in `each'
	  from /Users/bti/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:61:in `block in require'
  ....
  ```

Happy to get tips and to pair on this one.

----

Resources:
- https://github.com/rubygems/bundler/issues/5063
- https://github.com/rubygems/bundler/blob/master/lib/bundler/inline.rb
- https://github.com/WeTransfer/format_parser/blob/master/spec/integration/active_storage/rails_app.rb
- https://github.com/WeTransfer/format_parser/blob/master/spec/active_storage/rails_app_spec.rb