### PR TITLE
Prep version 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,38 +74,6 @@ jobs:
          - ruby: 2.2.10
            env:
              RAILS_VERSION: '5-2-stable'
-         # Rails 5.1 Builds >= 2.2.2
-         - ruby: 2.6.6
-           env:
-             RAILS_VERSION: '~> 5.1.0'
-         - ruby: 2.5.8
-           env:
-             RAILS_VERSION: '~> 5.1.0'
-         - ruby: 2.4.10
-           env:
-             RAILS_VERSION: '~> 5.1.0'
-         - ruby: 2.3.8
-           env:
-             RAILS_VERSION: '~> 5.1.0'
-         - ruby: 2.2.10
-           env:
-             RAILS_VERSION: '~> 5.1.0'
-         # Rails 5.0 Builds >= 2.2.2
-         - ruby: 2.6.6
-           env:
-             RAILS_VERSION: '~> 5.0.0'
-         - ruby: 2.5.8
-           env:
-             RAILS_VERSION: '~> 5.0.0'
-         - ruby: 2.4.10
-           env:
-             RAILS_VERSION: '~> 5.0.0'
-         - ruby: 2.3.8
-           env:
-             RAILS_VERSION: '~> 5.0.0'
-         - ruby: 2.2.10
-           env:
-             RAILS_VERSION: '~> 5.0.0'
     env: ${{ matrix.env }}
     steps:
       - uses: actions/checkout@v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,14 @@
