### PR TITLE
Update ammeter (to a temporary repo) to support RSpec 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ end
 # Until 1.13.2 is released due to Rubygems usage
 gem 'ffi', '~> 1.12.0'
 
+# Until https://github.com/alexrothenberg/ammeter/pull/64 is merged and released
+gem 'ammeter', github: 'pirj/ammeter', branch: 'support-rspec-4'
+
 custom_gemfile = File.expand_path('Gemfile-custom', __dir__)
 eval_gemfile custom_gemfile if File.exist?(custom_gemfile)
 

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
     end
   end
 
-  s.add_development_dependency 'ammeter',  '~> 1.1.2'
+  s.add_development_dependency 'ammeter',  '~> 1.1.5'
   s.add_development_dependency 'aruba',    '~> 0.14.12'
   s.add_development_dependency 'cucumber', '~> 1.3.5'
 end


### PR DESCRIPTION
`ammeter` is `rspec-rails`'s development dependency, used to test generators.
Its runtime contains code that is not compatible with the latest changes in RSpec 4 (unification of metadata multi-condition filtering), making `rspec-core`'s `rspec-rails` sub-build to fail.

```ruby
    c.include Ammeter::RSpec::Rails::GeneratorExampleGroup,
      :type          => :generator,
      :file_path     => lambda { |file_path, metadata|
        metadata[:type].nil? && generator_path_regex =~ file_path
      }
```

This is a temporary measure to use `ammeter`'s patched fork until the patch is accepted and a newer version is released.

See
- https://github.com/rspec/rspec-core/issues/1821
- https://github.com/rspec/rspec-core/pull/2874
- https://github.com/alexrothenberg/ammeter/pull/64
- example failure (Ammeter::RSpec::Rails::GeneratorExampleGroup that defines destination is not included) https://github.com/rspec/rspec-core/pull/2874/checks?check_run_id=1942170588