### PR TITLE
Prevent using 3.9 with Rails 6.1

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  version_string = ['>= 3.0']
+  version_string = ['>= 3.0', '< 6.1']
 
   if RUBY_VERSION <= '1.8.7' && ENV['RAILS_VERSION'] != '3-2-stable'
     version_string << '!= 3.2.22.1'


### PR DESCRIPTION
There's an issue with Rails 6.1 that caused error `WrongScopeError`, which was only fixed in rspec-rails 4.0 by #2215.

This should warn the user that rspec-rails need to be upgraded.