### PR TITLE
Clarify version to use with Rails 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ They’re also specifications (or _specs,_ for short):
 detailed explanations of how the application is supposed to behave,
 expressed in plain English.
 
-According to [RSpec Rails new versioning strategy][], use **[`rspec-rails` 5.x][]** for Rails 6.x, **[`rspec-rails` 4.x][]** for Rails 5.x, **[`rspec-rails` 3.x][]** for Rails earlier than 5.0 and **[`rspec-rails` 1.x][]** for Rails 2.x.
+According to [RSpec Rails new versioning strategy][] use:
+* **[`rspec-rails` 5.x][]** for Rails 6.x.
+* **[`rspec-rails` 4.x][]** for Rails from 5.x or 6.x.
+* **[`rspec-rails` 3.x][]** for Rails earlier than 5.0.
+* **[`rspec-rails` 1.x][]** for Rails 2.x.
 
 [Build Status]: https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=main
 [travis-ci]: https://travis-ci.org/rspec/rspec-rails

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ They’re also specifications (or _specs,_ for short):
 detailed explanations of how the application is supposed to behave,
 expressed in plain English.
 
-Use **[`rspec-rails` 4.x][]** for Rails from 5.0 to 6.0.
-Use **[`rspec-rails` 3.x][]** for Rails earlier than 5.0.
-Use **[`rspec-rails` 1.x][]** for Rails 2.x.
+According to [RSpec Rails new versioning strategy][], use **[`rspec-rails` 5.x][]** for Rails 6.x, **[`rspec-rails` 4.x][]** for Rails 5.x, **[`rspec-rails` 3.x][]** for Rails earlier than 5.0 and **[`rspec-rails` 1.x][]** for Rails 2.x.
 
 [Build Status]: https://secure.travis-ci.org/rspec/rspec-rails.svg?branch=main
 [travis-ci]: https://travis-ci.org/rspec/rspec-rails
@@ -23,6 +21,8 @@ Use **[`rspec-rails` 1.x][]** for Rails 2.x.
 [`rspec-rails` 1.x]: https://github.com/dchelimsky/rspec-rails
 [`rspec-rails` 3.x]: https://github.com/rspec/rspec-rails/tree/3-9-maintenance
 [`rspec-rails` 4.x]: https://github.com/rspec/rspec-rails/tree/4-1-maintenance
+[`rspec-rails` 5.x]: https://github.com/rspec/rspec-rails/tree/5-0-maintenance
+[RSpec Rails new versioning strategy]: https://github.com/rspec/rspec-rails/blob/main/rfcs/versioning-strategy.md
 
 ## Installation
 


### PR DESCRIPTION
By reading the README, it wasn't clear to me what version I'm supposed to use with Rails 6.0 and, to me "Rails from 5.0 to 6.0" means Rails 6.0 is included. After I read [versioning-strategy](https://github.com/rspec/rspec-rails/blob/main/rfcs/versioning-strategy.md), I understand rspec-rails 5.x have to used for Rails 6 and above. Also, the reasons of this rule wasn't clear.

I also changed the formatting.

Let me know if I misterstood.