### PR TITLE
Fix scaffold template with namespace and `--model-name` option

### DIFF
--- a/lib/generators/rspec/scaffold/templates/api_controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/api_controller_spec.rb
@@ -64,21 +64,21 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with valid params" do
       it "creates a new <%= class_name %>" do
         expect {
-          post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
+          post :create, params: {<%= singular_table_name %>: valid_attributes}, session: valid_session
         }.to change(<%= class_name %>, :count).by(1)
       end
 
-      it "renders a JSON response with the new <%= ns_file_name %>" do
-        post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
+      it "renders a JSON response with the new <%= singular_table_name %>" do
+        post :create, params: {<%= singular_table_name %>: valid_attributes}, session: valid_session
         expect(response).to have_http_status(:created)
         expect(response.content_type).to eq('application/json')
-        expect(response.location).to eq(<%= ns_file_name %>_url(<%= class_name %>.last))
+        expect(response.location).to eq(<%= singular_table_name %>_url(<%= class_name %>.last))
       end
     end
 
     context "with invalid params" do
-      it "renders a JSON response with errors for the new <%= ns_file_name %>" do
-        post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
+      it "renders a JSON response with errors for the new <%= singular_table_name %>" do
+        post :create, params: {<%= singular_table_name %>: invalid_attributes}, session: valid_session
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to eq('application/json')
       end
@@ -91,25 +91,25 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
         skip("Add a hash of attributes valid for your model")
       }
 
-      it "updates the requested <%= ns_file_name %>" do
+      it "updates the requested <%= singular_table_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: new_attributes}, session: valid_session
+        put :update, params: {id: <%= file_name %>.to_param, <%= singular_table_name %>: new_attributes}, session: valid_session
         <%= file_name %>.reload
         skip("Add assertions for updated state")
       end
 
-      it "renders a JSON response with the <%= ns_file_name %>" do
+      it "renders a JSON response with the <%= singular_table_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: valid_attributes}, session: valid_session
+        put :update, params: {id: <%= file_name %>.to_param, <%= singular_table_name %>: valid_attributes}, session: valid_session
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to eq('application/json')
       end
     end
 
     context "with invalid params" do
-      it "renders a JSON response with errors for the <%= ns_file_name %>" do
+      it "renders a JSON response with errors for the <%= singular_table_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
+        put :update, params: {id: <%= file_name %>.to_param, <%= singular_table_name %>: invalid_attributes}, session: valid_session
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to eq('application/json')
       end
@@ -117,7 +117,7 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
   end
 
   describe "DELETE #destroy" do
-    it "destroys the requested <%= ns_file_name %>" do
+    it "destroys the requested <%= singular_table_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       expect {
         delete :destroy, params: {id: <%= file_name %>.to_param}, session: valid_session

--- a/lib/generators/rspec/scaffold/templates/api_request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/api_request_spec.rb
@@ -56,13 +56,13 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
       it "creates a new <%= class_name %>" do
         expect {
           post <%= index_helper %>_url,
-               params: { <%= ns_file_name %>: valid_attributes }, headers: valid_headers, as: :json
+               params: { <%= singular_table_name %>: valid_attributes }, headers: valid_headers, as: :json
         }.to change(<%= class_name %>, :count).by(1)
       end
 
-      it "renders a JSON response with the new <%= ns_file_name %>" do
+      it "renders a JSON response with the new <%= singular_table_name %>" do
         post <%= index_helper %>_url,
-             params: { <%= ns_file_name %>: valid_attributes }, headers: valid_headers, as: :json
+             params: { <%= singular_table_name %>: valid_attributes }, headers: valid_headers, as: :json
         expect(response).to have_http_status(:created)
         expect(response.content_type).to match(a_string_including("application/json"))
       end
@@ -72,13 +72,13 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
       it "does not create a new <%= class_name %>" do
         expect {
           post <%= index_helper %>_url,
-               params: { <%= ns_file_name %>: invalid_attributes }, as: :json
+               params: { <%= singular_table_name %>: invalid_attributes }, as: :json
         }.to change(<%= class_name %>, :count).by(0)
       end
 
-      it "renders a JSON response with errors for the new <%= ns_file_name %>" do
+      it "renders a JSON response with errors for the new <%= singular_table_name %>" do
         post <%= index_helper %>_url,
-             params: { <%= ns_file_name %>: invalid_attributes }, headers: valid_headers, as: :json
+             params: { <%= singular_table_name %>: invalid_attributes }, headers: valid_headers, as: :json
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to match(a_string_including("application/json"))
       end
