### PR TITLE
Work around ammeter' incompatibility with RSpec 4

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,4 +74,8 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  # TODO: Remove once https://github.com/alexrothenberg/ammeter/pull/64 is merged
+  # Work around ammeter's incompatibility with RSpec 4
+  config.include Ammeter::RSpec::Rails::GeneratorExampleGroup, type: :generator
 end


### PR DESCRIPTION
See:

- rspec/rspec-core#1821
- rspec/rspec-core#2874
- alexrothenberg/ammeter#64
- example failure (Ammeter::RSpec::Rails::GeneratorExampleGroup that defines destination is not included) https://github.com/rspec/rspec-core/pull/2874/checks?check_run_id=1942170588

Less impactful alternative to #2468