### PR TITLE
Fixes requests specs generated by scaffold with namespace resource

### DIFF
--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -127,6 +127,10 @@ module Rspec
       def banner
         self.class.banner
       end
+
+      def show_helper(resource_name = file_name)
+        "#{singular_route_name}_url(#{resource_name})"
+      end
     end
   end
 end

--- a/lib/generators/rspec/scaffold/templates/api_request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/api_request_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
   describe "GET /show" do
     it "renders a successful response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      get <%= show_helper.tr('@', '') %>, as: :json
+      get <%= show_helper %>, as: :json
       expect(response).to be_successful
     end
   end
@@ -93,7 +93,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
 
       it "updates the requested <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        patch <%= show_helper.tr('@', '') %>,
+        patch <%= show_helper %>,
               params: { <%= singular_table_name %>: new_attributes }, headers: valid_headers, as: :json
         <%= file_name %>.reload
         skip("Add assertions for updated state")
@@ -101,7 +101,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
 
       it "renders a JSON response with the <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        patch <%= show_helper.tr('@', '') %>,
+        patch <%= show_helper %>,
               params: { <%= singular_table_name %>: new_attributes }, headers: valid_headers, as: :json
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to match(a_string_including("application/json"))
@@ -111,7 +111,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
     context "with invalid parameters" do
       it "renders a JSON response with errors for the <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        patch <%= show_helper.tr('@', '') %>,
+        patch <%= show_helper %>,
               params: { <%= singular_table_name %>: invalid_attributes }, headers: valid_headers, as: :json
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to match(a_string_including("application/json"))
@@ -123,7 +123,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
     it "destroys the requested <%= ns_file_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       expect {
-        delete <%= show_helper.tr('@', '') %>, headers: valid_headers, as: :json
+        delete <%= show_helper %>, headers: valid_headers, as: :json
       }.to change(<%= class_name %>, :count).by(-1)
     end
   end

--- a/lib/generators/rspec/scaffold/templates/request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/request_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
   describe "GET /show" do
     it "renders a successful response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      get <%= show_helper.tr('@', '') %>
+      get <%= show_helper %>
       expect(response).to be_successful
     end
   end
@@ -71,7 +71,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
 
       it "redirects to the created <%= ns_file_name %>" do
         post <%= index_helper %>_url, params: { <%= ns_file_name %>: valid_attributes }
-        expect(response).to redirect_to(<%= show_helper.gsub("\@#{file_name}", class_name+".last") %>)
+        expect(response).to redirect_to(<%= show_helper(class_name+".last") %>)
       end
     end
 
@@ -97,14 +97,14 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
 
       it "updates the requested <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        patch <%= show_helper.tr('@', '') %>, params: { <%= singular_table_name %>: new_attributes }
+        patch <%= show_helper %>, params: { <%= singular_table_name %>: new_attributes }
         <%= file_name %>.reload
         skip("Add assertions for updated state")
       end
 
       it "redirects to the <%= ns_file_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        patch <%= show_helper.tr('@', '') %>, params: { <%= singular_table_name %>: new_attributes }
+        patch <%= show_helper %>, params: { <%= singular_table_name %>: new_attributes }
         <%= file_name %>.reload
         expect(response).to redirect_to(<%= singular_table_name %>_url(<%= file_name %>))
       end
@@ -113,7 +113,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
     context "with invalid parameters" do
       it "renders a successful response (i.e. to display the 'edit' template)" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        patch <%= show_helper.tr('@', '') %>, params: { <%= singular_table_name %>: invalid_attributes }
+        patch <%= show_helper %>, params: { <%= singular_table_name %>: invalid_attributes }
         expect(response).to be_successful
       end
     end
@@ -123,13 +123,13 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
     it "destroys the requested <%= ns_file_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       expect {
-        delete <%= show_helper.tr('@', '') %>
+        delete <%= show_helper %>
       }.to change(<%= class_name %>, :count).by(-1)
     end
 
     it "redirects to the <%= table_name %> list" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      delete <%= show_helper.tr('@', '') %>
+      delete <%= show_helper %>
       expect(response).to redirect_to(<%= index_helper %>_url)
     end
   end

--- a/lib/generators/rspec/scaffold/templates/request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/request_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
   describe "GET /edit" do
     it "renders a successful response" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
