### PR TITLE
Remove redundunt include Capybara::DSL

### DIFF
--- a/lib/rspec/rails/vendor/capybara.rb
+++ b/lib/rspec/rails/vendor/capybara.rb
@@ -10,20 +10,18 @@ end
 
 if defined?(Capybara)
   RSpec.configure do |c|
-    if defined?(Capybara::DSL)
-      c.include Capybara::DSL, type: :feature
-      if defined?(ActionPack) && ActionPack::VERSION::STRING >= "5.1"
-        c.include Capybara::DSL, type: :system
-      end
-    end
+    # 'capybara/rspec' defines configurations below.
+    #
+    # config.include Capybara::DSL, type: :feature
+    # config.include Capybara::RSpecMatchers, type: :feature
+    # config.include Capybara::DSL, type: :system
+    # config.include Capybara::RSpecMatchers, type: :system
+    # config.include Capybara::RSpecMatchers, type: :view
 
     if defined?(Capybara::RSpecMatchers)
-      c.include Capybara::RSpecMatchers, type: :view
       c.include Capybara::RSpecMatchers, type: :helper
       c.include Capybara::RSpecMatchers, type: :mailer
       c.include Capybara::RSpecMatchers, type: :controller
-      c.include Capybara::RSpecMatchers, type: :feature
-      c.include Capybara::RSpecMatchers, type: :system
     end
 
     unless defined?(Capybara::RSpecMatchers) || defined?(Capybara::DSL)


### PR DESCRIPTION
## Overivew

Both Capybara and rspec-rails includes Capybara::DSL and Capybara::RSpecMatchers for feature/system specs.

```
begin
  require 'capybara/rspec'
rescue LoadError
end

begin
  require 'capybara/rails'
rescue LoadError
end

if defined?(Capybara)
  RSpec.configure do |c|

    binding.pry ### BREAKPOINT HERE
    if defined?(Capybara::DSL)
      c.include Capybara::DSL, type: :feature
      if defined?(ActionPack) && ActionPack::VERSION::STRING >= "5.1"
        c.include Capybara::DSL, type: :system
```

When I watch the configuration by setting a breakpoint above with an actual Rails application, configuration instance already has Capybara::DSL and RSpecMatchers

```
 @include_modules=
  #<RSpec::Core::FilterableItemRepository::QueryOptimized:0x00007f7f7aad00d8
   @applicable_keys=#<RSpec::Core::Set:0x00007f7f7aad0038 @values={:capybara_feature=>true, :type=>true}>,
   @applies_predicate=:any?,
   @items_and_filters=
    [[#<RSpec::Core::SharedExampleGroupModule "Capybara Features">, {:capybara_feature=>true}],
     [Capybara::DSL, {:type=>:feature}],
     [Capybara::RSpecMatchers, {:type=>:feature}],
     [Capybara::DSL, {:type=>:system}],
     [Capybara::RSpecMatchers, {:type=>:system}],
     [Capybara::RSpecMatchers, {:type=>:view}]],
   @memoized_lookups={},
```

So no need to include Capybara::DSL for feature/system specs.

## Direction

Remove redundunt includes, and leave the setup of feature/system spec to Capybara.