### PR TITLE
[WiP] Update of requests specs for invalid params for rails 6.1.1 and above

### DIFF
--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -167,4 +167,17 @@ gsub_file 'spec/requests/gadgets_spec.rb',
 gsub_file 'spec/controllers/uploads_controller_spec.rb',
           'skip("Add a hash of attributes valid for your model")',
           '{}'
+
+# adds validation to widget so our test for happy and unhappy path will be ready to test validation
+gsub_file 'spec/requests/widgets_spec.rb',
+          'skip("Add a hash of attributes invalid for your model")',
+          '{ name: "" }'
+
+gsub_file 'spec/requests/widgets_spec.rb',
+          'skip("Add a hash of attributes valid for your model")',
+          '{ name: "lorem" }'
+
+gsub_file 'app/models/widget.rb',
+          'end',
+          'validates :name, presence: true; end'
 final_tasks

--- a/lib/generators/rspec/scaffold/templates/request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/request_spec.rb
@@ -118,11 +118,19 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
     end
 
     context "with invalid parameters" do
+    <% if Rails.version.to_f < 6.1 || Rails.version == '6.1.0' %>
       it "renders a successful response (i.e. to display the 'edit' template)" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         patch <%= show_helper.tr('@', '') %>, params: { <%= singular_table_name %>: invalid_attributes }
         expect(response).to be_successful
       end
+     <% else %>
+      it "renders a response with 422 status - unporcessable entity" do
+        <%= file_name %> = <%= class_name %>.create! valid_attributes
+        patch <%= show_helper.tr('@', '') %>, params: { <%= singular_table_name %>: invalid_attributes }
+        expect(response.status).to eq(422)
+      end
+    <% end %>
     end
   end
 

--- a/lib/generators/rspec/scaffold/templates/request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/request_spec.rb
@@ -82,10 +82,17 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
         }.to change(<%= class_name %>, :count).by(0)
       end
 
+    <% if Rails.version.to_f < 6.1 || Rails.version == '6.1.0' %>
       it "renders a successful response (i.e. to display the 'new' template)" do
         post <%= index_helper %>_url, params: { <%= ns_file_name %>: invalid_attributes }
         expect(response).to be_successful
       end
+    <% else %>
+      it "renders a response with 422 status - unporcessable entity" do
+        post <%= index_helper %>_url, params: { <%= ns_file_name %>: invalid_attributes }
+        expect(response.status).to eq(422)
+      end
+    <% end %>
     end
   end
 


### PR DESCRIPTION
In order to make requests specs generated for rails 6.1.1 and above
working, we have to update expected behaviour of invalid params for create.

Since rails 6.1.1 is rendering 422 status instead of 302 like before, when
it re-renders form for invalid params, we changed expected behaviour in
request specs.

Also gstubbed files in example app so it will have proper validation
in widget that will be called in generated tests.

Issue related: https://github.com/rspec/rspec-rails/issues/2463