### PR TITLE
[WiP] Update of request specs generator due to change in rails 6.1 controller default behaviour.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2020-12-23T21:24:00+01:00 from the rspec-dev repo.
+# This file was generated on 2020-12-25T18:48:30+00:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 github: [JonRowe, benoittgt]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,5 @@
-# This file was generated on 2019-12-05T21:32:23+00:00 from the rspec-dev repo.
+# This file was generated on 2020-12-23T21:24:00+01:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
-github: [JonRowe]
+github: [JonRowe, benoittgt]
 open_collective: rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
              RAILS_VERSION: '~> 6.1.0'
 
          # Rails 6.0 builds >= 2.5.0
-         - ruby: 3.0
+         - ruby: 3.0.0-rc1
            env:
              RAILS_VERSION: '~> 6.0.0'
          - ruby: 2.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
              RAILS_VERSION: '~> 6.1.0'
 
          # Rails 6.0 builds >= 2.5.0
-         - ruby: 3.0.0-rc1
+         - ruby: 3.0
            env:
              RAILS_VERSION: '~> 6.0.0'
          - ruby: 2.7

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --warnings
---color
 --require spec_helper

--- a/BUILD_DETAIL.md
+++ b/BUILD_DETAIL.md
@@ -1,5 +1,5 @@
 <!---
-This file was generated on 2019-12-05T21:32:23+00:00 from the rspec-dev repo.
+This file was generated on 2020-12-25T18:48:30+00:00 from the rspec-dev repo.
 DO NOT modify it by hand as your changes will get lost the next time it is generated.
 -->
 
@@ -112,22 +112,23 @@ $ bundle exec yard doc --no-cache
 $ bin/yard doc --no-cache
 ```
 
-## Rubocop
+## RuboCop
 
-We use [Rubocop](https://github.com/rubocop-hq/rubocop) to enforce style conventions on the project so
-that the code has stylistic consistency throughout. Run with:
+We use [RuboCop](https://github.com/rubocop-hq/rubocop) to enforce style
+conventions on the project so that the code has stylistic consistency
+throughout. Run with:
 
 ```
-$ bundle exec rubocop
+$ bundle exec rubocop lib
 
 # or, if you installed your bundle with `--standalone --binstubs`:
 
-$ bin/rubocop
+$ bin/rubocop lib
 ```
 
-Our Rubocop configuration is a work-in-progress, so if you get a failure
-due to a Rubocop default, feel free to ask about changing the
-configuration. Otherwise, you'll need to address the Rubocop failure,
+Our RuboCop configuration is a work-in-progress, so if you get a failure
+due to a RuboCop default, feel free to ask about changing the
+configuration. Otherwise, you'll need to address the RuboCop failure,
 or, as a measure of last resort, by wrapping the offending code in
 comments like `# rubocop:disable SomeCheck` and `# rubocop:enable SomeCheck`.
 
@@ -161,4 +162,3 @@ build for another repo, so our CI build includes a spec that runs the
 spec suite of each of the _other_ project repos. Note that we only run
 the spec suite, not the full build, of the other projects, as the spec
 suite runs very quickly compared to the full build.
-

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!---
-This file was generated on 2019-12-05T21:32:23+00:00 from the rspec-dev repo.
+This file was generated on 2020-12-25T18:48:30+00:00 from the rspec-dev repo.
 DO NOT modify it by hand as your changes will get lost the next time it is generated.
 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!---
-This file was generated on 2019-12-05T21:32:23+00:00 from the rspec-dev repo.
+This file was generated on 2020-12-25T18:48:30+00:00 from the rspec-dev repo.
 DO NOT modify it by hand as your changes will get lost the next time it is generated.
 -->
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,5 @@
 <!---
-This file was generated on 2019-12-05T21:32:23+00:00 from the rspec-dev repo.
+This file was generated on 2020-12-25T18:48:30+00:00 from the rspec-dev repo.
 DO NOT modify it by hand as your changes will get lost the next time it is generated.
 -->
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'yard', '~> 0.9.24', require: false
 
 group :documentation do
   gem 'github-markup', '~> 3.0.3'