@@ -91,7 +91,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
         skip("Add a hash of attributes valid for your model")
       }
 
-      it "updates the requested <%= ns_file_name %>" do
+      it "updates the requested <%= singular_table_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         patch <%= show_helper %>,
               params: { <%= singular_table_name %>: new_attributes }, headers: valid_headers, as: :json
@@ -99,7 +99,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
         skip("Add assertions for updated state")
       end
 
-      it "renders a JSON response with the <%= ns_file_name %>" do
+      it "renders a JSON response with the <%= singular_table_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         patch <%= show_helper %>,
               params: { <%= singular_table_name %>: new_attributes }, headers: valid_headers, as: :json
@@ -109,7 +109,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
     end
 
     context "with invalid parameters" do
-      it "renders a JSON response with errors for the <%= ns_file_name %>" do
+      it "renders a JSON response with errors for the <%= singular_table_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         patch <%= show_helper %>,
               params: { <%= singular_table_name %>: invalid_attributes }, headers: valid_headers, as: :json
@@ -120,7 +120,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
   end
 
   describe "DELETE /destroy" do
-    it "destroys the requested <%= ns_file_name %>" do
+    it "destroys the requested <%= singular_table_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       expect {
         delete <%= show_helper %>, headers: valid_headers, as: :json

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -79,19 +79,19 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with valid params" do
       it "creates a new <%= class_name %>" do
         expect {
-          post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
+          post :create, params: {<%= singular_table_name %>: valid_attributes}, session: valid_session
         }.to change(<%= class_name %>, :count).by(1)
       end
 
-      it "redirects to the created <%= ns_file_name %>" do
-        post :create, params: {<%= ns_file_name %>: valid_attributes}, session: valid_session
+      it "redirects to the created <%= singular_table_name %>" do
+        post :create, params: {<%= singular_table_name %>: valid_attributes}, session: valid_session
         expect(response).to redirect_to(<%= class_name %>.last)
       end
     end
 
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: {<%= ns_file_name %>: invalid_attributes}, session: valid_session
+        post :create, params: {<%= singular_table_name %>: invalid_attributes}, session: valid_session
         expect(response).to be_successful
       end
     end
@@ -103,16 +103,16 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
         skip("Add a hash of attributes valid for your model")
       }
 
-      it "updates the requested <%= ns_file_name %>" do
+      it "updates the requested <%= singular_table_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: new_attributes}, session: valid_session
+        put :update, params: {id: <%= file_name %>.to_param, <%= singular_table_name %>: new_attributes}, session: valid_session
         <%= file_name %>.reload
         skip("Add assertions for updated state")
       end
 
-      it "redirects to the <%= ns_file_name %>" do
+      it "redirects to the <%= singular_table_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: valid_attributes}, session: valid_session
+        put :update, params: {id: <%= file_name %>.to_param, <%= singular_table_name %>: valid_attributes}, session: valid_session
         expect(response).to redirect_to(<%= file_name %>)
       end
     end
@@ -120,14 +120,14 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'edit' template)" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
-        put :update, params: {id: <%= file_name %>.to_param, <%= ns_file_name %>: invalid_attributes}, session: valid_session
+        put :update, params: {id: <%= file_name %>.to_param, <%= singular_table_name %>: invalid_attributes}, session: valid_session
         expect(response).to be_successful
       end
     end
   end
 
   describe "DELETE #destroy" do
-    it "destroys the requested <%= ns_file_name %>" do
+    it "destroys the requested <%= singular_table_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       expect {
         delete :destroy, params: {id: <%= file_name %>.to_param}, session: valid_session

--- a/lib/generators/rspec/scaffold/templates/request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/request_spec.rb
@@ -65,12 +65,12 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
     context "with valid parameters" do
       it "creates a new <%= class_name %>" do
         expect {
-          post <%= index_helper %>_url, params: { <%= ns_file_name %>: valid_attributes }
+          post <%= index_helper %>_url, params: { <%= singular_table_name %>: valid_attributes }
         }.to change(<%= class_name %>, :count).by(1)
       end
 
-      it "redirects to the created <%= ns_file_name %>" do
-        post <%= index_helper %>_url, params: { <%= ns_file_name %>: valid_attributes }
+      it "redirects to the created <%= singular_table_name %>" do
+        post <%= index_helper %>_url, params: { <%= singular_table_name %>: valid_attributes }
         expect(response).to redirect_to(<%= show_helper(class_name+".last") %>)
       end
     end
