### PR TITLE
Fix keyword arguments in dynamic methods in controller specs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ Bug Fixes:
 * Fix `ActiveRecord::TestFixture#uses_transaction` by using example description
   to replace example name rather than example in our monkey patched
   `run_in_transaction?` method.  (Stan Lo, #2495)
+* Prevent keyword arguments being lost when methods are invoked dynamically
+  in controller specs. (Josh Cheek, #2509, #2514)
 
 ### 5.0.1 / 2021-03-18
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v5.0.0...v5.0.1)

--- a/lib/rspec/rails/example/controller_example_group.rb
+++ b/lib/rspec/rails/example/controller_example_group.rb
@@ -176,6 +176,7 @@ module RSpec
           super
         end
       end
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
       included do
         subject { controller }

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -25,6 +25,10 @@ module RSpec::Rails
           def a_method(value:); value; end
           def method_missing(_name, *_args, **kwargs, &_block); a_method(**kwargs); end
 
+          # This example requires prepend so that the `method_missing` definition
+          # from `ControllerExampleGroup` bubbles up to our artificial one, in reality
+          # this is likely to be either an internal RSpec dispatch or one from a 3rd
+          # party gem.
           prepend ControllerExampleGroup
         end
       example = group.new

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -19,6 +19,19 @@ module RSpec::Rails
       expect(group.included_modules).to include(RSpec::Rails::Matchers::RoutingMatchers)
     end
 
+    it "handles methods invoked via `method_missing` that use keywords" do
+      group =
+        RSpec::Core::ExampleGroup.describe ApplicationController do
+          def a_method(value:); value; end
+          def method_missing(_name, *_args, **kwargs, &_block); a_method(**kwargs); end
+
+          prepend ControllerExampleGroup
+        end
+      example = group.new
+
+      expect(example.call_a_method(value: :value)).to eq :value
+    end
+
     context "with implicit subject" do
       it "uses the controller as the subject" do
         controller = double('controller')


### PR DESCRIPTION
Supersedes #2509 by demonstrating the issue in isolation from the rest of RSpec, many thanks to the original reporter @joshcheek