### PR TITLE
Remove Rails 7 builds against Ruby < 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         # Rails Master builds >= 2.5
+         # Rails Master (7.0) builds >= 2.7
          - ruby: 3.0
            allow_failure: true
            env:
@@ -25,16 +25,8 @@ jobs:
            allow_failure: true
            env:
              RAILS_VERSION: 'master'
-         - ruby: 2.6
-           allow_failure: true
-           env:
-             RAILS_VERSION: 'master'
-         - ruby: 2.5
-           allow_failure: true
-           env:
-             RAILS_VERSION: 'master'
 
-         # Rails 6.1.0 builds >= 2.5
+         # Rails 6.1 builds >= 2.5
          - ruby: 3.0
            allow_failure: true
            env:


### PR DESCRIPTION
There won't be Rails 6.2. Rails master is tracking 7.0.
7.0 is dropping support for 2.5, 2.6.

    activesupport-7.0.0.alpha requires ruby version >= 2.7.0, which is incompatible

See https://github.com/rspec/rspec-rails/pull/2461/checks?check_run_id=1922949773