@@ -78,12 +78,12 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
     context "with invalid parameters" do
       it "does not create a new <%= class_name %>" do
         expect {
-          post <%= index_helper %>_url, params: { <%= ns_file_name %>: invalid_attributes }
+          post <%= index_helper %>_url, params: { <%= singular_table_name %>: invalid_attributes }
         }.to change(<%= class_name %>, :count).by(0)
       end
 
       it "renders a successful response (i.e. to display the 'new' template)" do
-        post <%= index_helper %>_url, params: { <%= ns_file_name %>: invalid_attributes }
+        post <%= index_helper %>_url, params: { <%= singular_table_name %>: invalid_attributes }
         expect(response).to be_successful
       end
     end
@@ -95,14 +95,14 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
         skip("Add a hash of attributes valid for your model")
       }
 
-      it "updates the requested <%= ns_file_name %>" do
+      it "updates the requested <%= singular_table_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         patch <%= show_helper %>, params: { <%= singular_table_name %>: new_attributes }
         <%= file_name %>.reload
         skip("Add assertions for updated state")
       end
 
-      it "redirects to the <%= ns_file_name %>" do
+      it "redirects to the <%= singular_table_name %>" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         patch <%= show_helper %>, params: { <%= singular_table_name %>: new_attributes }
         <%= file_name %>.reload
@@ -120,7 +120,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
   end
 
   describe "DELETE /destroy" do