-  gem 'redcarpet', '~> 3.4.0', platforms: [:ruby]
+  gem 'redcarpet', '~> 3.5.1', platforms: [:ruby]
   gem 'relish', '~> 0.7.1'
 end
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rspec-rails [![Build Status][]][travis-ci] [![Code Climate][]][code-climate] [![Gem Version][]](gem-version)
+# rspec-rails [![Build Status][]][travis-ci] [![Code Climate][]][code-climate] [![Gem Version][]][gem-version]
 
 `rspec-rails` brings the [RSpec][] testing framework to [Ruby on Rails][]
 as a drop-in alternative to its default testing framework, Minitest.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See the `4-0-maintenance` branch on Github if you want or require the latest sta
    ```ruby
    # Run against the latest stable release
    group :development, :test do
-     gem 'rspec-rails', '~> 4.0.1'
+     gem 'rspec-rails', '~> 4.0.2'
    end
 
    # Or, run against the main branch

--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -167,4 +167,17 @@ gsub_file 'spec/requests/gadgets_spec.rb',
 gsub_file 'spec/controllers/uploads_controller_spec.rb',
           'skip("Add a hash of attributes valid for your model")',
           '{}'
+
+# adds validation to widget so our test for happy and unhappy path will be ready to test validation
+gsub_file 'spec/requests/widgets_spec.rb',
+          'skip("Add a hash of attributes invalid for your model")',
+          '{ name: "" }'
+
+gsub_file 'spec/requests/widgets_spec.rb',
+          'skip("Add a hash of attributes valid for your model")',
+          '{ name: "lorem" }'
+
+gsub_file 'app/models/widget.rb',
+          'end',
+          'validates :name, presence: true; end'
 final_tasks

--- a/lib/generators/rspec/scaffold/templates/request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/request_spec.rb
@@ -82,10 +82,17 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
         }.to change(<%= class_name %>, :count).by(0)
       end
 
+    <% if Rails.version.to_f < 6.1 || Rails.version == '6.1.0' %>
       it "renders a successful response (i.e. to display the 'new' template)" do
         post <%= index_helper %>_url, params: { <%= ns_file_name %>: invalid_attributes }
         expect(response).to be_successful
       end
+    <% else %>
+      it "renders a response with 422 status - unporcessable entity" do
+        post <%= index_helper %>_url, params: { <%= ns_file_name %>: invalid_attributes }
+        expect(response.status).to eq(422)
+      end
+    <% end %>
     end
   end
 

--- a/lib/rspec/rails/extensions/active_record/proxy.rb
+++ b/lib/rspec/rails/extensions/active_record/proxy.rb
@@ -1,7 +1,10 @@
 RSpec.configure do |rspec|
   # Delay this in order to give users a chance to configure `expect_with`...
   rspec.before(:suite) do
-    if defined?(RSpec::Matchers) && RSpec::Matchers.configuration.syntax.include?(:should) && defined?(ActiveRecord::Associations)
+    if defined?(RSpec::Matchers) &&
+        RSpec::Matchers.configuration.respond_to?(:syntax) && # RSpec 4 dropped support for monkey-patching `should` syntax
+        RSpec::Matchers.configuration.syntax.include?(:should) &&
+        defined?(ActiveRecord::Associations)
       RSpec::Matchers.configuration.add_should_and_should_not_to ActiveRecord::Associations::CollectionProxy
     end
   end

--- a/lib/rspec/rails/matchers/relation_match_array.rb
+++ b/lib/rspec/rails/matchers/relation_match_array.rb
@@ -1,3 +1,3 @@
-if defined?(ActiveRecord::Relation)
+if defined?(ActiveRecord::Relation) && defined?(RSpec::Matchers::BuiltIn::OperatorMatcher) # RSpec 4 removed OperatorMatcher
   RSpec::Matchers::BuiltIn::OperatorMatcher.register(ActiveRecord::Relation, '=~', RSpec::Matchers::BuiltIn::ContainExactly)
 end

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   # get released.
   %w[core expectations mocks support].each do |name|
     if ENV['RSPEC_CI']
-      s.add_runtime_dependency "rspec-#{name}", "= 4.0.0.pre"
+      s.add_runtime_dependency "rspec-#{name}", ENV.fetch('RSPEC_VERSION', '3.11.0.pre')
     elsif RSpec::Rails::Version::STRING =~ /pre/ # prerelease builds
       expected_rspec_version = "3.11.0.pre"
       s.add_runtime_dependency "rspec-#{name}", "= #{expected_rspec_version}"

--- a/spec/rspec/rails/fixture_support_spec.rb
+++ b/spec/rspec/rails/fixture_support_spec.rb
@@ -12,7 +12,7 @@ module RSpec::Rails
       end
     end
 
-    it "will allow #setup_fixture to run successfully", if: Rails.version.to_f > 6.0 do
+    it "will allow #setup_fixture to run successfully", skip: Rails.version.to_f <= 6.0 do
       group = RSpec::Core::ExampleGroup.describe do
         include FixtureSupport
 

--- a/spec/sanity_check_spec.rb
+++ b/spec/sanity_check_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Verify required rspec dependencies" do
     end
   end
 
-  it "passes when libraries are required", unless: RSpec::Support::Ruby.jruby? do
+  it "passes when libraries are required", skip: RSpec::Support::Ruby.jruby? do
     script = tmp_root.join("pass_sanity_check")
     File.open(script, "w") do |f|
       f.write <<-EOF.gsub(/^\s+\|/, '')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,8 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-  config.disable_monkey_patching!
+  # Zero monkey patching mode is the default and only mode in RSpec 4
+  config.disable_monkey_patching! if config.respond_to?(:disable_monkey_patching!)
 
   config.warnings = true
   config.raise_on_warning = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,8 @@ end
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
-    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    # include_chain_clauses_in_custom_matcher_descriptions is removed in RSpec Expectations 4
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true if expectations.respond_to?(:include_chain_clauses_in_custom_matcher_descriptions=)
     expectations.max_formatted_output_length = 1000
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,8 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 
-  config.shared_context_metadata_behavior = :apply_to_host_groups
+  # shared_context_metadata_behavior is removed in RSpec 4
+  config.shared_context_metadata_behavior = :apply_to_host_groups if config.respond_to?(:shared_context_metadata_behavior=)
 
   # Zero monkey patching mode is the default and only mode in RSpec 4
   config.disable_monkey_patching! if config.respond_to?(:disable_monkey_patching!)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,8 +47,7 @@ RSpec.configure do |config|
     mocks.verify_doubled_constant_names = true
   end
 
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
+  config.filter_run_when_matching :focus
 
   config.order = :random
   Kernel.srand config.seed

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -20,7 +20,7 @@ module RSpec
           klass.include(RSpec::Rails::FeatureCheck)
         end
 
-        shared_examples_for 'a model generator with fixtures' do |name, class_name|
+        RSpec.shared_examples_for 'a model generator with fixtures' do |name, class_name|
           before { run_generator [name, '--fixture'] }
 
           describe 'the spec' do
@@ -38,7 +38,7 @@ module RSpec
           end
         end
 
-        shared_examples_for "a request spec generator" do
+        RSpec.shared_examples_for "a request spec generator" do
           describe 'generated with flag `--no-request-specs`' do
             before do
               run_generator %w[posts --no-request-specs]

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-shared_examples_for "an rspec-rails example group mixin" do |type, *paths|
+RSpec.shared_examples_for "an rspec-rails example group mixin" do |type, *paths|
   let(:mixin) { described_class }
 
   def define_group_in(path, group_definition)


### PR DESCRIPTION
Since rails 6.1.1 changed default behaviour of CRUD response for invalid
attributes - to respond with 422 status, we have to update our scaffold
for generating specs for Create and Update with invalid attributes.

I updated both generators to check if controller responds with status
422 instead of 200.

Also, I didn't find any tests about those generators, so I couldn't update them - if there are some, please let me know so I can update them.

Linked issue: https://github.com/rspec/rspec-rails/issues/2463