### PR TITLE
Prefer require_relative to avoid calculating relative paths

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
+require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'

--- a/spec/generators/rspec/install/install_generator_spec.rb
+++ b/spec/generators/rspec/install/install_generator_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe Rspec::Generators::InstallGenerator, type: :generator do
     match(/ActiveRecord::Migration\.maintain_test_schema!/m)
   end
 
+  def require_rails_environment
+    match(/^require_relative '\.\.\/config\/environment'$/m)
+  end
+
   def require_rspec_rails
     match(/^require 'rspec\/rails'$/m)
   end
@@ -62,6 +66,11 @@ RSpec.describe Rspec::Generators::InstallGenerator, type: :generator do
   end
 
   context "generates spec/rails_helper.rb" do
+    specify "requiring Rails environment" do
+      run_generator
+      expect(rails_helper).to require_rails_environment
+    end
+
     specify "requiring rspec/rails" do
       run_generator
       expect(rails_helper).to require_rspec_rails
@@ -97,6 +106,11 @@ RSpec.describe Rspec::Generators::InstallGenerator, type: :generator do
   context "generates spec/rails_helper.rb", "without ActiveRecord available" do
     before do
       hide_const("ActiveRecord")
+    end
+
+    specify "requiring Rails environment" do
+      run_generator
+      expect(rails_helper).to require_rails_environment
     end
 
     specify "requiring rspec/rails" do


### PR DESCRIPTION
Calculating a relative path to require duplicates the builtin Ruby
feature.

https://ruby-doc.org/core-3.0.2/Kernel.html#method-i-require_relative