-    it "destroys the requested <%= ns_file_name %>" do
+    it "destroys the requested <%= singular_table_name %>" do
       <%= file_name %> = <%= class_name %>.create! valid_attributes
       expect {
         delete <%= show_helper %>

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
   describe 'namespaced request spec' do
     subject { file('spec/requests/admin/posts_spec.rb') }
 
-    describe 'with no options' do
-      before  { run_generator %w[admin/posts] }
+    describe 'with default options' do
+      before { run_generator %w[admin/posts] }
       it { is_expected.to exist }
       it { is_expected.to contain(/^RSpec.describe "\/admin\/posts", #{type_metatag(:request)}/) }
       it { is_expected.to contain('post admin_posts_url, params: { admin_post: valid_attributes }') }
@@ -112,7 +112,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
     end
 
     describe 'with --model-name' do
-      before  { run_generator %w[admin/posts --model-name=post] }
+      before { run_generator %w[admin/posts --model-name=post] }
       it { is_expected.to contain('post admin_posts_url, params: { post: valid_attributes }') }
       it { is_expected.not_to contain('params: { admin_post: valid_attributes }') }
       it { is_expected.to contain(' Post.create') }
@@ -137,18 +137,33 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
   describe 'namespaced controller spec' do
     subject { file('spec/controllers/admin/posts_controller_spec.rb') }
 
-    describe 'with no options' do
-      before  { run_generator %w[admin/posts --controller_specs] }
+    describe 'with default options' do
+      before { run_generator %w[admin/posts --controller_specs] }
       it { is_expected.to contain(/^RSpec.describe Admin::PostsController, #{type_metatag(:controller)}/) }
       it { is_expected.to contain('post :create, params: {admin_post: valid_attributes}') }
       it { is_expected.to contain('Admin::Post.create') }
     end
 
     describe 'with --model-name' do
-      before  { run_generator %w[admin/posts --model-name=post --controller_specs] }
+      before { run_generator %w[admin/posts --model-name=post --controller_specs] }
       it { is_expected.to contain('post :create, params: {post: valid_attributes}') }
       it { is_expected.not_to contain('params: {admin_post: valid_attributes}') }
       it { is_expected.to contain(' Post.create') }
+    end
+
+    context 'with --api' do
+      describe 'with default options' do
+        before { run_generator %w[admin/posts --api --controller_specs] }
+        it { is_expected.to contain('post :create, params: {admin_post: valid_attributes}') }
+        it { is_expected.to contain('Admin::Post.create') }
+      end
+
+      describe 'with --model-name' do
+        before { run_generator %w[admin/posts --api --model-name=post --controller_specs] }
+        it { is_expected.to contain('post :create, params: {post: valid_attributes}') }
+        it { is_expected.not_to contain('params: {admin_post: valid_attributes}') }
+        it { is_expected.to contain(' Post.create') }
+      end
     end
   end
 

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -117,6 +117,12 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
       it { is_expected.not_to contain('params: { admin_post: valid_attributes }') }
       it { is_expected.to contain(' Post.create') }
     end
+
+    describe 'with --model-name & --api' do
+      before { run_generator %w[admin/posts --api --model-name=post] }
+      it { is_expected.to contain('params: { post: valid_attributes }') }
+      it { is_expected.not_to contain('params: { admin_post: valid_attributes }') }
+    end
   end
 
   describe 'namespaced controller spec' do

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -118,10 +118,19 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
       it { is_expected.to contain(' Post.create') }
     end
 
-    describe 'with --model-name & --api' do
-      before { run_generator %w[admin/posts --api --model-name=post] }
-      it { is_expected.to contain('params: { post: valid_attributes }') }
-      it { is_expected.not_to contain('params: { admin_post: valid_attributes }') }
+    context 'with --api' do
+      describe 'with default options' do
+        before { run_generator %w[admin/posts --api] }
+        it { is_expected.to contain('params: { admin_post: valid_attributes }') }
+        it { is_expected.to contain('Admin::Post.create') }
+      end
+
+      describe 'with --model-name' do
+        before { run_generator %w[admin/posts --api --model-name=post] }
+        it { is_expected.to contain('params: { post: valid_attributes }') }
+        it { is_expected.not_to contain('params: { admin_post: valid_attributes }') }
+        it { is_expected.to contain(' Post.create') }
+      end
     end
   end
 

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -121,8 +121,20 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
 
   describe 'namespaced controller spec' do
     subject { file('spec/controllers/admin/posts_controller_spec.rb') }
-    before  { run_generator %w[admin/posts --controller_specs] }
-    it { is_expected.to contain(/^RSpec.describe Admin::PostsController, #{type_metatag(:controller)}/) }
+
+    describe 'with no options' do
+      before  { run_generator %w[admin/posts --controller_specs] }
+      it { is_expected.to contain(/^RSpec.describe Admin::PostsController, #{type_metatag(:controller)}/) }
+      it { is_expected.to contain('post :create, params: {admin_post: valid_attributes}') }
+      it { is_expected.to contain('Admin::Post.create') }
+    end
+
+    describe 'with --model-name' do
+      before  { run_generator %w[admin/posts --model-name=post --controller_specs] }
+      it { is_expected.to contain('post :create, params: {post: valid_attributes}') }
+      it { is_expected.not_to contain('params: {admin_post: valid_attributes}') }
+      it { is_expected.to contain(' Post.create') }
+    end
   end
 
   describe 'view specs' do

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -101,11 +101,22 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
 
   describe 'namespaced request spec' do
     subject { file('spec/requests/admin/posts_spec.rb') }
-    before  { run_generator %w[admin/posts] }
-    it { is_expected.to exist }
-    it { is_expected.to contain(/^RSpec.describe "\/admin\/posts", #{type_metatag(:request)}/) }
-    it { is_expected.to contain('admin_post_url(post)') }
-    it { is_expected.to contain('Admin::Post.create') }
+
+    describe 'with no options' do
+      before  { run_generator %w[admin/posts] }
+      it { is_expected.to exist }
+      it { is_expected.to contain(/^RSpec.describe "\/admin\/posts", #{type_metatag(:request)}/) }
+      it { is_expected.to contain('post admin_posts_url, params: { admin_post: valid_attributes }') }
+      it { is_expected.to contain('admin_post_url(post)') }
+      it { is_expected.to contain('Admin::Post.create') }
+    end
+
+    describe 'with --model-name' do
+      before  { run_generator %w[admin/posts --model-name=post] }
+      it { is_expected.to contain('post admin_posts_url, params: { post: valid_attributes }') }
+      it { is_expected.not_to contain('params: { admin_post: valid_attributes }') }
+      it { is_expected.to contain(' Post.create') }
+    end
   end
 
   describe 'namespaced controller spec' do


### PR DESCRIPTION
close https://github.com/rspec/rspec-rails/issues/2532

Fixed the behavior of scaffold template when namespace and `--model-name` option passed.

```shell
$ rails g scaffold_controller admin/products --model-name=product
```

```rb
describe "POST /create" do
  context "with valid parameters" do
    it "creates a new Product" do
      expect {
        # Here, I expected `{ product: valid_attributes }` like the test of update action
        post admin_products_url, params: { admin_product: valid_attributes } 
      }.to change(Product, :count).by(1)
    end
    # ...
end
```

This is because `ns_file_name` method that is called in scaffold template returns `admin_product` when namespaced.

https://github.com/rspec/rspec-rails/blob/ba2d66abf275fe1f490c3ed219459e42698936d6/lib/generators/rspec/scaffold/scaffold_generator.rb#L79-L83

So, I replaced `ns_file_name` to `singular_table_name` in scaffold templates.

Also, I added some tests to ensure that templates works in the old way when the `--model-name` option is not passed.