### PR TITLE
Fix have_enqueued_mail for Rails 7 and argument matching

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,9 @@ Bug Fixes:
 
 * Properly name params in controller and request spec templates when
   using the `--model-name` parameter. (@kenzo-tanaka, #2534)
+* Fix parameter matching with mail delivery job and
+  ActionMailer::MailDeliveryJob. (Fabio Napoleoni, #2516, #2546)
+* Fix Rails 7 `have_enqueued_mail` compatibility (Mikael Henriksson, #2537, #2546)
 
 ### 5.0.2 / 2021-08-14
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v5.0.1...v5.0.2)

--- a/features/matchers/have_enqueued_mail_matcher.feature
+++ b/features/matchers/have_enqueued_mail_matcher.feature
@@ -62,14 +62,64 @@ Feature: have_enqueued_mail matcher
           expect {
             MyMailer.signup('user').deliver_later
           }.to have_enqueued_mail(MyMailer, :signup).with('user')
+        end
+      end
+      """
+    When I run `rspec spec/mailers/my_mailer_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Parameterize the mailer
+    Given a file named "app/mailers/my_mailer.rb" with:
+      """ruby
+      class MyMailer < ApplicationMailer
+
+        def signup(user = nil)
+          @user = user
+
+          mail to: "to@example.org"
+        end
+      end
+      """
+    Given a file named "spec/mailers/my_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe MyMailer do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
           # Works with named parameters
           expect {
-            MyMailer.with('foo' => 'bar').signup.deliver_later
-          }.to have_enqueued_mail(MyMailer, :signup).with('foo' => 'bar')
+            MyMailer.with(foo: 'bar').signup.deliver_later
+          }.to have_enqueued_mail(MyMailer, :signup).with(foo: 'bar')
+        end
+      end
+      """
+    When I run `rspec spec/mailers/my_mailer_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Parameterize and pass an argument to the mailer
+    Given a file named "app/mailers/my_mailer.rb" with:
+      """ruby
+      class MyMailer < ApplicationMailer
+
+        def signup(user = nil)
+          @user = user
+
+          mail to: "to@example.org"
+        end
+      end
+      """
+    Given a file named "spec/mailers/my_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe MyMailer do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
           # Works also with both, named parameters match first argument
           expect {
             MyMailer.with('foo' => 'bar').signup('user').deliver_later
-          }.to have_enqueued_mail(MyMailer, :signup).with({'foo' => 'bar'}, 'user')
+          }.to have_enqueued_mail(MyMailer, :signup).with({foo: 'bar'}, 'user')
         end
       end
       """

--- a/features/matchers/have_enqueued_mail_matcher.feature
+++ b/features/matchers/have_enqueued_mail_matcher.feature
@@ -38,3 +38,40 @@ Feature: have_enqueued_mail matcher
       """
     When I run `rspec spec/mailers/user_mailer_spec.rb`
     Then the examples should all pass
+
+  Scenario: Checking mailer arguments
+    Given a file named "app/mailers/my_mailer.rb" with:
+      """ruby
+      class MyMailer < ApplicationMailer
+
+        def signup(user = nil)
+          @user = user
+
+          mail to: "to@example.org"
+        end
+      end
+      """
+    Given a file named "spec/mailers/my_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe MyMailer do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
+          # Works with plain args
+          expect {
+            MyMailer.signup('user').deliver_later
+          }.to have_enqueued_mail(MyMailer, :signup).with('user')
+          # Works with named parameters
+          expect {
+            MyMailer.with('foo' => 'bar').signup.deliver_later
+          }.to have_enqueued_mail(MyMailer, :signup).with('foo' => 'bar')
+          # Works also with both, named parameters match first argument
+          expect {
+            MyMailer.with('foo' => 'bar').signup('user').deliver_later
+          }.to have_enqueued_mail(MyMailer, :signup).with({'foo' => 'bar'}, 'user')
+        end
+      end
+      """
+    When I run `rspec spec/mailers/my_mailer_spec.rb`
+    Then the examples should all pass

--- a/features/matchers/have_enqueued_mail_matcher.feature
+++ b/features/matchers/have_enqueued_mail_matcher.feature
@@ -73,8 +73,8 @@ Feature: have_enqueued_mail matcher
       """ruby
       class MyMailer < ApplicationMailer
 
-        def signup(user = nil)
-          @user = user
+        def signup
+          @foo = params[:foo]
 
           mail to: "to@example.org"
         end
@@ -102,8 +102,9 @@ Feature: have_enqueued_mail matcher
       """ruby
       class MyMailer < ApplicationMailer
 
-        def signup(user = nil)
+        def signup(user)
           @user = user
+          @foo = params[:foo]
 
           mail to: "to@example.org"
         end
@@ -118,7 +119,7 @@ Feature: have_enqueued_mail matcher
           ActiveJob::Base.queue_adapter = :test
           # Works also with both, named parameters match first argument
           expect {
-            MyMailer.with('foo' => 'bar').signup('user').deliver_later
+            MyMailer.with(foo: 'bar').signup('user').deliver_later
           }.to have_enqueued_mail(MyMailer, :signup).with({foo: 'bar'}, 'user')
         end
       end

--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -28,11 +28,15 @@ module RSpec
       end
 
       def has_action_mailer_parameterized?
-        has_action_mailer? && defined?(::ActionMailer::Parameterized)
+        has_action_mailer? && defined?(::ActionMailer::Parameterized::DeliveryJob)
       end
 
       def has_action_mailer_unified_delivery?
         has_action_mailer? && defined?(::ActionMailer::MailDeliveryJob)
+      end
+
+      def has_action_mailer_legacy_delivery_job?
+        defined?(ActionMailer::DeliveryJob)
       end
 
       def has_action_mailbox?

--- a/lib/rspec/rails/matchers/have_enqueued_mail.rb
+++ b/lib/rspec/rails/matchers/have_enqueued_mail.rb
@@ -89,14 +89,14 @@ module RSpec
         end
 
         def process_arguments(job, given_mail_args)
-          if job[:job] == ActionMailer::MailDeliveryJob
-            if given_mail_args.first.is_a?(Hash) && job[:args][3]['params'].present?
-              [hash_including(params: given_mail_args[0], args: given_mail_args.drop(1))]
-            else
-              [hash_including(args: given_mail_args)]
-            end
+          # Old matcher behavior working with all builtin classes but ActionMailer::MailDeliveryJob
+          return given_mail_args unless defined?(ActionMailer::MailDeliveryJob) && job[:job] <= ActionMailer::MailDeliveryJob
+
+          # If matching args starts with a hash and job instance has params match with them
+          if given_mail_args.first.is_a?(Hash) && job[:args][3]['params'].present?
+            [hash_including(params: given_mail_args[0], args: given_mail_args.drop(1))]
           else
-            given_mail_args
+            [hash_including(args: given_mail_args)]
           end
         end
 

--- a/lib/rspec/rails/matchers/have_enqueued_mail.rb
+++ b/lib/rspec/rails/matchers/have_enqueued_mail.rb
@@ -7,6 +7,7 @@ require "rspec/rails/matchers/active_job"
 module RSpec
   module Rails
     module Matchers
+      # rubocop: disable Metrics/ClassLength
       # Matcher class for `have_enqueued_mail`. Should not be instantiated directly.
       #
       # @private
@@ -153,6 +154,8 @@ module RSpec
           RSpec::Rails::FeatureCheck.has_action_mailer_unified_delivery? && job[:job] <= ActionMailer::MailDeliveryJob
         end
       end
+      # rubocop: enable Metrics/ClassLength
+
       # @api public
       # Passes if an email has been enqueued inside block.
       # May chain with to specify expected arguments.

--- a/lib/rspec/rails/matchers/have_enqueued_mail.rb
+++ b/lib/rspec/rails/matchers/have_enqueued_mail.rb
@@ -143,7 +143,7 @@ module RSpec
         end
 
         def legacy_mail?(job)
-          job[:job] <= ActionMailer::DeliveryJob
+          RSpec::Rails::FeatureCheck.has_action_mailer_legacy_delivery_job? && job[:job] <= ActionMailer::DeliveryJob
         end
 
         def parameterized_mail?(job)

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -72,6 +72,7 @@ module RSpec::Rails
 
     describe '#after' do
       it 'sets the :extra_failure_lines metadata to an array of STDOUT lines' do
+        allow(Capybara::Session).to receive(:instance_created?).and_return(true)
         group = RSpec::Core::ExampleGroup.describe do
           include SystemExampleGroup
 

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -393,18 +393,22 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         }.to have_enqueued_mail(UnifiedMailer, :test_email).and have_enqueued_mail(UnifiedMailer, :email_with_args)
       end
 
-      it "passes with provided argument matchers" do
+      it "matches arguments when mailer has only args" do
+        expect {
+          UnifiedMailer.email_with_args(1, 2).deliver_later
+        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(1, 2)
+      end
+
+      it "matches arguments when mailer is parameterized" do
         expect {
           UnifiedMailer.with('foo' => 'bar').test_email.deliver_later
-        }.to have_enqueued_mail(UnifiedMailer, :test_email).with(
-          a_hash_including(params: {'foo' => 'bar'})
-        )
+        }.to have_enqueued_mail(UnifiedMailer, :test_email).with('foo' => 'bar')
+      end
 
+      it "matches arguments when mixing parameterized and non-parameterized emails" do
         expect {
           UnifiedMailer.with('foo' => 'bar').email_with_args(1, 2).deliver_later
-        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(
-          a_hash_including(params: {'foo' => 'bar'}, args: [1, 2])
-        )
+        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with({'foo' => 'bar'}, 1, 2)
       end
 
       it "passes when using a mailer with `delivery_job` set to a sub class of `ActionMailer::DeliveryJob`" do

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -22,7 +22,12 @@ if RSpec::Rails::FeatureCheck.has_active_job?
       def email_with_args(arg1, arg2); end
     end
 
-    class DeliveryJobSubClass < ActionMailer::DeliveryJob
+    if RSpec::Rails::FeatureCheck.has_action_mailer_legacy_delivery_job?
+      class DeliveryJobSubClass < ActionMailer::DeliveryJob
+      end
+    else
+      class DeliveryJobSubClass < ActionMailer::MailDeliveryJob
+      end
     end
 
     class UnifiedMailerWithDeliveryJobSubClass < ActionMailer::Base


### PR DESCRIPTION
This is a combo of #2516 and #2537, supposed to fix #2351 and #2531 with a slight fix for argument matching and a small fix for our system spec spec on Rails 7.