### PR TITLE
Remove incompatible --color CLI option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,6 @@ end
 desc "Run all examples"
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.ruby_opts = %w[-w]
-  t.rspec_opts = %w[--color]
 end
 
 Cucumber::Rake::Task.new(:cucumber) do |t|


### PR DESCRIPTION
The option was removed in RSpec 4, see https://github.com/rspec/rspec-core/pull/2864
Follow-up to https://github.com/rspec/rspec-rails/pull/2458