### PR TITLE
Stop using --color option

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --warnings
---color
 --require spec_helper


### PR DESCRIPTION
Similar to https://github.com/rspec/rspec-support/pull/496

`--color` removed in https://github.com/rspec/rspec-core/pull/2864 (`4.0-dev` branch for upcoming RSpec 4)