### PR TITLE
Respect RSpec `default_path` for generators

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -73,6 +73,8 @@ Bug Fixes:
   `run_in_transaction?` method.  (Stan Lo, #2495)
 * Prevent keyword arguments being lost when methods are invoked dynamically
   in controller specs. (Josh Cheek, #2509, #2514)
+* Read configuration options from files to respect spec path setting.
+  (@vivekmiyani, #2508)
 
 ### 5.0.1 / 2021-03-18
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v5.0.0...v5.0.1)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v6.0.0.rc1...main)
 
+Enhancements:
+
+* Generators now respects default path configuration option. (@vivekmiyani, #2508)
+
 Breaking Changes:
 
 * Change the order of `after_teardown` from `after` to `around` in system
@@ -73,8 +77,6 @@ Bug Fixes:
   `run_in_transaction?` method.  (Stan Lo, #2495)
 * Prevent keyword arguments being lost when methods are invoked dynamically
   in controller specs. (Josh Cheek, #2509, #2514)
-* Read configuration options from files to respect spec path setting.
-  (@vivekmiyani, #2508)
 
 ### 5.0.1 / 2021-03-18
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v5.0.0...v5.0.1)

--- a/features/README.md
+++ b/features/README.md
@@ -34,10 +34,14 @@ without having to type RAILS_ENV=test.
 
 Now you can run:
 
-    script/rails generate rspec:install
+    bundle exec rails generate rspec:install
 
 This adds the spec directory and some skeleton files, including a .rspec
 file.
+
+You can also customize the default spec path with `--default-path` option:
+
+    bundle exec rails generate rspec:install --default-path behaviour
 
 ## Issues
 

--- a/features/generator_specs/channel_specs.feature
+++ b/features/generator_specs/channel_specs.feature
@@ -1,0 +1,31 @@
+Feature: Channel generator spec
+
+    Scenario: Channel generator
+        When I run `bundle exec rails generate channel group`
+        Then the features should pass
+        Then the output should contain:
+          """
+                invoke  rspec
+                create    spec/channels/group_channel_spec.rb
+                create  app/channels/group_channel.rb
+             identical  app/javascript/channels/index.js
+             identical  app/javascript/channels/consumer.js
+                create  app/javascript/channels/group_channel.js
+          """
+
+    Scenario: Channel generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate channel group`
+        Then the features should pass
+        Then the output should contain:
+          """
+                invoke  rspec
+                create    behaviour/channels/group_channel_spec.rb
+                create  app/channels/group_channel.rb
+             identical  app/javascript/channels/index.js
+             identical  app/javascript/channels/consumer.js
+                create  app/javascript/channels/group_channel.js
+          """

--- a/features/generator_specs/channel_specs.feature
+++ b/features/generator_specs/channel_specs.feature
@@ -7,10 +7,10 @@ Feature: Channel generator spec
           """
                 invoke  rspec
                 create    spec/channels/group_channel_spec.rb
+          """
+        Then the output should contain:
+          """
                 create  app/channels/group_channel.rb
-             identical  app/javascript/channels/index.js
-             identical  app/javascript/channels/consumer.js
-                create  app/javascript/channels/group_channel.js
           """
 
     Scenario: Channel generator with customized `default-path`
@@ -24,8 +24,8 @@ Feature: Channel generator spec
           """
                 invoke  rspec
                 create    behaviour/channels/group_channel_spec.rb
+          """
+        Then the output should contain:
+          """
                 create  app/channels/group_channel.rb
-             identical  app/javascript/channels/index.js
-             identical  app/javascript/channels/consumer.js
-                create  app/javascript/channels/group_channel.js
           """

--- a/features/generator_specs/controller_specs.feature
+++ b/features/generator_specs/controller_specs.feature
@@ -14,9 +14,6 @@ Feature: Controller generator spec
                 create    app/helpers/posts_helper.rb
                 invoke    rspec
                 create      spec/helpers/posts_helper_spec.rb
-                invoke  assets
-                invoke    css
-                create      app/assets/stylesheets/posts.css
           """
 
     Scenario: Controller generator with customized `default-path`
@@ -37,7 +34,4 @@ Feature: Controller generator spec
                 create    app/helpers/posts_helper.rb
                 invoke    rspec
                 create      behaviour/helpers/posts_helper_spec.rb
-                invoke  assets
-                invoke    css
-                create      app/assets/stylesheets/posts.css
           """

--- a/features/generator_specs/controller_specs.feature
+++ b/features/generator_specs/controller_specs.feature
@@ -1,0 +1,43 @@
+Feature: Controller generator spec
+
+    Scenario: Controller generator
+        When I run `bundle exec rails generate controller posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  app/controllers/posts_controller.rb
+                invoke  erb
+                create    app/views/posts
+                invoke  rspec
+                create    spec/requests/posts_spec.rb
+                invoke  helper
+                create    app/helpers/posts_helper.rb
+                invoke    rspec
+                create      spec/helpers/posts_helper_spec.rb
+                invoke  assets
+                invoke    css
+                create      app/assets/stylesheets/posts.css
+          """
+
+    Scenario: Controller generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate controller posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  app/controllers/posts_controller.rb
+                invoke  erb
+                create    app/views/posts
+                invoke  rspec
+                create    behaviour/requests/posts_spec.rb
+                invoke  helper
+                create    app/helpers/posts_helper.rb
+                invoke    rspec
+                create      behaviour/helpers/posts_helper_spec.rb
+                invoke  assets
+                invoke    css
+                create      app/assets/stylesheets/posts.css
+          """

--- a/features/generator_specs/feature_specs.feature
+++ b/features/generator_specs/feature_specs.feature
@@ -1,0 +1,21 @@
+Feature: Feature generator spec
+
+    Scenario: Feature generator
+        When I run `bundle exec rails generate rspec:feature posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  spec/features/posts_spec.rb
+          """
+
+    Scenario: Feature generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate rspec:feature posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  behaviour/features/posts_spec.rb
+          """

--- a/features/generator_specs/generator_specs.feature
+++ b/features/generator_specs/generator_specs.feature
@@ -15,8 +15,11 @@ Feature: Generator spec
                 create    spec/generator/my_generators_generator_spec.rb
           """
 
-    Scenario: Use custom generator with different default path
-        When I run `bundle exec rails generate rspec:install --default-path behaviour --force`
+    Scenario: Use custom generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
         And I run `bundle exec rails generate generator my_generator`
         Then the features should pass
         Then the output should contain:

--- a/features/generator_specs/generator_specs.feature
+++ b/features/generator_specs/generator_specs.feature
@@ -14,3 +14,17 @@ Feature: Generator spec
                 invoke  rspec
                 create    spec/generator/my_generators_generator_spec.rb
           """
+
+    Scenario: Use custom generator with different default path
+        When I run `bundle exec rails generate rspec:install --default-path behaviour --force`
+        And I run `bundle exec rails generate generator my_generator`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  lib/generators/my_generator
+                create  lib/generators/my_generator/my_generator_generator.rb
+                create  lib/generators/my_generator/USAGE
+                create  lib/generators/my_generator/templates
+                invoke  rspec
+                create    behaviour/generator/my_generators_generator_spec.rb
+          """

--- a/features/generator_specs/helper_specs.feature
+++ b/features/generator_specs/helper_specs.feature
@@ -1,0 +1,25 @@
+Feature: Helper generator spec
+
+    Scenario: Helper generator
+        When I run `bundle exec rails generate helper posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  app/helpers/posts_helper.rb
+                invoke  rspec
+                create    spec/helpers/posts_helper_spec.rb
+          """
+
+    Scenario: Helper generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate helper posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  app/helpers/posts_helper.rb
+                invoke  rspec
+                create    behaviour/helpers/posts_helper_spec.rb
+          """

--- a/features/generator_specs/integration_specs.feature
+++ b/features/generator_specs/integration_specs.feature
@@ -1,0 +1,21 @@
+Feature: Integration generator spec
+
+    Scenario: Integration generator
+        When I run `bundle exec rails generate rspec:integration posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  spec/requests/posts_spec.rb
+          """
+
+    Scenario: Integration generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate rspec:integration posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  behaviour/requests/posts_spec.rb
+          """

--- a/features/generator_specs/job_specs.feature
+++ b/features/generator_specs/job_specs.feature
@@ -1,0 +1,25 @@
+Feature: Job generator spec
+
+    Scenario: Job generator
+        When I run `bundle exec rails generate job user`
+        Then the features should pass
+        Then the output should contain:
+          """
+                invoke  rspec
+                create    spec/jobs/user_job_spec.rb
+                create  app/jobs/user_job.rb
+          """
+
+    Scenario: Job generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate job user`
+        Then the features should pass
+        Then the output should contain:
+          """
+                invoke  rspec
+                create    behaviour/jobs/user_job_spec.rb
+                create  app/jobs/user_job.rb
+          """

--- a/features/generator_specs/mailbox_specs.feature
+++ b/features/generator_specs/mailbox_specs.feature
@@ -1,0 +1,25 @@
+Feature: Mailbox generator spec
+
+    Scenario: Mailbox generator
+        When I run `bundle exec rails generate mailbox forwards`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  app/mailboxes/forwards_mailbox.rb
+                invoke  rspec
+                create    spec/mailboxes/forwards_mailbox_spec.rb
+          """
+
+    Scenario: Mailbox generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate mailbox forwards`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  app/mailboxes/forwards_mailbox.rb
+                invoke  rspec
+                create    behaviour/mailboxes/forwards_mailbox_spec.rb
+          """

--- a/features/generator_specs/mailer_specs.feature
+++ b/features/generator_specs/mailer_specs.feature
@@ -1,0 +1,43 @@
+Feature: Mailer generator spec
+
+    Scenario: Mailer generator
+        When I run `bundle exec rails generate mailer posts index show`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  app/mailers/posts_mailer.rb
+                invoke  erb
+                create    app/views/posts_mailer
+                create    app/views/posts_mailer/index.text.erb
+                create    app/views/posts_mailer/index.html.erb
+                create    app/views/posts_mailer/show.text.erb
+                create    app/views/posts_mailer/show.html.erb
+                invoke  rspec
+                create    spec/mailers/posts_spec.rb
+                create    spec/fixtures/posts/index
+                create    spec/fixtures/posts/show
+                create    spec/mailers/previews/posts_preview.rb
+          """
+
+    Scenario: Mailer generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate mailer posts index show`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  app/mailers/posts_mailer.rb
+                invoke  erb
+                create    app/views/posts_mailer
+                create    app/views/posts_mailer/index.text.erb
+                create    app/views/posts_mailer/index.html.erb
+                create    app/views/posts_mailer/show.text.erb
+                create    app/views/posts_mailer/show.html.erb
+                invoke  rspec
+                create    behaviour/mailers/posts_spec.rb
+                create    behaviour/fixtures/posts/index
+                create    behaviour/fixtures/posts/show
+                create    behaviour/mailers/previews/posts_preview.rb
+          """

--- a/features/generator_specs/request_specs.feature
+++ b/features/generator_specs/request_specs.feature
@@ -1,0 +1,21 @@
+Feature: Request generator spec
+
+    Scenario: Request generator
+        When I run `bundle exec rails generate rspec:request posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  spec/requests/posts_spec.rb
+          """
+
+    Scenario: Request generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate rspec:request posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  behaviour/requests/posts_spec.rb
+          """

--- a/features/generator_specs/system_specs.feature
+++ b/features/generator_specs/system_specs.feature
@@ -1,0 +1,21 @@
+Feature: System generator spec
+
+    Scenario: System generator
+        When I run `bundle exec rails generate rspec:system posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  spec/system/posts_spec.rb
+          """
+
+    Scenario: System generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate rspec:system posts`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  behaviour/system/posts_spec.rb
+          """

--- a/features/generator_specs/view_specs.feature
+++ b/features/generator_specs/view_specs.feature
@@ -1,0 +1,23 @@
+Feature: View generator spec
+
+    Scenario: View generator
+        When I run `bundle exec rails generate rspec:view posts index`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  spec/views/posts
+                create  spec/views/posts/index.html.erb_spec.rb
+          """
+
+    Scenario: View generator with customized `default-path`
+        Given a file named ".rspec" with:
+          """
+          --default-path behaviour
+          """
+        And I run `bundle exec rails generate rspec:view posts index`
+        Then the features should pass
+        Then the output should contain:
+          """
+                create  behaviour/views/posts
+                create  behaviour/views/posts/index.html.erb_spec.rb
+          """

--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -20,8 +20,7 @@ module Rspec
         end
       end
 
-      # This is specifically to parse and load `.rspec` file,
-      # So we can use different directory.
+      # Read configuration options from files to respect `--default-path`
       def self.configuration
         @configuration ||= begin
                              configuration = RSpec.configuration

--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -20,7 +20,8 @@ module Rspec
         end
       end
 
-      # Read configuration options from files to respect `--default-path`
+      # @private
+      # Load configuration from RSpec to ensure `--default-path` is set
       def self.configuration
         @configuration ||= begin
                              configuration = RSpec.configuration

--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -20,8 +20,19 @@ module Rspec
         end
       end
 
+      # This is specifically to parse and load `.rspec` file,
+      # So we can use different directory.
+      def self.configuration
+        @configuration ||= begin
+                             configuration = RSpec.configuration
+                             options = RSpec::Core::ConfigurationOptions.new({})
+                             options.configure(configuration)
+                             configuration
+                           end
+      end
+
       def target_path(*paths)
-        File.join(RSpec.configuration.default_path, *paths)
+        File.join(self.class.configuration.default_path, *paths)
       end
     end
   end

--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -1,4 +1,5 @@
 require 'rails/generators/named_base'
+require 'rspec/core'
 require 'rspec/rails/feature_check'
 
 # @private
@@ -17,6 +18,10 @@ module Rspec
         else
           @_rspec_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'rspec', generator_name, 'templates'))
         end
+      end
+
+      def target_path(*paths)
+        File.join(RSpec.configuration.default_path, *paths)
       end
     end
   end

--- a/lib/generators/rspec/channel/channel_generator.rb
+++ b/lib/generators/rspec/channel/channel_generator.rb
@@ -5,7 +5,7 @@ module Rspec
     # @private
     class ChannelGenerator < Base
       def create_channel_spec
-        template 'channel_spec.rb.erb', File.join('spec/channels', class_path, "#{file_name}_channel_spec.rb")
+        template 'channel_spec.rb.erb', target_path('channels', class_path, "#{file_name}_channel_spec.rb")
       end
     end
   end

--- a/lib/generators/rspec/controller/controller_generator.rb
+++ b/lib/generators/rspec/controller/controller_generator.rb
@@ -16,14 +16,14 @@ module Rspec
         return unless options[:request_specs]
 
         template 'request_spec.rb',
-                 File.join('spec/requests', class_path, "#{file_name}_spec.rb")
+                 target_path('requests', class_path, "#{file_name}_spec.rb")
       end
 
       def generate_controller_spec
         return unless options[:controller_specs]
 
         template 'controller_spec.rb',
-                 File.join('spec/controllers', class_path, "#{file_name}_controller_spec.rb")
+                 target_path('controllers', class_path, "#{file_name}_controller_spec.rb")
       end
 
       def generate_view_specs
@@ -35,7 +35,7 @@ module Rspec
         actions.each do |action|
           @action = action
           template 'view_spec.rb',
-                   File.join("spec", "views", file_path, "#{@action}.html.#{options[:template_engine]}_spec.rb")
+                   target_path('views', file_path, "#{@action}.html.#{options[:template_engine]}_spec.rb")
         end
       end
 
@@ -44,7 +44,7 @@ module Rspec
         return unless options[:routing_specs]
 
         template 'routing_spec.rb',
-                 File.join('spec/routing', class_path, "#{file_name}_routing_spec.rb")
+                 target_path('routing', class_path, "#{file_name}_routing_spec.rb")
       end
     end
   end

--- a/lib/generators/rspec/feature/feature_generator.rb
+++ b/lib/generators/rspec/feature/feature_generator.rb
@@ -10,7 +10,7 @@ module Rspec
       def generate_feature_spec
         return unless options[:feature_specs]
 
-        template template_name, File.join('spec/features', class_path, filename)
+        template template_name, target_path('features', class_path, filename)
       end
 
       def template_name

--- a/lib/generators/rspec/generator/generator_generator.rb
+++ b/lib/generators/rspec/generator/generator_generator.rb
@@ -9,7 +9,7 @@ module Rspec
       def generate_generator_spec
         return unless options[:generator_specs]
 
-        template template_name, File.join('spec/generator', class_path, filename)
+        template template_name, target_path('generator', class_path, filename)
       end
 
       def template_name

--- a/lib/generators/rspec/helper/helper_generator.rb
+++ b/lib/generators/rspec/helper/helper_generator.rb
@@ -9,7 +9,7 @@ module Rspec
       def generate_helper_spec
         return unless options[:helper_specs]
 
-        template 'helper_spec.rb', File.join('spec/helpers', class_path, "#{file_name}_helper_spec.rb")
+        template 'helper_spec.rb', target_path('helpers', class_path, "#{file_name}_helper_spec.rb")
       end
     end
   end

--- a/lib/generators/rspec/install/install_generator.rb
+++ b/lib/generators/rspec/install/install_generator.rb
@@ -44,9 +44,11 @@ DESC
         replace_generator_command(spec_helper_path)
         remove_warnings_configuration(spec_helper_path)
 
-        dot_rspec_path = File.join(tmpdir, '.rspec')
+        unless default_path == "spec"
+          dot_rspec_path = File.join(tmpdir, '.rspec')
 
-        append_default_path(dot_rspec_path)
+          append_default_path(dot_rspec_path)
+        end
       end
 
       def replace_generator_command(spec_helper_path)

--- a/lib/generators/rspec/install/install_generator.rb
+++ b/lib/generators/rspec/install/install_generator.rb
@@ -12,6 +12,8 @@ Description:
     Copy rspec files to your application.
 DESC
 
+      class_option :default_path, type: :string, default: 'spec'
+
       def self.source_root
         @source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
       end
@@ -20,12 +22,12 @@ DESC
         Dir.mktmpdir do |dir|
           generate_rspec_init dir
           template File.join(dir, '.rspec'), '.rspec'
-          directory File.join(dir, 'spec'), 'spec'
+          directory File.join(dir, 'spec'), default_path
         end
       end
 
       def copy_rails_files
-        template 'spec/rails_helper.rb'
+        template 'spec/rails_helper.rb', "#{default_path}/rails_helper.rb"
       end
 
     private
@@ -41,6 +43,10 @@ DESC
 
         replace_generator_command(spec_helper_path)
         remove_warnings_configuration(spec_helper_path)
+
+        dot_rspec_path = File.join(tmpdir, '.rspec')
+
+        append_default_path(dot_rspec_path)
       end
 
       def replace_generator_command(spec_helper_path)
@@ -57,6 +63,15 @@ DESC
                   /#{empty_line}(#{comment_line})+\s+config\.warnings = true\n/,
                   '',
                   verbose: false
+      end
+
+      def append_default_path(dot_rspec_path)
+        append_to_file dot_rspec_path,
+                       "--default-path #{default_path}"
+      end
+
+      def default_path
+        options[:default_path]
       end
     end
   end

--- a/lib/generators/rspec/integration/integration_generator.rb
+++ b/lib/generators/rspec/integration/integration_generator.rb
@@ -22,7 +22,7 @@ module Rspec
         WARNING
 
         template 'request_spec.rb',
-                 File.join('spec/requests', "#{name.underscore.pluralize}_spec.rb")
+                 target_path('requests', "#{name.underscore.pluralize}_spec.rb")
       end
     end
   end

--- a/lib/generators/rspec/job/job_generator.rb
+++ b/lib/generators/rspec/job/job_generator.rb
@@ -6,7 +6,7 @@ module Rspec
     class JobGenerator < Base
       def create_job_spec
         file_suffix = file_name.end_with?('job') ? 'spec.rb' : 'job_spec.rb'
-        template 'job_spec.rb.erb', File.join('spec/jobs', class_path, [file_name, file_suffix].join('_'))
+        template 'job_spec.rb.erb', target_path('jobs', class_path, [file_name, file_suffix].join('_'))
       end
     end
   end

--- a/lib/generators/rspec/mailbox/mailbox_generator.rb
+++ b/lib/generators/rspec/mailbox/mailbox_generator.rb
@@ -6,7 +6,7 @@ module Rspec
     class MailboxGenerator < Base
       def create_mailbox_spec
         template('mailbox_spec.rb.erb',
-                 File.join('spec/mailboxes', class_path, "#{file_name}_mailbox_spec.rb")
+                 target_path('mailboxes', class_path, "#{file_name}_mailbox_spec.rb")
         )
       end
     end

--- a/lib/generators/rspec/mailer/mailer_generator.rb
+++ b/lib/generators/rspec/mailer/mailer_generator.rb
@@ -8,20 +8,20 @@ module Rspec
       argument :actions, type: :array, default: [], banner: "method method"
 
       def generate_mailer_spec
-        template "mailer_spec.rb", File.join('spec/mailers', class_path, "#{file_name}_spec.rb")
+        template "mailer_spec.rb", target_path('mailers', class_path, "#{file_name}_spec.rb")
       end
 
       def generate_fixtures_files
         actions.each do |action|
           @action, @path = action, File.join(file_path, action)
-          template "fixture", File.join("spec/fixtures", @path)
+          template "fixture", target_path("fixtures", @path)
         end
       end
 
       def generate_preview_files
         return unless RSpec::Rails::FeatureCheck.has_action_mailer_preview?
 
-        template "preview.rb", File.join("spec/mailers/previews", class_path, "#{file_name}_preview.rb")
+        template "preview.rb", target_path("mailers/previews", class_path, "#{file_name}_preview.rb")
       end
     end
   end

--- a/lib/generators/rspec/model/model_generator.rb
+++ b/lib/generators/rspec/model/model_generator.rb
@@ -11,8 +11,8 @@ module Rspec
       class_option :fixture, type: :boolean
 
       def create_model_spec
-        template_file = File.join(
-          'spec/models',
+        template_file = target_path(
+          'models',
           class_path,
           "#{file_name}_spec.rb"
         )
@@ -24,7 +24,7 @@ module Rspec
       def create_fixture_file
         return unless missing_fixture_replacement?
 
-        template 'fixtures.yml', File.join('spec/fixtures', class_path, "#{(pluralize_table_names? ? plural_file_name : file_name)}.yml")
+        template 'fixtures.yml', target_path('fixtures', class_path, "#{(pluralize_table_names? ? plural_file_name : file_name)}.yml")
       end
 
     private

--- a/lib/generators/rspec/request/request_generator.rb
+++ b/lib/generators/rspec/request/request_generator.rb
@@ -10,7 +10,7 @@ module Rspec
         return unless options[:request_specs]
 
         template 'request_spec.rb',
-                 File.join('spec/requests', "#{name.underscore.pluralize}_spec.rb")
+                 target_path('requests', "#{name.underscore.pluralize}_spec.rb")
       end
     end
   end

--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -58,8 +58,8 @@ module Rspec
       def generate_routing_spec
         return unless options[:routing_specs]
 
-        template_file = File.join(
-          'spec/routing',
+        template_file = target_path(
+          'routing',
           controller_class_path,
           "#{controller_file_name}_routing_spec.rb"
         )
@@ -72,7 +72,7 @@ module Rspec
 
       def copy_view(view)
         template "#{view}_spec.rb",
-                 File.join("spec/views", controller_file_path, "#{view}.html.#{options[:template_engine]}_spec.rb")
+                 target_path("views", controller_file_path, "#{view}.html.#{options[:template_engine]}_spec.rb")
       end
 
       # support for namespaced-resources
@@ -121,7 +121,7 @@ module Rspec
       end
 
       def template_file(folder:, suffix: '')
-        File.join('spec', folder, controller_class_path, "#{controller_file_name}#{suffix}_spec.rb")
+        target_path(folder, controller_class_path, "#{controller_file_name}#{suffix}_spec.rb")
       end
 
       def banner

--- a/lib/generators/rspec/system/system_generator.rb
+++ b/lib/generators/rspec/system/system_generator.rb
@@ -9,7 +9,7 @@ module Rspec
       def generate_system_spec
         return unless options[:system_specs]
 
-        template template_name, File.join('spec/system', class_path, filename)
+        template template_name, target_path('system', class_path, filename)
       end
 
       def template_name

--- a/lib/generators/rspec/view/view_generator.rb
+++ b/lib/generators/rspec/view/view_generator.rb
@@ -9,12 +9,12 @@ module Rspec
       class_option :template_engine, desc: "Template engine to generate view files"
 
       def create_view_specs
-        empty_directory File.join("spec", "views", file_path)
+        empty_directory target_path("views", file_path)
 
         actions.each do |action|
           @action = action
           template 'view_spec.rb',
-                   File.join("spec", "views", file_path, "#{@action}.html.#{options[:template_engine]}_spec.rb")
+                   target_path("views", file_path, "#{@action}.html.#{options[:template_engine]}_spec.rb")
         end
       end
     end


### PR DESCRIPTION
Fixes #2507.

## TODO

- [x]  Replace hardcoded `spec` directory to `default_path`
- [x] Change log entry
- [ ] Add feature test for each generator listed below:
  - [x]  channel
  - [x] controller
  - [x] feature
  - [x] generator
  - [x] helper
  - [ ] install
  - [x] integration
  - [x] job
  - [x] mailbox
  - [x] mailer
  - [ ] model
  - [x] request
  - [ ] scaffold
  - [x] system
  - [x] view