### PR TITLE
Fix parameter matching with mail delivery job and `ActionMailer::MailDeliveryJob`

### DIFF
--- a/features/matchers/have_enqueued_mail_matcher.feature
+++ b/features/matchers/have_enqueued_mail_matcher.feature
@@ -38,3 +38,40 @@ Feature: have_enqueued_mail matcher
       """
     When I run `rspec spec/mailers/user_mailer_spec.rb`
     Then the examples should all pass
+
+  Scenario: Checking mailer arguments
+    Given a file named "app/mailers/my_mailer.rb" with:
+      """ruby
+      class MyMailer < ApplicationMailer
+
+        def signup(user = nil)
+          @user = user
+
+          mail to: "to@example.org"
+        end
+      end
+      """
+    Given a file named "spec/mailers/my_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe MyMailer do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
+          # Works with plain args
+          expect {
+            MyMailer.signup('user').deliver_later
+          }.to have_enqueued_mail(MyMailer, :signup).with('user')
+          # Works with named parameters
+          expect {
+            MyMailer.with('foo' => 'bar').signup.deliver_later
+          }.to have_enqueued_mail(MyMailer, :signup).with('foo' => 'bar')
+          # Works also with both, named parameters match first argument
+          expect {
+            MyMailer.with('foo' => 'bar').signup('user').deliver_later
+          }.to have_enqueued_mail(MyMailer, :signup).with({'foo' => 'bar'}, 'user')
+        end
+      end
+      """
+    When I run `rspec spec/mailers/my_mailer_spec.rb`
+    Then the examples should all pass

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -393,18 +393,22 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         }.to have_enqueued_mail(UnifiedMailer, :test_email).and have_enqueued_mail(UnifiedMailer, :email_with_args)
       end
 
-      it "passes with provided argument matchers" do
+      it "matches arguments when mailer has only args" do
+        expect {
+          UnifiedMailer.email_with_args(1, 2).deliver_later
+        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(1, 2)
+      end
+
+      it "matches arguments when mailer is parameterized" do
         expect {
           UnifiedMailer.with('foo' => 'bar').test_email.deliver_later
-        }.to have_enqueued_mail(UnifiedMailer, :test_email).with(
-          a_hash_including(params: {'foo' => 'bar'})
-        )
+        }.to have_enqueued_mail(UnifiedMailer, :test_email).with('foo' => 'bar')
+      end
 
+      it "matches arguments when mixing parameterized and non-parameterized emails" do
         expect {
           UnifiedMailer.with('foo' => 'bar').email_with_args(1, 2).deliver_later
-        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(
-          a_hash_including(params: {'foo' => 'bar'}, args: [1, 2])
-        )
+        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with({'foo' => 'bar'}, 1, 2)
       end
 
       it "passes when using a mailer with `delivery_job` set to a sub class of `ActionMailer::DeliveryJob`" do


### PR DESCRIPTION
This should fix #2351. 

Maybe it's a breaking change for Rails 6 users, I don't know but it will allow users to easily upgrade to rails 6 without changing tons of specs.

Let me know if it's ok, it's my first PR in rspec.