### PR TITLE
Fill in a comment line that are missing from the template

### DIFF
--- a/lib/generators/rspec/scaffold/templates/request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/request_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
     include Engine.routes.url_helpers
   <% end -%>
 
+  # This should return the minimal set of attributes required to create a valid
   # <%= class_name %>. As you add validations to <%= class_name %>, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) {


### PR DESCRIPTION
I filled in the missing line to make it the same as the other templates.

[original](https://github.com/rspec/rspec-rails/blob/1fe6c2e8a56f46ae4c2f13ffa0733cce3b717c2d/lib/generators/rspec/scaffold/templates/controller_spec.rb?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L29)