-### Development
+### 5.0.0
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v4.1.0...main)
+
+Enhancements:
 
 * Support new #file_fixture_path and new fixture test support code. (Jon Rowe, #2398)
 * Support for Rails 6.1. (Benoit Tigeot, Jon Rowe, Phil Pirozhkov, and more #2398)
+
+Breaking Changes:
+
+* Drop support for Rails below 5.2.
 
 ### 4.1.0 / 2021-03-06
 

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -17,7 +17,7 @@ when /master/
   gem 'selenium-webdriver', require: false
 when /stable$/
   gem_list = %w[rails railties actionmailer actionpack activerecord activesupport activejob actionview]
-  gem 'puma', "3.12.1" if version > '5-0-stable'
+  gem 'puma', "3.12.1"
   gem 'activerecord-jdbcsqlite3-adapter', git: 'https://github.com/jruby/activerecord-jdbc-adapter', platforms: [:jruby]
 
   gem_list.each do |rails_gem|
@@ -31,7 +31,7 @@ when nil, false, ""
 else
   gem "rails", version
   gem "sprockets", '~> 3.0' if RUBY_VERSION < '2.5'
-  gem "puma" if version >= '5-1-stable'
+  gem "puma"
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
-  gem 'selenium-webdriver', require: false if version >= '5'
+  gem 'selenium-webdriver', require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -13,11 +13,7 @@ require 'cucumber/rake/task'
 
 def rails_template_command
   require "rails/version"
-  if Rails.version.to_f >= 5.0
-    "app:template"
-  else
-    "rails:template"
-  end
+  "app:template"
 end
 
 desc "Run all examples"
@@ -35,14 +31,6 @@ Cucumber::Rake::Task.new(:cucumber) do |t|
       string_version[/\d[\.-]\d/].tr('-', '.')
     end
   tags = []
-
-  if version.to_f >= 5.1
-    tags << "~@rails_pre_5.1"
-  end
-
-  if version.to_f == 5.0
-    tags << "~@system_test"
-  end
 
   if version.to_f >= 6.0
     tags << "~@rails_pre_6"

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -24,11 +24,7 @@ in_root do
   gsub_file "Gemfile", /.*puma.*/, ''
   gsub_file "Gemfile", /.*bootsnap.*/, ''
 
-  # We soft-support Rails 4.2. `rails-controller-testing` only supports Rails 5+.
-  # This conditional is to facilitate local testing against Rails 4.2.
-  if Rails::VERSION::STRING >= '5'
-    append_to_file 'Gemfile', "gem 'rails-controller-testing'\n"
-  end
+  append_to_file 'Gemfile', "gem 'rails-controller-testing'\n"
 
   if Rails::VERSION::STRING >= '6'
     gsub_file "Gemfile", /.*rails-controller-testing.*/, "gem 'rails-controller-testing', git: 'https://github.com/rails/rails-controller-testing'"
@@ -47,14 +43,12 @@ in_root do
     gsub_file "Gemfile", /.*gem..sqlite3.*/, "gem 'sqlite3', '~> 1.3.6'"
   end
 
-  if Rails::VERSION::STRING >= "5.1.0"
-    # webdrivers 4 up until 4.3.0 don't specify `required_ruby_version`, but contain
-    # Ruby 2.2-incompatible syntax (safe navigation).
-    # That basically means we use pre-4.0 for Ruby 2.2, and 4.3+ for newer Rubies.
-    gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers', '!= 4.0.0', '!= 4.0.1', '!= 4.1.0', '!= 4.1.1', '!= 4.1.2', '!= 4.1.3', '!= 4.2.0'"
-  end
+  # webdrivers 4 up until 4.3.0 don't specify `required_ruby_version`, but contain
+  # Ruby 2.2-incompatible syntax (safe navigation).
+  # That basically means we use pre-4.0 for Ruby 2.2, and 4.3+ for newer Rubies.
+  gsub_file "Gemfile", /.*chromedriver-helper.*/, "gem 'webdrivers', '!= 4.0.0', '!= 4.0.1', '!= 4.1.0', '!= 4.1.1', '!= 4.1.2', '!= 4.1.3', '!= 4.2.0'"
 
-  if Rails::VERSION::STRING >= '5.2.0' && Rails::VERSION::STRING < '6'
+  if Rails::VERSION::STRING < '6'
     copy_file sqlite_initializer, 'config/initializers/sqlite3_fix.rb'
   end
 

--- a/features/feature_specs/feature_spec.feature
+++ b/features/feature_specs/feature_spec.feature
@@ -17,35 +17,6 @@ Feature: Feature spec
   [customer](http://c2.com/cgi/wiki?CustomerTest) and [acceptance](http://c2.com/cgi/wiki?AcceptanceTest) tests. When capybara is required it sets
   `:type => :feature` automatically for you.
 
-  @rails_pre_5.1
-  Scenario: Feature specs are skipped without Capybara
-    Given a file named "spec/features/widget_management_spec.rb" with:
-      """ruby
-      require "rails_helper"
-
-      RSpec.feature "Widget management", :type => :feature do
-        scenario "User creates a new widget" do
-          visit "/widgets/new"
-
-          fill_in "Name", :with => "My Widget"
-          click_button "Create Widget"
-
-          expect(page).to have_text("Widget was successfully created.")
-        end
-      end
-      """
-    When I run `rspec spec/features/widget_management_spec.rb`
-    Then the exit status should be 0
-    And the output should contain "1 example, 0 failures, 1 pending"
-    And the output should contain:
-      """
-      Pending: (Failures listed here are expected and do not affect your suite's status)
-
-        1) Widget management User creates a new widget
-           # Feature specs require the Capybara (https://github.com/teamcapybara/capybara) gem, version 2.13.0 or later.
-           # ./spec/features/widget_management_spec.rb:4
-      """
-
   @capybara
   Scenario: specify creating a Widget by driving the application with capybara
     Given a file named "spec/features/widget_management_spec.rb" with:

--- a/features/upgrade/README.md
+++ b/features/upgrade/README.md
@@ -1,3 +1,9 @@
+# Upgrading from rspec-rails 4.x to version 5
+
+RSpec Rails 5 is a major version under semantic versioning, it also follows our new versioning strategy for RSpec-Rails, which is to keep in step with Rails supported versions. Thus it supports 5.2, 6.0 and 6.1. There are no changes required to upgrade to RSpec Rails 5 if you are using a supported version of Rails.
+
+If you are using an older version of Rails, you can use 4.x which hard supports 5.0 and 5.1, and soft supports 4.2 (which is unmaintained).
+
 # Upgrading from rspec-rails 3.x to version 4
 
 RSpec Rails 4 is a major version under semantic versioning, it allowed us to change the supported Rails versions to 5 and 6 only. There are no changes required to upgrade to RSpec Rails 4 if you are using Rails 5 or 6.

--- a/lib/generators/rspec/mailer/templates/mailer_spec.rb
+++ b/lib/generators/rspec/mailer/templates/mailer_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 <% module_namespacing do -%>
-RSpec.describe <%= Rails.version.to_f >= 5.0 ? class_name.sub(/(Mailer)?$/, 'Mailer') : class_name %>, <%= type_metatag(:mailer) %> do
+RSpec.describe <%= class_name.sub(/(Mailer)?$/, 'Mailer') %>, <%= type_metatag(:mailer) %> do
 <% for action in actions -%>
   describe "<%= action %>" do
-    let(:mail) { <%= Rails.version.to_f >= 5.0 ? class_name.sub(/(Mailer)?$/, 'Mailer') : class_name %>.<%= action %> }
+    let(:mail) { <%= class_name.sub(/(Mailer)?$/, 'Mailer') %>.<%= action %> }
 
     it "renders the headers" do
       expect(mail.subject).to eq(<%= action.to_s.humanize.inspect %>)

--- a/lib/generators/rspec/mailer/templates/preview.rb
+++ b/lib/generators/rspec/mailer/templates/preview.rb
@@ -5,7 +5,7 @@ class <%= class_name %>Preview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/<%= file_path %>/<%= action %>
   def <%= action %>
-    <%= Rails.version.to_f >= 5.0 ? class_name.sub(/(Mailer)?$/, 'Mailer') : class_name %>.<%= action %>
+    <%= class_name.sub(/(Mailer)?$/, 'Mailer') %>.<%= action %>
   end
 <% end -%>
 

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -46,11 +46,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #index" do
     it "returns a success response" do
       <%= class_name %>.create! valid_attributes
-<% if Rails::VERSION::STRING < '5.0' -%>
-      get :index, {}, valid_session
-<% else -%>
       get :index, params: {}, session: valid_session
-<% end -%>
       expect(response).to be_successful
     end
   end
@@ -59,22 +55,14 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #show" do
     it "returns a success response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if Rails::VERSION::STRING < '5.0' -%>
-      get :show, {id: <%= file_name %>.to_param}, valid_session
-<% else -%>
       get :show, params: {id: <%= file_name %>.to_param}, session: valid_session
-<% end -%>
       expect(response).to be_successful
     end
   end
 
   describe "GET #new" do
     it "returns a success response" do
-<% if Rails::VERSION::STRING < '5.0' -%>
-      get :new, {}, valid_session
-<% else -%>
       get :new, params: {}, session: valid_session
-<% end -%>
       expect(response).to be_successful
     end
   end
@@ -82,11 +70,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   describe "GET #edit" do
     it "returns a success response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if Rails::VERSION::STRING < '5.0' -%>
-      get :edit, {id: <%= file_name %>.to_param}, valid_session
-<% else -%>
       get :edit, params: {id: <%= file_name %>.to_param}, session: valid_session
-<% end -%>
       expect(response).to be_successful
     end
   end
@@ -95,31 +79,19 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with valid params" do
       it "creates a new <%= class_name %>" do
         expect {
-<% if Rails::VERSION::STRING < '5.0' -%>
-          post :create, {<%= ns_file_name %>: valid_attributes}, valid_session
-<% else -%>
           post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
-<% end -%>
         }.to change(<%= class_name %>, :count).by(1)
       end
 
       it "redirects to the created <%= ns_file_name %>" do
-<% if Rails::VERSION::STRING < '5.0' -%>
-        post :create, {<%= ns_file_name %>: valid_attributes}, valid_session
-<% else -%>
         post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
-<% end -%>
         expect(response).to redirect_to(<%= class_name %>.last)
       end
     end
 
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'new' template)" do
-<% if Rails::VERSION::STRING < '5.0' -%>
-        post :create, {<%= ns_file_name %>: invalid_attributes}, valid_session
-<% else -%>
         post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
-<% end -%>
         expect(response).to be_successful
       end
     end
@@ -133,22 +105,14 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
 
       it "updates the requested <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if Rails::VERSION::STRING < '5.0' -%>
-        put :update, {id: <%= file_name %>.to_param, <%= ns_file_name %>: new_attributes}, valid_session
-<% else -%>
         put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: new_attributes}, session: valid_session
