### PR TITLE
Fix Rails integration branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         # Rails Master (7.0) builds >= 2.7
+         # Edge Rails (7.0) builds >= 2.7
          - ruby: 3.0
            allow_failure: true
            env:
-             RAILS_VERSION: 'master'
+             RAILS_VERSION: 'main'
          - ruby: 2.7
            allow_failure: true
            env:
-             RAILS_VERSION: 'master'
+             RAILS_VERSION: 'main'
 
          # Rails 6.1 builds >= 2.5
          - ruby: 3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
     # Rails 6.1 builds >= 2.5
     - jdk: oraclejdk11
       env:
-        - RAILS_VERSION='master'
+        - RAILS_VERSION='main'
         - JRUBY_OPT=--dev
         - JAVA_OPTS="--add-opens java.base/sun.nio.ch=org.jruby.dist --add-opens java.base/java.io=org.jruby.dist --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.security.cert=ALL-UNNAMED --add-opens=java.base/java.util.zip=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/javax.crypto=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED"
 
@@ -64,6 +64,6 @@ matrix:
 
 branches:
   only:
-    - master
+    - main
     - /^\d+-\d+-maintenance$/
     - /^\d+-\d+-dev$/

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -1,7 +1,7 @@
 version_file = File.expand_path("../.rails-version", __FILE__)
 
 case version = ENV['RAILS_VERSION'] || (File.exist?(version_file) && File.read(version_file).chomp) || ''
-when /master/
+when /main/
   gem "rails", :git => "https://github.com/rails/rails.git"
   gem 'puma', "3.12.1"
   gem 'activerecord-jdbcsqlite3-adapter', git: 'https://github.com/jruby/activerecord-jdbc-adapter', platforms: [:jruby]

--- a/Gemfile-sqlite-dependencies
+++ b/Gemfile-sqlite-dependencies
@@ -5,7 +5,7 @@ MAJOR =
   case RAILS_VERSION
   when /5-2-stable/
     5
-  when /master/, /stable/, nil, false, ''
+  when /main/, /stable/, nil, false, ''
     6
   else
     /(\d+)[\.|-]\d+/.match(RAILS_VERSION).captures.first.to_i

