### PR TITLE
Get RubyGems/Bundler update CI step back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+      - run: script/update_rubygems_and_install_bundler
       - run: script/clone_all_rspec_repos
       - run: bundle install --binstubs
       - run: script/run_build


### PR DESCRIPTION
https://github.com/rubygems/bundler/pull/6728

Example failure (https://github.com/rspec/rspec-rails/pull/2548):
```
Failure/Error: expect(`bundle exec #{script} 2>&1`).to be_empty
       expected `"Your RubyGems version (2.7.6.3)) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`\n".empty?` to be truthy, got false
```