-<% end -%>
         <%= file_name %>.reload
         skip("Add assertions for updated state")
       end
 
       it "redirects to the <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if Rails::VERSION::STRING < '5.0' -%>
-        put :update, {id: <%= file_name %>.to_param, <%= ns_file_name %>: valid_attributes}, valid_session
-<% else -%>
         put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: valid_attributes}, session: valid_session
-<% end -%>
         expect(response).to redirect_to(<%= file_name %>)
       end
     end
@@ -156,11 +120,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'edit' template)" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if Rails::VERSION::STRING < '5.0' -%>
-        put :update, {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, valid_session
-<% else -%>
         put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
-<% end -%>
         expect(response).to be_successful
       end
     end
@@ -170,21 +130,13 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     it "destroys the requested <%= ns_file_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       expect {
-<% if Rails::VERSION::STRING < '5.0' -%>
-        delete :destroy, {id: <%= file_name %>.to_param}, valid_session
-<% else -%>
         delete :destroy, params: {id: <%= file_name %>.to_param}, session: valid_session
-<% end -%>
       }.to change(<%= class_name %>, :count).by(-1)
     end
 
     it "redirects to the <%= table_name %> list" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-<% if Rails::VERSION::STRING < '5.0' -%>
-      delete :destroy, {id: <%= file_name %>.to_param}, valid_session
-<% else -%>
       delete :destroy, params: {id: <%= file_name %>.to_param}, session: valid_session
