### PR TITLE
remove all spec views on destroy controller

### DIFF
--- a/lib/generators/rspec/controller/controller_generator.rb
+++ b/lib/generators/rspec/controller/controller_generator.rb
@@ -27,7 +27,7 @@ module Rspec
       end
 
       def generate_view_specs
-        return if actions.empty?
+        return if actions.empty? && behavior == :invoke
         return unless options[:view_specs] && options[:template_engine]
 
         empty_directory File.join("spec", "views", file_path)

--- a/spec/generators/rspec/controller/controller_generator_spec.rb
+++ b/spec/generators/rspec/controller/controller_generator_spec.rb
@@ -115,6 +115,11 @@ RSpec.describe Rspec::Generators::ControllerGenerator, type: :generator do
         end
       end
     end
+
+    describe 'are removed' do
+      subject { run_generator %w[posts], behavior: :revoke }
+      it { is_expected.to match('remove  spec/views/posts') }
+    end
   end
 
   describe 'routing spec' do


### PR DESCRIPTION
**Actions**:
1. `rails g controller Authors index show`
2. `rails d controller Authors` 

**Current**
_ON GENERATE_
Rails generates controller and view files
Rspec generates controller and view files
_ON DESTROY_
Rails destroys controller and view files
Rspec destroys only controller

**Proposal**
_ON DESTROY_
Rails destroys controller and view files
Rspec destroys controller and view files