-      get <%= edit_helper.tr('@','') %>
+      get <%= edit_helper %>
       expect(response).to be_successful
     end
   end

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
     before  { run_generator %w[admin/posts] }
     it { is_expected.to exist }
     it { is_expected.to contain(/^RSpec.describe "\/admin\/posts", #{type_metatag(:request)}/) }
-    it { is_expected.to contain('admin_post_url(admin_post)') }
+    it { is_expected.to contain('admin_post_url(post)') }
     it { is_expected.to contain('Admin::Post.create') }
   end
 


### PR DESCRIPTION
# Description
Refactor show_helper to match variable spec data in requests specs created by scaffold generators, when the resource has a namespace

# Example generator response
`rails g scaffold accounts/user name:string`

```ruby
require 'rails_helper'

# This spec was generated by rspec-rails when you ran the scaffold generator.
# It demonstrates how one might use RSpec to test the controller code that
# was generated by Rails when you ran the scaffold generator.
#
# It assumes that the implementation code is generated by the rails scaffold
# generator. If you are using any extension libraries to generate different
# controller code, this generated spec may or may not pass.
#
# It only uses APIs available in rails and/or rspec-rails. There are a number
# of tools you can use to make these specs even more expressive, but we're
# sticking to rails and rspec-rails APIs to keep things simple and stable.

RSpec.describe "/accounts/users", type: :request do
  # This should return the minimal set of attributes required to create a valid
  # Accounts::User. As you add validations to Accounts::User, be sure to
  # adjust the attributes here as well.
  let(:valid_attributes) {
    skip("Add a hash of attributes valid for your model")
  }

  let(:invalid_attributes) {
    skip("Add a hash of attributes invalid for your model")
  }

  # This should return the minimal set of values that should be in the headers
  # in order to pass any filters (e.g. authentication) defined in
  # Accounts::UsersController, or in your router and rack
  # middleware. Be sure to keep this updated too.
  let(:valid_headers) {
    {}
  }

  describe "GET /index" do
    it "renders a successful response" do
      Accounts::User.create! valid_attributes
      get accounts_users_url, headers: valid_headers, as: :json
      expect(response).to be_successful
    end
  end

  describe "GET /show" do
    it "renders a successful response" do
      user = Accounts::User.create! valid_attributes
      get accounts_user_url(user), as: :json
      expect(response).to be_successful
    end
  end

  describe "POST /create" do
    context "with valid parameters" do
      it "creates a new Accounts::User" do
        expect {
          post accounts_users_url,
               params: { accounts_user: valid_attributes }, headers: valid_headers, as: :json
        }.to change(Accounts::User, :count).by(1)
      end

      it "renders a JSON response with the new accounts_user" do
        post accounts_users_url,
             params: { accounts_user: valid_attributes }, headers: valid_headers, as: :json
        expect(response).to have_http_status(:created)
        expect(response.content_type).to match(a_string_including("application/json"))
      end
    end

    context "with invalid parameters" do
      it "does not create a new Accounts::User" do
        expect {
          post accounts_users_url,
               params: { accounts_user: invalid_attributes }, as: :json
        }.to change(Accounts::User, :count).by(0)
      end

      it "renders a JSON response with errors for the new accounts_user" do
        post accounts_users_url,
             params: { accounts_user: invalid_attributes }, headers: valid_headers, as: :json
        expect(response).to have_http_status(:unprocessable_entity)
        expect(response.content_type).to match(a_string_including("application/json"))
      end
    end
  end

  describe "PATCH /update" do
    context "with valid parameters" do
      let(:new_attributes) {
        skip("Add a hash of attributes valid for your model")
      }

      it "updates the requested accounts_user" do
        user = Accounts::User.create! valid_attributes
        patch accounts_user_url(user),
              params: { accounts_user: new_attributes }, headers: valid_headers, as: :json
        user.reload
        skip("Add assertions for updated state")
      end

      it "renders a JSON response with the accounts_user" do
        user = Accounts::User.create! valid_attributes
        patch accounts_user_url(user),
              params: { accounts_user: new_attributes }, headers: valid_headers, as: :json
        expect(response).to have_http_status(:ok)
        expect(response.content_type).to match(a_string_including("application/json"))
      end
    end

    context "with invalid parameters" do
      it "renders a JSON response with errors for the accounts_user" do
        user = Accounts::User.create! valid_attributes
        patch accounts_user_url(user),
              params: { accounts_user: invalid_attributes }, headers: valid_headers, as: :json
        expect(response).to have_http_status(:unprocessable_entity)
        expect(response.content_type).to match(a_string_including("application/json"))
      end
    end
  end

  describe "DELETE /destroy" do
    it "destroys the requested accounts_user" do
      user = Accounts::User.create! valid_attributes
      expect {
        delete accounts_user_url(user), headers: valid_headers, as: :json
      }.to change(Accounts::User, :count).by(-1)
    end
  end
end

```
# Issues
closes #2491 