-<% end -%>
       expect(response).to redirect_to(<%= index_helper %>_url)
     end
   end

--- a/lib/generators/rspec/scaffold/templates/edit_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/edit_spec.rb
@@ -16,11 +16,7 @@ RSpec.describe "<%= ns_table_name %>/edit", <%= type_metatag(:view) %> do
     assert_select "form[action=?][method=?]", <%= ns_file_name %>_path(@<%= ns_file_name %>), "post" do
 <% for attribute in output_attributes -%>
       <%- name = attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>
-<% if Rails.version.to_f >= 5.1 -%>
       assert_select "<%= attribute.input_type -%>[name=?]", "<%= ns_file_name %>[<%= name %>]"
-<% else -%>
-      assert_select "<%= attribute.input_type -%>#<%= ns_file_name %>_<%= name %>[name=?]", "<%= ns_file_name %>[<%= name %>]"
-<% end -%>
 <% end -%>
     end
   end

--- a/lib/generators/rspec/scaffold/templates/new_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/new_spec.rb
@@ -15,11 +15,7 @@ RSpec.describe "<%= ns_table_name %>/new", <%= type_metatag(:view) %> do
     assert_select "form[action=?][method=?]", <%= index_helper %>_path, "post" do
 <% for attribute in output_attributes -%>
       <%- name = attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>
-<% if Rails.version.to_f >= 5.1 -%>
       assert_select "<%= attribute.input_type -%>[name=?]", "<%= ns_file_name %>[<%= name %>]"
-<% else -%>
-      assert_select "<%= attribute.input_type -%>#<%= ns_file_name %>_<%= name %>[name=?]", "<%= ns_file_name %>[<%= name %>]"
-<% end -%>
 <% end -%>
     end
   end

--- a/lib/generators/rspec/system/system_generator.rb
+++ b/lib/generators/rspec/system/system_generator.rb
@@ -1,25 +1,23 @@
 require 'generators/rspec'
 
-if ::Rails::VERSION::STRING >= '5.1'
-  module Rspec
-    module Generators
-      # @private
-      class SystemGenerator < Base
-        class_option :system_specs, type: :boolean, default: true,  desc: "Generate system specs"
+module Rspec
+  module Generators
+    # @private
+    class SystemGenerator < Base
+      class_option :system_specs, type: :boolean, default: true,  desc: "Generate system specs"
 
-        def generate_system_spec
-          return unless options[:system_specs]
+      def generate_system_spec
+        return unless options[:system_specs]
 
-          template template_name, File.join('spec/system', class_path, filename)
-        end
+        template template_name, File.join('spec/system', class_path, filename)
+      end
 
-        def template_name
-          'system_spec.rb'
-        end
+      def template_name
+        'system_spec.rb'
+      end
 
-        def filename
-          "#{table_name}_spec.rb"
-        end
+      def filename
+        "#{table_name}_spec.rb"
       end
     end
   end

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -7,13 +7,11 @@ module RSpec
     # Railtie to hook into Rails.
     class Railtie < ::Rails::Railtie
       # As of Rails 5.1.0 you can register directories to work with `rake notes`
