### PR TITLE
Fix Ruby 3.1 on CI for dependent builds (this time for real)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
              RAILS_VERSION: '~> 7.0.0'
 
          # Rails 6.1 builds >= 2.5
+         - ruby: 3.1
+           env:
+             RAILS_VERSION: '~> 6.1.0'
          - ruby: '3.0'
            env:
              RAILS_VERSION: '~> 6.1.0'
@@ -60,6 +63,9 @@ jobs:
              JAVA_OPTS: '--add-opens java.base/sun.nio.ch=org.jruby.dist --add-opens java.base/java.io=org.jruby.dist --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.security.cert=ALL-UNNAMED --add-opens=java.base/java.util.zip=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/javax.crypto=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED'
 
          # Rails 6.0 builds >= 2.5.0
+         - ruby: 3.1
+           env:
+             RAILS_VERSION: '~> 6.0.0'
          - ruby: '3.0'
            env:
              RAILS_VERSION: '~> 6.0.0'

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -25,15 +25,15 @@ else
   gem "puma"
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
   gem 'selenium-webdriver', require: false
+end
 
-  # This is required for Ruby 3.1 and Rails 6.1.x as of time
-  # of writing, because in Ruby 3.1 these gems are no longer
-  # automatically included.  This issue was fixed on the Rails
-  # side in Rails 7.0.1, but is not yet fixed in the Rails 6.1.x
-  # branch.  Discussion can be found here - https://github.com/mikel/mail/pull/1439
-  if RUBY_VERSION >= '3.1' && version.split(' ').last < '7.0'
-    gem 'net-smtp', require: false
-    gem 'net-imap', require: false
-    gem 'net-pop', require: false
-  end
+# This is required for Ruby 3.1 and Rails prior to 7.0.1 as of time
+# of writing, because in Ruby 3.1 these gems are no longer
+# automatically included.  This issue was fixed on the Rails
+# side in Rails 7.0.1, but is not yet fixed in the Rails 6.1.x
+# branch.  Discussion can be found here - https://github.com/mikel/mail/pull/1439
+if RUBY_VERSION >= '3.1'
+  gem 'net-smtp', require: false
+  gem 'net-imap', require: false
+  gem 'net-pop', require: false
 end


### PR DESCRIPTION
Follow-up to #2553 I've quite missed the fact that dependent builds specify no `RAILS_VERSION`, and another `case` branch was used, causing `net-` dependency failures.

Also, add Ruby 3.1/Rails 6.x to CI matrix, since Rails 6.0 is what our dependent builds use.