### PR TITLE
Update cucumber

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,28 +22,7 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = %w[--color]
 end
 
-Cucumber::Rake::Task.new(:cucumber) do |t|
-  string_version = ENV.fetch("RAILS_VERSION", "~> 6.0.0")
-  version =
-    if string_version == "master" || string_version.nil?
-      Float::INFINITY
-    else
-      string_version[/\d[\.-]\d/].tr('-', '.')
-    end
-  tags = []
-
-  if version.to_f >= 6.0
-    tags << "'not @rails_pre_6'"
-  end
-
-  if version.to_f < 6.0
-    tags << "'not @rails_post_6'"
-  end
-
-  cucumber_flag = tags.map { |tag| "--tag #{tag}" }
-
-  t.cucumber_opts = cucumber_flag
-end
+Cucumber::Rake::Task.new(:cucumber)
 
 namespace :generate do
   desc "generate a fresh app with rspec installed"

--- a/Rakefile
+++ b/Rakefile
@@ -33,11 +33,11 @@ Cucumber::Rake::Task.new(:cucumber) do |t|
   tags = []
 
   if version.to_f >= 6.0
-    tags << "~@rails_pre_6"
+    tags << "'not @rails_pre_6'"
   end
 
   if version.to_f < 6.0
-    tags << "~@rails_post_6"
+    tags << "'not @rails_post_6'"
   end
 
   cucumber_flag = tags.map { |tag| "--tag #{tag}" }

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,3 +1,3 @@
-default: --require features --format progress --tags ~@wip
-pretty:  --require features --format pretty   --tags ~@wip
+default: --require features --format progress --tags 'not @wip'
+pretty:  --require features --format pretty   --tags 'not @wip'
 wip:     --require features --tags @wip

--- a/features/support/rails_versions.rb
+++ b/features/support/rails_versions.rb
@@ -1,0 +1,22 @@
+def rails_version
+  string_version = ENV.fetch("RAILS_VERSION", "~> 6.0.0")
+  if string_version == "master" || string_version.nil?
+    Float::INFINITY
+  else
+    string_version[/\d[\.-]\d/].tr('-', '.')
+  end
+end
+
+Before "@rails_pre_6" do |scenario|
+  if rails_version.to_f >= 6.0
+    warn "Skipping scenario #{scenario.name} on Rails v#{rails_version}"
+    skip_this_scenario
+  end
+end
+
+Before "@rails_post_6" do |scenario|
+  if rails_version.to_f < 6.0
+    warn "Skipping scenario #{scenario.name} on Rails v#{rails_version}"
+    skip_this_scenario
+  end
+end

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -58,5 +58,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'ammeter',  '~> 1.1.5'
   s.add_development_dependency 'aruba',    '~> 0.14.12'
-  s.add_development_dependency 'cucumber', '~> 1.3.5'
+  s.add_development_dependency 'cucumber', '>= 3.2', '!= 4.0.0', '< 8.0.0'
 end


### PR DESCRIPTION
`cucumber` 4.0.0 is not aware of breaking changes in diff-lcs 1.4.3, so excluding it.

`cucumber` 3.2 would run on Ruby 2.2, 2.3 and 2.4.

Running `cucumber` was **not** excluding features that don't match the current Rails version (`@rails_pre_6`/`@rails_post_6`). `rake cucumber` was working fine.
I've reworked this from `Rakefile` to be a `Before` Cucumber hook in `features/support`.

Sibling PRs:
 - https://github.com/rspec/rspec-core/pull/2877
 - https://github.com/rspec/rspec-mocks/pull/1439
 - https://github.com/rspec/rspec-expectations/pull/1320