-      if ::Rails::VERSION::STRING >= '5.1'
-        require 'rails/source_annotation_extractor'
-        if ::Rails::VERSION::STRING >= '6.0'
-          ::Rails::SourceAnnotationExtractor::Annotation.register_directories("spec")
-        else
-          SourceAnnotationExtractor::Annotation.register_directories("spec")
-        end
+      require 'rails/source_annotation_extractor'
+      if ::Rails::VERSION::STRING >= '6.0'
+        ::Rails::SourceAnnotationExtractor::Annotation.register_directories("spec")
+      else
+        SourceAnnotationExtractor::Annotation.register_directories("spec")
       end
       generators = config.app_generators
       generators.integration_tool :rspec

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -80,10 +80,8 @@ module RSpec
       #   `RSpec::Rails::FixtureSupport` directly instead
       config.include RSpec::Rails::FixtureSupport
 
-      if ::Rails::VERSION::STRING > '5'
-        config.add_setting :file_fixture_path, default: 'spec/fixtures/files'
-        config.include RSpec::Rails::FileFixtureSupport
-      end
+      config.add_setting :file_fixture_path, default: 'spec/fixtures/files'
+      config.include RSpec::Rails::FileFixtureSupport
 
       # Add support for fixture_path on fixture_file_upload
       config.include RSpec::Rails::FixtureFileUploadSupport

--- a/lib/rspec/rails/example/request_example_group.rb
+++ b/lib/rspec/rails/example/request_example_group.rb
@@ -10,10 +10,7 @@ module RSpec
       include RSpec::Rails::Matchers::RedirectTo
       include RSpec::Rails::Matchers::RenderTemplate
       include ActionController::TemplateAssertions
-
-      if ActionPack::VERSION::MAJOR >= 5
-        include ActionDispatch::IntegrationTest::Behavior
-      end
+      include ActionDispatch::IntegrationTest::Behavior
 
       # Delegates to `Rails.application`.
       def app

--- a/lib/rspec/rails/file_fixture_support.rb
+++ b/lib/rspec/rails/file_fixture_support.rb
@@ -1,16 +1,14 @@
-if ::Rails::VERSION::STRING > '5'
-  require 'active_support/testing/file_fixtures'
+require 'active_support/testing/file_fixtures'
 
-  module RSpec
-    module Rails
-      # @private
-      module FileFixtureSupport
-        extend ActiveSupport::Concern
-        include ActiveSupport::Testing::FileFixtures
+module RSpec
+  module Rails
+    # @private
+    module FileFixtureSupport
+      extend ActiveSupport::Concern
+      include ActiveSupport::Testing::FileFixtures
 
-        included do
-          self.file_fixture_path = RSpec.configuration.file_fixture_path
-        end
+      included do
+        self.file_fixture_path = RSpec.configuration.file_fixture_path
       end
     end
   end

--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -21,11 +21,7 @@ module RSpec
             include Fixtures
 
             self.fixture_path = RSpec.configuration.fixture_path
-            if ::Rails::VERSION::STRING > '5'
-              self.use_transactional_tests = RSpec.configuration.use_transactional_fixtures
-            else
-              self.use_transactional_fixtures = RSpec.configuration.use_transactional_fixtures
-            end
+            self.use_transactional_tests = RSpec.configuration.use_transactional_fixtures
             self.use_instantiated_fixtures = RSpec.configuration.use_instantiated_fixtures
 
             fixtures RSpec.configuration.global_fixtures if RSpec.configuration.global_fixtures

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  version_string = ['>= 4.2']
+  version_string = ['>= 5.2']
 
   s.add_runtime_dependency 'actionpack',    version_string
   s.add_runtime_dependency 'activesupport', version_string

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -167,35 +167,18 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
       it { is_expected.to contain('assert_select "tr>td", text: 3.5.to_s, count: 2') }
     end
 
