### PR TITLE
Fixed content_type comparison from eq to match

### DIFF
--- a/lib/generators/rspec/scaffold/templates/api_request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/api_request_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
         post <%= index_helper %>_url,
              params: { <%= ns_file_name %>: invalid_attributes }, headers: valid_headers, as: :json
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.content_type).to eq("application/json")
+        expect(response.content_type).to match(a_string_including("application/json"))
       end
     end
   end
@@ -114,7 +114,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
         patch <%= show_helper.tr('@', '') %>,
               params: { <%= singular_table_name %>: invalid_attributes }, headers: valid_headers, as: :json
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.content_type).to eq("application/json")
+        expect(response.content_type).to match(a_string_including("application/json"))
       end
     end
   end


### PR DESCRIPTION
Since Rails 6.1, the return value of content-type has changed as follows, so the scaffold template has been modified to support Rails6.1 and others.

https://github.com/rails/rails/pull/36034/files#diff-f5ff9aa07f44111a79d56c09ec37d774b462d97aff68f32490c2e56e74c95783R137