### PR TITLE
Remove explicit sprockets dependency for Rails 7

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -3,11 +3,6 @@ version_file = File.expand_path("../.rails-version", __FILE__)
 case version = ENV['RAILS_VERSION'] || (File.exist?(version_file) && File.read(version_file).chomp) || ''
 when /master/
   gem "rails", :git => "https://github.com/rails/rails.git"
-  gem "activerecord-deprecated_finders", :git => "https://github.com/rails/activerecord-deprecated_finders.git"
-  gem "web-console", :git => "https://github.com/rails/web-console", :group => :development
-  gem 'coffee-rails', :git => "https://github.com/rails/coffee-rails.git"
-  gem 'sprockets', :git => 'https://github.com/rails/sprockets.git', :branch => 'master'
-  gem 'sprockets-rails', :git => 'https://github.com/rails/sprockets-rails.git', :branch => 'master'
   gem 'puma', "3.12.1"
   gem 'activerecord-jdbcsqlite3-adapter', git: 'https://github.com/jruby/activerecord-jdbc-adapter', platforms: [:jruby]
   gem 'selenium-webdriver', require: false


### PR DESCRIPTION
https://github.com/rspec/rspec-rails/runs/4222116982?check_suite_focus=true

```
    [!] There was an error parsing `Gemfile`:
    [!] There was an error parsing `Gemfile-rails-dependencies`: You cannot specify the same gem twice with different version requirements.
    You specified: sprockets-rails (>= 2.0.0) and sprockets-rails (>= 0). Bundler cannot continue.

     #  from /home/runner/work/rspec-rails/rspec-rails/Gemfile-rails-dependencies:10
     #  -------------------------------------------
     #    gem 'sprockets', :git => 'https://github.com/rails/sprockets.git', :branch => 'master'
     >    gem 'sprockets-rails', :git => 'https://github.com/rails/sprockets-rails.git', :branch => 'master'
```