### PR TITLE
Changed message in have_broadcasted_to test

### DIFF
--- a/features/matchers/have_broadcasted_matcher.feature
+++ b/features/matchers/have_broadcasted_matcher.feature
@@ -105,7 +105,7 @@ Feature: have_broadcasted matcher
       require "rails_helper"
 
       RSpec.describe ChatChannel, type: :channel do
-        it "successfully subscribes" do
+        it "matches with stream name" do
           user = User.new(42)
 
           expect {


### PR DESCRIPTION
Previously it was "successfully subscribes" which has very little to do with this particular test. Probably it's an artifact from copying the more general action cable tests somewhere. I found this because it shows up on documentation when googling the have_broascasted_for matcher. The message I chose is consistent with the others in this file: all existing similar tests have this message.