### PR TITLE
Abort with argument

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -28,8 +28,7 @@ require 'rspec/rails'
 begin
   ActiveRecord::Migration.maintain_test_schema!
 rescue ActiveRecord::PendingMigrationError => e
-  puts e.to_s.strip
-  exit 1
+  abort e.to_s.strip
 end
 <% end -%>
 RSpec.configure do |config|


### PR DESCRIPTION
It condenses two lines into one being that `abort` exits with 1.