### PR TITLE
Fix keyword arguments in dynamic matchers

### DIFF
--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -176,6 +176,7 @@ module RSpec
           super
         end
       end
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
       included do
         subject { controller }

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -21,9 +21,8 @@ module RSpec::Rails
 
     it "handles methods invoked via `method_missing` that use keywords" do
       example = group.new
-      example.define_singleton_method(:has_val?) { |val:| val == 1 }
-      expect(example).to example.have_val(val: 1)
-      expect(example).to_not example.have_val(val: 2)
+      example.define_singleton_method(:keyword_value) { |value:| value }
+      expect(example.keyword_value(value: 42)).to eq 42
     end
 
     context "with implicit subject" do

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -19,6 +19,13 @@ module RSpec::Rails
       expect(group.included_modules).to include(RSpec::Rails::Matchers::RoutingMatchers)
     end
 
+    it "handles dynamic matchers with keywords (big change from ruby 2 to ruby 3)" do
+      example = group.new
+      example.define_singleton_method(:has_val?) { |val:| val == 1 }
+      expect(example).to example.have_val(val: 1)
+      expect(example).to_not example.have_val(val: 2)
+    end
+
     context "with implicit subject" do
       it "uses the controller as the subject" do
         controller = double('controller')

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -19,7 +19,7 @@ module RSpec::Rails
       expect(group.included_modules).to include(RSpec::Rails::Matchers::RoutingMatchers)
     end
 
-    it "handles dynamic matchers with keywords (big change from ruby 2 to ruby 3)" do
+    it "handles dynamic matchers with keywords" do
       example = group.new
       example.define_singleton_method(:has_val?) { |val:| val == 1 }
       expect(example).to example.have_val(val: 1)

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -21,8 +21,9 @@ module RSpec::Rails
 
     it "handles methods invoked via `method_missing` that use keywords" do
       example = group.new
-      example.define_singleton_method(:keyword_value) { |value:| value }
-      expect(example.keyword_value(value: 42)).to eq 42
+      example.define_singleton_method(:has_val?) { |val:| val == 1 }
+      expect(example).to example.have_val(val: 1)
+      expect(example).to_not example.have_val(val: 2)
     end
 
     context "with implicit subject" do

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -19,7 +19,7 @@ module RSpec::Rails
       expect(group.included_modules).to include(RSpec::Rails::Matchers::RoutingMatchers)
     end
 
-    it "handles dynamic matchers with keywords" do
+    it "handles methods invoked via `method_missing` that use keywords" do
       example = group.new
       example.define_singleton_method(:has_val?) { |val:| val == 1 }
       expect(example).to example.have_val(val: 1)


### PR DESCRIPTION
Ruby 3 changed the way keyword arguments work. Currently, to forward arguments, the only way that works in Ruby 2.6, 2.7, and 3.0, is to call `ruby2_keywords :method_name` for the method that receives the arguments.

This will cause Ruby to remember that the final hash was created by keyword arguments, and then when expanding out the arguments later, eg [here](https://github.com/rspec/rspec-expectations/blob/43bf64b01f8356979ffbc373b2e81d2ab1389b29/lib/rspec/matchers/built_in/has.rb#L67), it will see that the last element was created by keywords, and it will pass that into the keywords area of a method infocation.

If we don't do this, it will consider it an ordinal argument and not line it up with the keywords. This typically causes a "wrong number of arguments" error, because it's passing an extra ordinal argument.

Here is another example from within RSpec, where they have arrived at this solution for the same problem: [rspec/matchers/dsl.rb#L538-L540](https://github.com/rspec/rspec-expectations/blob/43bf64b01f8356979ffbc373b2e81d2ab1389b29/lib/rspec/matchers/dsl.rb#L538-L540)

Currently, my team is hacking around this with:

```ruby
# What we are currently doing without this patch (we're on Ruby 3.0.1)
def has_updated?(model, ruby2_attrs = {}, **ruby3_attrs)
  attrs = ruby2_attrs.merge(ruby3_attrs)
  # ...
end

# What we will do with this patch
def has_updated?(model, **attrs)
  # ...
end
```