### PR TITLE
Fix Rails 7 build

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -6,7 +6,6 @@ when /master/
   gem "activerecord-deprecated_finders", :git => "https://github.com/rails/activerecord-deprecated_finders.git"
   gem "web-console", :git => "https://github.com/rails/web-console", :group => :development
   gem 'coffee-rails', :git => "https://github.com/rails/coffee-rails.git"
-  gem 'i18n', :git => 'https://github.com/svenfuchs/i18n.git', :branch => 'master'
   gem 'sprockets', :git => 'https://github.com/rails/sprockets.git', :branch => 'master'
   gem 'sprockets-rails', :git => 'https://github.com/rails/sprockets-rails.git', :branch => 'master'
   gem 'puma', "3.12.1"

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -3,7 +3,6 @@ version_file = File.expand_path("../.rails-version", __FILE__)
 case version = ENV['RAILS_VERSION'] || (File.exist?(version_file) && File.read(version_file).chomp) || ''
 when /master/
   gem "rails", :git => "https://github.com/rails/rails.git"
-  gem "journey", :git => "https://github.com/rails/journey.git"
   gem "activerecord-deprecated_finders", :git => "https://github.com/rails/activerecord-deprecated_finders.git"
   gem "web-console", :git => "https://github.com/rails/web-console", :group => :development
   gem 'coffee-rails', :git => "https://github.com/rails/coffee-rails.git"

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -8,7 +8,6 @@ when /master/
   gem "activerecord-deprecated_finders", :git => "https://github.com/rails/activerecord-deprecated_finders.git"
   gem "web-console", :git => "https://github.com/rails/web-console", :group => :development
   gem 'coffee-rails', :git => "https://github.com/rails/coffee-rails.git"
-  gem 'rack', :git => 'https://github.com/rack/rack.git'
   gem 'i18n', :git => 'https://github.com/svenfuchs/i18n.git', :branch => 'master'
   gem 'sprockets', :git => 'https://github.com/rails/sprockets.git', :branch => 'master'
   gem 'sprockets-rails', :git => 'https://github.com/rails/sprockets-rails.git', :branch => 'master'

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -3,7 +3,6 @@ version_file = File.expand_path("../.rails-version", __FILE__)
 case version = ENV['RAILS_VERSION'] || (File.exist?(version_file) && File.read(version_file).chomp) || ''
 when /master/
   gem "rails", :git => "https://github.com/rails/rails.git"
-  gem "arel", :git => "https://github.com/rails/arel.git"
   gem "journey", :git => "https://github.com/rails/journey.git"
   gem "activerecord-deprecated_finders", :git => "https://github.com/rails/activerecord-deprecated_finders.git"
   gem "web-console", :git => "https://github.com/rails/web-console", :group => :development

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -18,7 +18,7 @@ in_root do
 
   # Remove the existing rails version so we can properly use main or other
   # edge branches
-  gsub_file 'Gemfile', /^.*\bgem 'rails.*$/, ''
+  gsub_file 'Gemfile', /^.*\bgem ['"]rails.*$/, ''
   gsub_file "Gemfile", /.*web-console.*/, ''
   gsub_file "Gemfile", /.*debugger.*/, ''
   gsub_file "Gemfile", /.*puma.*/, ''

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -20,7 +20,7 @@ in_root do
   # edge branches
   gsub_file 'Gemfile', /^.*\bgem ['"]rails.*$/, ''
   gsub_file "Gemfile", /.*web-console.*/, ''
-  gsub_file "Gemfile", /.*debugger.*/, ''
+  gsub_file "Gemfile", /.*debug.*/, ''
   gsub_file "Gemfile", /.*puma.*/, ''
   gsub_file "Gemfile", /.*bootsnap.*/, ''
 

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -19,6 +19,7 @@ in_root do
   # Remove the existing rails version so we can properly use main or other
   # edge branches
   gsub_file 'Gemfile', /^.*\bgem ['"]rails.*$/, ''
+  gsub_file 'Gemfile', /^.*\bgem ['"]selenium\-webdriver.*$/, ''
   gsub_file "Gemfile", /.*web-console.*/, ''
   gsub_file "Gemfile", /.*debug.*/, ''
   gsub_file "Gemfile", /.*puma.*/, ''

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -78,4 +78,11 @@ in_root do
             'REPLACE_BUNDLE_PATH',
             bundle_install_path
   chmod 'ci_retry_bundle_install.sh', 0755
+
+  if Rails::VERSION::STRING > '7'
+    create_file 'app/assets/config/manifest.js' do
+      "//= link application.css"
+    end
+    create_file 'app/assets/stylesheets/application.css'
+  end
 end


### PR DESCRIPTION
This change:

1. Removes explicit dependencies on gems independent, but required by Rails (`i18n`, `rack`)
2. Removes explicit dependencies on Rails-swallowed gems (`journey`, `arel`)
3. Minor fixes to `tmp/example_app/Gemfile` generation to avoid conflicts with `Gemfile-rails-dependencies`
4. Added sprockets manifest generation

These changes only affect our build, and only against Rails' `main`.
See https://github.com/rspec/rspec-rails/pull/2521#issuecomment-932412247 and https://github.com/rspec/rspec-rails/pull/2521/checks?check_run_id=3757830550

### `rack`

Using rack from git opens up opportunities to fail due to unreleased rack issues, e.g. https://github.com/rack/rack/issues/1768

No need to explicitly depend on rack, Rails does that: https://github.com/rails/rails/blob/c2b083df913f44e664576aafe24c41ec657f8eb5/actionpack/actionpack.gemspec#L37

### `i18n`

Depending on i18n's latest git version opens up opportunities to:
1. fail due to i18n's unstable changes
2. fail due to version conflict (their `master` can flip to 2.0, while `rails` would depend on `< 2`)

Rails explicitly depend on `i18n` anyway: https://github.com/rails/rails/blob/c2b083df913f44e664576aafe24c41ec657f8eb5/activesupport/activesupport.gemspec#L36

### `journey`

https://github.com/rails/journey

> This gem was merged on Rails 4.0 and will only receive security fixes

### `arel`

https://github.com/rails/arel

Arel was swallowed by Rails back in 2018