### PR TITLE
Implement check to prevent duplicate job naming

### DIFF
--- a/lib/generators/rspec/job/job_generator.rb
+++ b/lib/generators/rspec/job/job_generator.rb
@@ -5,7 +5,8 @@ module Rspec
     # @private
     class JobGenerator < Base
       def create_job_spec
-        template 'job_spec.rb.erb', File.join('spec/jobs', class_path, "#{file_name}_job_spec.rb")
+        file_suffix = file_name.end_with?('job') ? 'spec.rb' : 'job_spec.rb'
+        template 'job_spec.rb.erb', File.join('spec/jobs', class_path, [file_name, file_suffix].join('_'))
       end
     end
   end

--- a/lib/generators/rspec/job/templates/job_spec.rb.erb
+++ b/lib/generators/rspec/job/templates/job_spec.rb.erb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>Job, <%= type_metatag(:job) %> do
+  RSpec.describe <%= class_name %><%= "Job" unless class_name.end_with?("Job")%>, <%= type_metatag(:job) %> do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/lib/generators/rspec/job/templates/job_spec.rb.erb
+++ b/lib/generators/rspec/job/templates/job_spec.rb.erb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-  RSpec.describe <%= class_name %><%= "Job" unless class_name.end_with?("Job")%>, <%= type_metatag(:job) %> do
+RSpec.describe <%= class_name %><%= "Job" unless class_name.end_with?("Job")%>, <%= type_metatag(:job) %> do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/spec/generators/rspec/job/job_generator_spec.rb
+++ b/spec/generators/rspec/job/job_generator_spec.rb
@@ -6,13 +6,25 @@ RSpec.describe Rspec::Generators::JobGenerator, type: :generator, skip: !RSpec::
   setup_default_destination
 
   describe 'the generated files' do
-    before { run_generator %w[user] }
+    before { run_generator [file_name] }
 
-    subject { file('spec/jobs/user_job_spec.rb') }
+    context 'with file_name without job as suffix' do
+      let(:file_name) { 'user' }
+      subject { file('spec/jobs/user_job_spec.rb') }
 
-    it { is_expected.to exist }
-    it { is_expected.to contain(/require 'rails_helper'/) }
-    it { is_expected.to contain(/describe UserJob, #{type_metatag(:job)}/) }
+      it { is_expected.to exist }
+      it { is_expected.to contain(/require 'rails_helper'/) }
+      it { is_expected.to contain(/describe UserJob, #{type_metatag(:job)}/) }
+    end
 
+    context 'with file_name with job as suffix' do
+      let(:file_name) { 'user_job' }
+
+      subject { file('spec/jobs/user_job_spec.rb') }
+
+      it { is_expected.to exist }
+      it { is_expected.to contain(/require 'rails_helper'/) }
+      it { is_expected.to contain(/describe UserJob, #{type_metatag(:job)}/) }
+    end
   end
 end


### PR DESCRIPTION
# Description

When generating a new job with:
		    
	    rails g job mailer_job
Rails will not append another _job to the Job-Name or the file. 

This pr tries to align the creation of the spec file with the creation of the job file and checks for the file suffix before appending another _job.

# Example

## Setup

		rails g job sms_sending_job

## Before

		spec/jobs/sms_sending_job_job.rb

## After


		spec/jobs/sms_sending_job.rb



