### PR TITLE
Be conservative on which Rails version is supported

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  version_string = ['>= 4.2']
+  version_string = ['>= 4.2', '< 6.2']
 
   s.add_runtime_dependency 'actionpack',    version_string
   s.add_runtime_dependency 'activesupport', version_string


### PR DESCRIPTION
`rspec-rails` 3.9 can be installed with Rails 6.1, because it does not limit which rails version is supported, but it actually does not support Rails 6.1. It is not possible to add restriction on the next point release (let's say 3.9.2), because bundler will then install previous version (3.9.1) that does not have the dependency restriction.

Moving forward with rspec-rails 4.1, I think we should be more conservative on which Rails version is supported. If it happens that the next rails version (6.2 or 7.0) is still compatible, it will be easy to make a point release of rspec-rails 4.1.x with the upper bound dependency on Rails updated.