--- a/benchmarks/before_block_capture_block_vs_yield.rb
+++ b/benchmarks/before_block_capture_block_vs_yield.rb
@@ -42,11 +42,11 @@ capturing the block and then performing an `instance_exec` on it later in the
 example context.
 
 rspec-core has already performed [many related benchmarks about
-this](https://github.com/rspec/rspec-core/tree/master/benchmarks):
+this](https://github.com/rspec/rspec-core/tree/main/benchmarks):
 
-- [call vs yield](https://github.com/rspec/rspec-core/blob/master/benchmarks/call_v_yield.rb)
-- [capture block vs yield](https://github.com/rspec/rspec-core/blob/master/benchmarks/capture_block_vs_yield.rb)
-- [flat map vs inject](https://github.com/rspec/rspec-core/blob/master/benchmarks/flat_map_vs_inject.rb)
+- [call vs yield](https://github.com/rspec/rspec-core/blob/main/benchmarks/call_v_yield.rb)
+- [capture block vs yield](https://github.com/rspec/rspec-core/blob/main/benchmarks/capture_block_vs_yield.rb)
+- [flat map vs inject](https://github.com/rspec/rspec-core/blob/main/benchmarks/flat_map_vs_inject.rb)
 
 The results are very interesting:
 
@@ -64,7 +64,7 @@ The results are very interesting:
 > See also `flat_map_vs_inject.rb`, which appears to contradict these
 > results a little bit.
 >
-> -- https://github.com/rspec/rspec-core/blob/master/benchmarks/capture_block_vs_yield.rb#L83-L95
+> -- https://github.com/rspec/rspec-core/blob/main/benchmarks/capture_block_vs_yield.rb#L83-L95
 
 and
 
@@ -75,7 +75,7 @@ and
 > version remains faster in my benchmarks here no matter how small
 > I shrink the `words` array. I'm not sure why!
 >
-> -- https://github.com/rspec/rspec-core/blob/master/benchmarks/flat_map_vs_inject.rb#L37-L42
+> -- https://github.com/rspec/rspec-core/blob/main/benchmarks/flat_map_vs_inject.rb#L37-L42
 
 This seems to show that the error margin is enough to negate any benefit from
 capturing the block initially. It also shows that not capturing the block is

--- a/features/controller_specs/README.md
+++ b/features/controller_specs/README.md
@@ -2,7 +2,7 @@ Controller specs are marked by `:type => :controller` or if you have set
 `config.infer_spec_type_from_file_location!` by placing them in `spec/controllers`.
 
 A controller spec is an RSpec wrapper for a Rails functional test
-([ActionController::TestCase::Behavior](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/test_case.rb)).
+([ActionController::TestCase::Behavior](https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/test_case.rb)).
 It allows you to simulate a single http request in each example, and then
 specify expected outcomes such as:
 

--- a/features/support/rails_versions.rb
+++ b/features/support/rails_versions.rb
@@ -1,6 +1,6 @@
 def rails_version
   string_version = ENV.fetch("RAILS_VERSION", "~> 6.0.0")
-  if string_version == "master" || string_version.nil?
+  if string_version == "main" || string_version.nil?
     Float::INFINITY
   else
     string_version[/\d[\.-]\d/].tr('-', '.')

--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -1,6 +1,6 @@
 # The following code inspired and modified from Rails' `assert_response`:
 #
-#   https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/assertions/response.rb#L22-L38
+#   https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/testing/assertions/response.rb#L22-L38
 #
 # Thank you to all the Rails devs who did the heavy lifting on this!
 
@@ -243,7 +243,7 @@ module RSpec
 
           # @return [Array<Symbol>] of status codes which represent a HTTP status
           #   code "group"
-          # @see https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
+          # @see https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
           def self.valid_statuses
             [
               :error, :success, :missing,
@@ -313,7 +313,7 @@ module RSpec
 
           # @return [String] formatting the associated code(s) for the various
           #   status code "groups"
-          # @see https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
+          # @see https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
           # @see https://github.com/rack/rack/blob/master/lib/rack/response.rb `Rack::Response`
           def type_codes
             # At the time of this commit the most recent version of
@@ -373,7 +373,7 @@ module RSpec
       #   expect(response).to have_http_status(404)
       #   expect(page).to     have_http_status(:created)
       #
-      # @see https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
+      # @see https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/testing/test_response.rb `ActionDispatch::TestResponse`
       # @see https://github.com/rack/rack/blob/master/lib/rack/utils.rb `Rack::Utils::SYMBOL_TO_STATUS_CODE`
       def have_http_status(target)
         raise ArgumentError, "Invalid HTTP status: nil" unless target

--- a/spec/rspec/rails/matchers/have_http_status_spec.rb
+++ b/spec/rspec/rails/matchers/have_http_status_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe "have_http_status" do
     # The error query is an alias for `server_error?`:
     #
     # - https://github.com/rails/rails/blob/ca200378/actionpack/lib/action_dispatch/testing/test_response.rb#L27
-    # - https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb
+    # - https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/testing/test_response.rb
     #
     # `server_error?` is part of the Rack Helpers and is defined as:
     #
@@ -278,7 +278,7 @@ RSpec.describe "have_http_status" do
     # The success query is an alias for `successful?`:
     #
     # - https://github.com/rails/rails/blob/ca200378/actionpack/lib/action_dispatch/testing/test_response.rb#L18
-    # - https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb
+    # - https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/testing/test_response.rb
     #
     # `successful?` is part of the Rack Helpers and is defined as:
     #
@@ -336,7 +336,7 @@ RSpec.describe "have_http_status" do
     # The missing query is an alias for `not_found?`:
     #
     # - https://github.com/rails/rails/blob/ca200378/actionpack/lib/action_dispatch/testing/test_response.rb#L21
-    # - https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb
+    # - https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/testing/test_response.rb
     #
     # `not_found?` is part of the Rack Helpers and is defined as:
     #
@@ -395,7 +395,7 @@ RSpec.describe "have_http_status" do
     # The redirect query is an alias for `redirection?`:
     #
     # - https://github.com/rails/rails/blob/ca200378/actionpack/lib/action_dispatch/testing/test_response.rb#L24
-    # - https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/test_response.rb
+    # - https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/testing/test_response.rb
     #
     # `redirection?` is part of the Rack Helpers and is defined as:
     #


### PR DESCRIPTION
I'm not aware of the magic how `bundle install` worked when we pointed to `rails`' `master` branch: `git fetch origin master` in Rails source fails.