### PR TITLE
Fix FixtureSupport#run_in_transaction?

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Enhancements:
 
 * Make the API request scaffold template more consistent and compatible with
   Rails 6.1. (Naoto Hamada, #2484)
+* Provide support to turn off transactional tests for select examples.
+  (Stan Lo, #2495)
 
 ### 5.0.1 / 2021-03-18
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v5.0.0...v5.0.1)

--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -13,7 +13,8 @@ module RSpec
         # Monkey patched to avoid collisions with 'let(:name)' in Rails 6.1 and after
         # and let(:method_name) before Rails 6.1.
         def run_in_transaction?
-          use_transactional_tests && !self.class.uses_transaction?(self)
+          current_example_name = (RSpec.current_example && RSpec.current_example.metadata[:description])
+          use_transactional_tests && !self.class.uses_transaction?(current_example_name)
         end
 
         included do

--- a/spec/rspec/rails/fixture_support_spec.rb
+++ b/spec/rspec/rails/fixture_support_spec.rb
@@ -12,6 +12,33 @@ module RSpec::Rails
       end
     end
 
+    context "with use_transactional_tests set to true" do
+      it "works with #uses_transaction helper" do
+        group = RSpec::Core::ExampleGroup.describe do
+          include FixtureSupport
+          self.use_transactional_tests = true
+
+          uses_transaction "doesn't run in transaction"
+
+          it "doesn't run in transaction" do
+            expect(ActiveRecord::Base.connection.transaction_open?).to eq(false)
+          end
+
+          it "runs in transaction" do
+            expect(ActiveRecord::Base.connection.transaction_open?).to eq(true)
+          end
+        end
+
+        expect_to_pass(group)
+      end
+
+      def expect_to_pass(group)
+        result = group.run(failure_reporter)
+        failure_reporter.exceptions.map { |e| raise e }
+        expect(result).to be true
+      end
+    end
+
     it "will allow #setup_fixture to run successfully", skip: Rails.version.to_f <= 6.0 do
       group = RSpec::Core::ExampleGroup.describe do
         include FixtureSupport


### PR DESCRIPTION
`ActiveRecord::TestFixture`'s `uses_transaction` is designed to be used like this:

```ruby
uses_transaction :the_test_method_name
```

And in RSpec, the method name would be the example's name.

```ruby
uses_transaction "does someting"

it "does someting" {}
```

But in the current implementation, it's passing the example object instead of its name, which would always fail the name comparison in https://github.com/rails/rails/blob/main/activerecord/lib/active_record/test_fixtures.rb#L94-L97

So this PR fixes the issue by passing the example's name instead of the example object.