### PR TITLE
Fix "render" typo on request specs generated via scaffold

### DIFF
--- a/lib/generators/rspec/scaffold/templates/request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/request_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
   end
 
   describe "GET /edit" do
-    it "render a successful response" do
+    it "renders a successful response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       get <%= edit_helper.tr('@','') %>
       expect(response).to be_successful


### PR DESCRIPTION
As seen on other specs in the same file, the spec should read as:

`it "renders a successful response" do`

instead of:

`it "render a successful response" do`