### PR TITLE
Stop using the deceiving continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,25 +18,20 @@ jobs:
        include:
          # Edge Rails (7.1) builds >= 2.7
          - ruby: '3.0'
-           allow_failure: true
            env:
              RAILS_VERSION: 'main'
          - ruby: 2.7
-           allow_failure: true
            env:
              RAILS_VERSION: 'main'
 
          # Rails 7.0 builds >= 2.7
          - ruby: 3.1
-           allow_failure: true
            env:
              RAILS_VERSION: '~> 7.0.0'
          - ruby: '3.0'
-           allow_failure: true
            env:
              RAILS_VERSION: '~> 7.0.0'
          - ruby: 2.7
-           allow_failure: true
            env:
              RAILS_VERSION: '~> 7.0.0'
 
@@ -113,4 +108,4 @@ jobs:
       - run: script/clone_all_rspec_repos
       - run: bundle install --binstubs
       - run: script/run_build
-        continue-on-error: ${{ matrix.allow_failure || false }}
+        continue-on-error: false


### PR DESCRIPTION
Build jobs appear as green even though they actually fail, e.g. https://github.com/rspec/rspec-rails/pull/2537#issuecomment-977641695

A better approach is to mark jobs as "required" in branch protection.
![image](https://user-images.githubusercontent.com/6916/147753888-38e75682-b537-4eb2-8aec-b93d00a17dda.png)

This way, failed jobs are red, but this doesn't prevent the PR from being merged upon at maintainers' discretion.
![image](https://user-images.githubusercontent.com/6916/147754025-63b4e4c9-ac3e-4c37-b0d1-571c012056e9.png)

@JonRowe Can you please set up branch protection so it has 6.1 jobs and below as "Required"?