### PR TITLE
Fix Ruby 3.1 on CI

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -25,4 +25,15 @@ else
   gem "puma"
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
   gem 'selenium-webdriver', require: false
+
+  # This is required for Ruby 3.1 and Rails 6.1.x as of time
+  # of writing, because in Ruby 3.1 these gems are no longer
+  # automatically included.  This issue was fixed on the Rails
+  # side in Rails 7.0.1, but is not yet fixed in the Rails 6.1.x
+  # branch.  Discussion can be found here - https://github.com/mikel/mail/pull/1439
+  if RUBY_VERSION >= '3.1' && version.split(' ').last < '7.0'
+    gem 'net-smtp', require: false
+    gem 'net-imap', require: false
+    gem 'net-pop', require: false
+  end
 end


### PR DESCRIPTION
Originally by @petergoldstein from #2552

`net-*` gems were demoted, and while Rails 7.0.1 explicitly requires them, earlier versions don't.

Purposed to fix other RSpec repos' `rspec-rails` sub-build on Ruby 3.1, see e.g. https://github.com/rspec/rspec-support/pull/527/files#diff-bde1ccb98959c0287bdc7bc203ab3a0dab55c1841be3d7a9678cd42a50670141R108