### PR TITLE
Fix method name truncation for multibyte strings (redux)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v5.0.0...main)
 
+Bug Fixes:
+
+* Limit multibyte example descriptions when used in system tests for #method_name
+  which ends up as screenshot names etc. (@y-yagi, #2405, #2487)
+
 ### 5.0.0 / 2021-03-09
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v4.1.1...v5.0.0)
 

--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -41,7 +41,7 @@ module RSpec
         @method_name ||= [
           self.class.name.underscore,
           RSpec.current_example.description.underscore
-        ].join("_").tr(CHARS_TO_TRANSLATE.join, "_")[0...200] + "_#{rand(1000)}"
+        ].join("_").tr(CHARS_TO_TRANSLATE.join, "_").byteslice(0...200).scrub("") + "_#{rand(1000)}"
       end
 
       # Delegates to `Rails.application`.

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -14,15 +14,18 @@ module RSpec::Rails
           allow(example).to receive(:class).and_return(example_class_mock)
           expect(example.send(:method_name)).to start_with('method_name')
         end
+      end
 
-        it "slices long method name - #{'あ'*100}" do
-          group = RSpec::Core::ExampleGroup.describe do
+      it "handles long method names which include unicode characters" do
+        group =
+          RSpec::Core::ExampleGroup.describe do
             include SystemExampleGroup
           end
-          example = group.new
-          group.hooks.run(:before, :example, example)
-          expect(example.send(:method_name).bytesize).to be <= 210
-        end
+
+        example = group.new
+        allow(example.class).to receive(:name) { "really long unicode example name - #{'あ'*100}" }
+
+        expect(example.send(:method_name).bytesize).to be <= 210
       end
     end
 

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -14,6 +14,15 @@ module RSpec::Rails
           allow(example).to receive(:class).and_return(example_class_mock)
           expect(example.send(:method_name)).to start_with('method_name')
         end
+
+        it "slices long method name - #{'あ'*100}" do
+          group = RSpec::Core::ExampleGroup.describe do
+            include SystemExampleGroup
+          end
+          example = group.new
+          group.hooks.run(:before, :example, example)
+          expect(example.send(:method_name).bytesize).to be <= 210
+        end
       end
     end
 


### PR DESCRIPTION
This just reworks the spec for #2405 