### PR TITLE
Use RSpec.current_scope

### DIFF
--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -46,7 +46,7 @@ module RSpec
             def proxy_method_warning_if_called_in_before_context_scope(method_name)
               orig_implementation = instance_method(method_name)
               define_method(method_name) do |*args, &blk|
-                if inspect.include?("before(:context)")
+                if RSpec.current_scope == :before_context_hook
                   RSpec.warn_with("Calling fixture method in before :context ")
                 else
                   orig_implementation.bind(self).call(*args, &blk)


### PR DESCRIPTION
It was introduced in https://github.com/rspec/rspec-core/pull/2895

When `RSpec.current_scope` is released in [3.11](https://github.com/rspec/rspec-core/pull/2895) and [4.0](https://github.com/rspec/rspec-core/pull/2910), we're fine with merging this PR to `main` and to `5-0-maintenance`.

TODO:
 - [x] remove the `temp!` commit