-    if Rails.version.to_f >= 5.1
-      describe 'with reference attribute' do
-        before { run_generator %w[posts title:string author:references] }
-        describe 'edit' do
-          subject { file("spec/views/posts/edit.html.erb_spec.rb") }
-          it { is_expected.to contain(/assert_select "input\[name=\?\]", "post\[author_id\]/) }
-          it { is_expected.to contain(/assert_select "input\[name=\?\]", "post\[title\]/) }
-        end
-
-        describe 'new' do
-          subject { file("spec/views/posts/new.html.erb_spec.rb") }
-          it { is_expected.to contain(/assert_select "input\[name=\?\]", "post\[author_id\]"/) }
-          it { is_expected.to contain(/assert_select "input\[name=\?\]", "post\[title\]/) }
-        end
+    describe 'with reference attribute' do
+      before { run_generator %w[posts title:string author:references] }
+      describe 'edit' do
+        subject { file("spec/views/posts/edit.html.erb_spec.rb") }
+        it { is_expected.to contain(/assert_select "input\[name=\?\]", "post\[author_id\]/) }
+        it { is_expected.to contain(/assert_select "input\[name=\?\]", "post\[title\]/) }
       end
-    else
-      describe 'with reference attribute' do
-        before { run_generator %w[posts title:string author:references] }
-        describe 'edit' do
-          subject { file("spec/views/posts/edit.html.erb_spec.rb") }
-          it { is_expected.to contain(/assert_select "input#(.*)_author_id\[name=\?\]", "\1\[author_id\]/) }
-          it { is_expected.to contain(/assert_select "input#(.*)_title\[name=\?\]", "\1\[title\]/) }
-        end
 
-        describe 'new' do
-          subject { file("spec/views/posts/new.html.erb_spec.rb") }
-          it { is_expected.to contain(/assert_select "input#(.*)_author_id\[name=\?\]", "\1\[author_id\]"/) }
-          it { is_expected.to contain(/assert_select "input#(.*)_title\[name=\?\]", "\1\[title\]/) }
-        end
+      describe 'new' do
+        subject { file("spec/views/posts/new.html.erb_spec.rb") }
+        it { is_expected.to contain(/assert_select "input\[name=\?\]", "post\[author_id\]"/) }
+        it { is_expected.to contain(/assert_select "input\[name=\?\]", "post\[title\]/) }
       end
     end
 

--- a/spec/generators/rspec/system/system_generator_spec.rb
+++ b/spec/generators/rspec/system/system_generator_spec.rb
@@ -1,38 +1,36 @@
 # Generators are not automatically loaded by rails
-if ::Rails::VERSION::STRING >= '5.1'
-  require 'generators/rspec/system/system_generator'
-  require 'support/generators'
+require 'generators/rspec/system/system_generator'
+require 'support/generators'
 
-  RSpec.describe Rspec::Generators::SystemGenerator, type: :generator do
-    setup_default_destination
+RSpec.describe Rspec::Generators::SystemGenerator, type: :generator do
+  setup_default_destination
 
-    describe "system specs" do
-      subject(:system_spec) { file("spec/system/posts_spec.rb") }
-      describe "are generated independently from the command line" do
-        before do
-          run_generator %w[posts]
+  describe "system specs" do
+    subject(:system_spec) { file("spec/system/posts_spec.rb") }
+    describe "are generated independently from the command line" do
+      before do
+        run_generator %w[posts]
+      end
+      describe "the spec" do
+        it "exists" do
+          expect(system_spec).to exist
         end
-        describe "the spec" do
-          it "exists" do
-            expect(system_spec).to exist
-          end
-          it "contains 'rails_helper'" do
-            expect(system_spec).to contain(/require 'rails_helper'/)
-          end
-          it "contains the system" do
-            expect(system_spec).to contain(/^RSpec.describe \"Posts\", #{type_metatag(:system)}/)
-          end
+        it "contains 'rails_helper'" do
+          expect(system_spec).to contain(/require 'rails_helper'/)
+        end
+        it "contains the system" do
+          expect(system_spec).to contain(/^RSpec.describe \"Posts\", #{type_metatag(:system)}/)
         end
       end
+    end
 
-      describe "are not generated" do
-        before do
-          run_generator %w[posts --no-system-specs]
-        end
-        describe "the spec" do
-          it "does not exist" do
-            expect(system_spec).to_not exist
-          end
+    describe "are not generated" do
+      before do
+        run_generator %w[posts --no-system-specs]
+      end
+      describe "the spec" do
+        it "does not exist" do
+          expect(system_spec).to_not exist
         end
       end
     end

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -1,83 +1,81 @@
 module RSpec::Rails
-  if ActionPack::VERSION::STRING >= "5.1"
-    RSpec.describe SystemExampleGroup do
-      it_behaves_like "an rspec-rails example group mixin", :system,
-                      './spec/system/', '.\\spec\\system\\'
+  RSpec.describe SystemExampleGroup do
+    it_behaves_like "an rspec-rails example group mixin", :system,
+                    './spec/system/', '.\\spec\\system\\'
 
-      describe '#method_name' do
-        it 'converts special characters to underscores' do
-          group = RSpec::Core::ExampleGroup.describe ActionPack do
-            include SystemExampleGroup
-          end
-          SystemExampleGroup::CHARS_TO_TRANSLATE.each do |char|
-            example = group.new
-            example_class_mock = double('name' => "method#{char}name")
-            allow(example).to receive(:class).and_return(example_class_mock)
-            expect(example.send(:method_name)).to start_with('method_name')
-          end
+    describe '#method_name' do
+      it 'converts special characters to underscores' do
+        group = RSpec::Core::ExampleGroup.describe ActionPack do
+          include SystemExampleGroup
+        end
+        SystemExampleGroup::CHARS_TO_TRANSLATE.each do |char|
+          example = group.new
+          example_class_mock = double('name' => "method#{char}name")
+          allow(example).to receive(:class).and_return(example_class_mock)
+          expect(example.send(:method_name)).to start_with('method_name')
         end
       end
+    end
 
-      describe '#driver' do
-        it 'uses :selenium driver by default' do
-          group = RSpec::Core::ExampleGroup.describe do
-            include SystemExampleGroup
-          end
-          example = group.new
-          group.hooks.run(:before, :example, example)
-
-          expect(Capybara.current_driver).to eq :selenium
+    describe '#driver' do
+      it 'uses :selenium driver by default' do
+        group = RSpec::Core::ExampleGroup.describe do
+          include SystemExampleGroup
         end
+        example = group.new
+        group.hooks.run(:before, :example, example)
 
-        it 'sets :rack_test driver using by before_action' do
-          group = RSpec::Core::ExampleGroup.describe do
-            include SystemExampleGroup
-
-            before do
-              driven_by(:rack_test)
-            end
-          end
-          example = group.new
-          group.hooks.run(:before, :example, example)
-
-          expect(Capybara.current_driver).to eq :rack_test
-        end
-
-        it 'calls :driven_by method only once' do
-          group = RSpec::Core::ExampleGroup.describe do
-            include SystemExampleGroup
-
-            before do
-              driven_by(:rack_test)
-            end
-          end
-          example = group.new
-          allow(example).to receive(:driven_by).and_call_original
-          group.hooks.run(:before, :example, example)
-
-          expect(example).to have_received(:driven_by).once
-        end
+        expect(Capybara.current_driver).to eq :selenium
       end
 
-      describe '#after' do
-        it 'sets the :extra_failure_lines metadata to an array of STDOUT lines' do
-          group = RSpec::Core::ExampleGroup.describe do
-            include SystemExampleGroup
+      it 'sets :rack_test driver using by before_action' do
+        group = RSpec::Core::ExampleGroup.describe do
+          include SystemExampleGroup
 
-            before do
-              driven_by(:selenium)
-            end
-
-            def take_screenshot
-              puts 'line 1'
-              puts 'line 2'
-            end
+          before do
+            driven_by(:rack_test)
           end
-          example = group.it('fails') { fail }
-          group.run
-
-          expect(example.metadata[:extra_failure_lines]).to eq(["line 1\n", "line 2\n"])
         end
+        example = group.new
+        group.hooks.run(:before, :example, example)
+
+        expect(Capybara.current_driver).to eq :rack_test
+      end
+
+      it 'calls :driven_by method only once' do
+        group = RSpec::Core::ExampleGroup.describe do
+          include SystemExampleGroup
+
+          before do
+            driven_by(:rack_test)
+          end
+        end
+        example = group.new
+        allow(example).to receive(:driven_by).and_call_original
+        group.hooks.run(:before, :example, example)
+
+        expect(example).to have_received(:driven_by).once
+      end
+    end
+
+    describe '#after' do
+      it 'sets the :extra_failure_lines metadata to an array of STDOUT lines' do
+        group = RSpec::Core::ExampleGroup.describe do
+          include SystemExampleGroup
+
+          before do
+            driven_by(:selenium)
+          end
+
+          def take_screenshot
+            puts 'line 1'
+            puts 'line 2'
+          end
+        end
+        example = group.it('fails') { fail }
+        group.run
+
+        expect(example.metadata[:extra_failure_lines]).to eq(["line 1\n", "line 2\n"])
       end
     end
   end


### PR DESCRIPTION
As we prepare to release Rails 6.1 support, following our new versioning strategy this means changing the major version and matching the supported Rails versions, see https://guides.rubyonrails.org/maintenance_policy.html, which is 5.2+

So this is for review of that new constraint for us, and removes a bunch of 4.2 / 5 supporting conditionals.