### PR TITLE
Add compatibility for have_enqueued_mail (rails 7)

### DIFF
--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -28,11 +28,15 @@ module RSpec
       end
 
       def has_action_mailer_parameterized?
-        has_action_mailer? && defined?(::ActionMailer::Parameterized)
+        has_action_mailer? && defined?(::ActionMailer::Parameterized::DeliveryJob)
       end
 
       def has_action_mailer_unified_delivery?
         has_action_mailer? && defined?(::ActionMailer::MailDeliveryJob)
+      end
+
+      def has_action_mailer_legacy_delivery_job?
+        defined?(ActionMailer::DeliveryJob)
       end
 
       def has_action_mailbox?

--- a/lib/rspec/rails/matchers/have_enqueued_mail.rb
+++ b/lib/rspec/rails/matchers/have_enqueued_mail.rb
@@ -131,7 +131,7 @@ module RSpec
         end
 
         def legacy_mail?(job)
-          job[:job] <= ActionMailer::DeliveryJob
+          RSpec::Rails::FeatureCheck.has_action_mailer_legacy_delivery_job? && job[:job] <= ActionMailer::DeliveryJob
         end
 
         def parameterized_mail?(job)

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -22,7 +22,12 @@ if RSpec::Rails::FeatureCheck.has_active_job?
       def email_with_args(arg1, arg2); end
     end
 
-    class DeliveryJobSubClass < ActionMailer::DeliveryJob
+    if RSpec::Rails::FeatureCheck.has_action_mailer_legacy_delivery_job?
+      class DeliveryJobSubClass < ActionMailer::DeliveryJob
+      end
+    else
+      class DeliveryJobSubClass < ActionMailer::MailDeliveryJob
+      end
     end
 
     class UnifiedMailerWithDeliveryJobSubClass < ActionMailer::Base


### PR DESCRIPTION
1. ActionMailer::DeliveryJob does not exist anymore
2. ActionMailer::Parameterized::DeliveryJob

According to my research they have both been superseeded by ActionMailer::MailDeliveryJob

Closes #2531