### PR TITLE
Add a regression test for a removed method in 6.1

### DIFF
--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -702,4 +702,16 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
       }.to raise_error(/expected to perform exactly 1 jobs, but performed 0/)
     end
   end
+
+  describe 'Active Job test helpers' do
+    include ActiveJob::TestHelper
+
+    it 'does not raise that "assert_nothing_raised" is undefined' do
+      expect {
+        perform_enqueued_jobs do
+          :foo
+        end
+      }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
This method has been moved in https://github.com/rails/rails/commit/3cece0b6574c496605df055a2ebf77177f5b6e7f We do not include ActiveSupport::Testing::Assertion.

This resulted in failures when `perform_enqueued_jobs do` was called from specs.

Method was added back in https://github.com/rails/rails/pull/40780, and was released in Rails 6.1.1

6.1.1 does not fix the issue in a spec that contains the following, though:
```ruby
    perform_enqueued_jobs do
      SomeJob.perform_later
    end
```
We never included `perform_enqueued_jobs` method to be available in specs. Everywhere in our docs we recommend setting `ActiveJob::Base.queue_adapter.perform_enqueued_jobs` to `true` instead for those specs that need to perform jobs inline.

To make sure that `assert_nothing_raised` call doesn't blow up, we need to call `perform_enqueued_jobs` and for that - `include ActiveJob::TestHelper` that contains both of those definitions. And this is what Rails 6.1.1 has fixed.

Fixes #2410 
Originally from #2412 

Side note: It's not uncommon to perform jobs inline and check their side effects. Calling `perform` directly is not a direct replacement, because in this case argument serialization/deserialization is not covered.