### PR TITLE
Update ammeter dependency to support RSpec 4

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
     end
   end
 
-  s.add_development_dependency 'ammeter',  '~> 1.1.2'
+  s.add_development_dependency 'ammeter',  '~> 1.1.5'
   s.add_development_dependency 'aruba',    '~> 0.14.12'
   s.add_development_dependency 'cucumber', '~> 1.3.5'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,8 +74,4 @@ RSpec.configure do |config|
       example.run
     end
   end
-
-  # TODO: Remove once https://github.com/alexrothenberg/ammeter/pull/64 is merged
-  # Work around ammeter's incompatibility with RSpec 4
-  config.include Ammeter::RSpec::Rails::GeneratorExampleGroup, type: :generator
 end


### PR DESCRIPTION
`ammeter` has been updated to support RSpec 4's changes related to metadata filtering, that allows us to remove the hack and use its mainline version.

See https://github.com/alexrothenberg/ammeter/pull/64#issuecomment-785280792