### PR TITLE
Disallow failures for passing builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
            env:
              RAILS_VERSION: '~> 5.2.0'
          - ruby: 2.2.10
-           allow_failure: true
            env:
              RAILS_VERSION: '~> 5.2.0'
          - ruby: 2.2.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
 
          # Rails 6.1 builds >= 2.5
          - ruby: 3.0
-           allow_failure: true
            env:
              RAILS_VERSION: '~> 6.1.0'
          - ruby: 2.7

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -239,19 +239,8 @@ module RSpec::Rails
         expect(view_spec.view).to eq(view)
       end
 
-      if RUBY_VERSION <= "2.3.0" && ENV["RAILS_VERSION"] !~ /stable/ && ::Rails.version.to_f == 5.2
-        pending_only_on_ruby_22_rails_52 = """
-          Rails 5.2.4.2 has a syntax error in ActionDispatch::Request::Session.
-          (A &. usage which does not work in 2.2.10)
-          It has been fixed but not released, this spec will not pass until that
-          has been released.
-        """
-      else
-        pending_only_on_ruby_22_rails_52 = false
-      end
-
       # Regression test from rspec/rspec-rails#833
-      it 'is accessible to configuration-level hooks', pending: pending_only_on_ruby_22_rails_52 do
+      it 'is accessible to configuration-level hooks' do
         run_count = 0
         RSpec.configuration.before(:each, type: :view) do
           # `view` is provided from the view example type, and serves to


### PR DESCRIPTION
1. Disallow failures for Rails 6.1 on Ruby 3.0

Both are pretty stable, and the build actually passes
https://github.com/rspec/rspec-rails/runs/3771356606

2.  Turn pending test to a regular one for Rails 5.2

ActiveSupport::Cache::RedisCacheStore's usage of safe navigation was fixed in Rails 5.2.5:
https://github.com/rails/rails/blob/v5.2.4.3/activesupport/lib/active_support/cache/redis_cache_store.rb#L323 
https://github.com/rails/rails/blob/v5.2.5/activesupport/lib/active_support/cache/redis_cache_store.rb#L323

In ActionDispatch::Request::Session it was fixed, too:
https://github.com/rails/rails/blob/v5.2.4.3/actionpack/lib/action_dispatch/request/session.rb#L96 
https://github.com/rails/rails/blob/v5.2.5/actionpack/lib/action_dispatch/request/session.rb#L96

Our `pending` [was actually failing](https://github.com/rspec/rspec-rails/pull/2521/checks?check_run_id=3777869258) (since the test was passing) for some while:
```
 Failures:

  1) RSpec::Rails::ViewExampleGroup#view is accessible to configuration-level hooks FIXED
     Expected pending '
          Rails 5.2.4.2 has a syntax error in ActionDispatch::Request::Session.
          (A &. usage which does not work in 2.2.10)
          It has been fixed but not released, this spec will not pass until that
          has been released.
        ' to fail. No error was raised.
     # ./spec/rspec/rails/example/view_example_group_spec.rb:254
```

:question: Do we need to keep the build for `5-2-stable`?