### PR TITLE
Isolate changes for Ruby 3.1 w/out Rails 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
              RAILS_VERSION: '~> 7.0.0'
 
          # Rails 6.1 builds >= 2.5
+         - ruby: '3.1'
+           env:
+             RAILS_VERSION: '~> 6.1.0'
          - ruby: '3.0'
            env:
              RAILS_VERSION: '~> 6.1.0'

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,9 @@ Bug Fixes:
 
 * Properly name params in controller and request spec templates when
   using the `--model-name` parameter. (@kenzo-tanaka, #2534)
+* Fix parameter matching with mail delivery job and
+  ActionMailer::MailDeliveryJob. (Fabio Napoleoni, #2516, #2546)
+
 
 ### 5.0.2 / 2021-08-14
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v5.0.1...v5.0.2)

--- a/example_app_generator/spec/verify_mailer_preview_path_spec.rb
+++ b/example_app_generator/spec/verify_mailer_preview_path_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe 'Action Mailer railtie hook' do
     out =  io.readlines
               .reject { |line| line =~ /warning: circular argument reference/ }
               .reject { |line| line =~ /Gem::Specification#rubyforge_project=/ }
+              .reject { |line| line =~ /DEPRECATION WARNING/ }
+              .reject { |line| line =~ /warning: previous/ }
+              .reject { |line| line =~ /warning: already/ }
               .join
               .chomp
     CaptureExec.new(out, $?.exitstatus)

--- a/features/matchers/have_enqueued_mail_matcher.feature
+++ b/features/matchers/have_enqueued_mail_matcher.feature
@@ -38,3 +38,91 @@ Feature: have_enqueued_mail matcher
       """
     When I run `rspec spec/mailers/user_mailer_spec.rb`
     Then the examples should all pass
+
+  Scenario: Checking mailer arguments
+    Given a file named "app/mailers/my_mailer.rb" with:
+      """ruby
+      class MyMailer < ApplicationMailer
+
+        def signup(user = nil)
+          @user = user
+
+          mail to: "to@example.org"
+        end
+      end
+      """
+    Given a file named "spec/mailers/my_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe MyMailer do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
+          # Works with plain args
+          expect {
+            MyMailer.signup('user').deliver_later
+          }.to have_enqueued_mail(MyMailer, :signup).with('user')
+        end
+      end
+      """
+    When I run `rspec spec/mailers/my_mailer_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Parameterize the mailer
+    Given a file named "app/mailers/my_mailer.rb" with:
+      """ruby
+      class MyMailer < ApplicationMailer
+
+        def signup
+          @foo = params[:foo]
+
+          mail to: "to@example.org"
+        end
+      end
+      """
+    Given a file named "spec/mailers/my_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe MyMailer do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
+          # Works with named parameters
+          expect {
+            MyMailer.with(foo: 'bar').signup.deliver_later
+          }.to have_enqueued_mail(MyMailer, :signup).with(foo: 'bar')
+        end
+      end
+      """
+    When I run `rspec spec/mailers/my_mailer_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Parameterize and pass an argument to the mailer
+    Given a file named "app/mailers/my_mailer.rb" with:
+      """ruby
+      class MyMailer < ApplicationMailer
+
+        def signup(user)
+          @user = user
+          @foo = params[:foo]
+
+          mail to: "to@example.org"
+        end
+      end
+      """
+    Given a file named "spec/mailers/my_mailer_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe MyMailer do
+        it "matches with enqueued mailer" do
+          ActiveJob::Base.queue_adapter = :test
+          # Works also with both, named parameters match first argument
+          expect {
+            MyMailer.with(foo: 'bar').signup('user').deliver_later
+          }.to have_enqueued_mail(MyMailer, :signup).with({foo: 'bar'}, 'user')
+        end
+      end
+      """
+    When I run `rspec spec/mailers/my_mailer_spec.rb`
+    Then the examples should all pass

--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -28,11 +28,15 @@ module RSpec
       end
 
       def has_action_mailer_parameterized?
-        has_action_mailer? && defined?(::ActionMailer::Parameterized)
+        has_action_mailer? && defined?(::ActionMailer::Parameterized::DeliveryJob)
       end
 
       def has_action_mailer_unified_delivery?
         has_action_mailer? && defined?(::ActionMailer::MailDeliveryJob)
+      end
+
+      def has_action_mailer_legacy_delivery_job?
+        defined?(ActionMailer::DeliveryJob)
       end
 
       def has_action_mailbox?

--- a/lib/rspec/rails/matchers/have_enqueued_mail.rb
+++ b/lib/rspec/rails/matchers/have_enqueued_mail.rb
@@ -7,6 +7,7 @@ require "rspec/rails/matchers/active_job"
 module RSpec
   module Rails
     module Matchers
+      # rubocop: disable Metrics/ClassLength
       # Matcher class for `have_enqueued_mail`. Should not be instantiated directly.
       #
       # @private
@@ -76,7 +77,7 @@ module RSpec
         def arguments_match?(job)
           @args =
             if @mail_args.any?
-              base_mailer_args + @mail_args
+              base_mailer_args + process_arguments(job, @mail_args)
             elsif @mailer_class && @method_name
               base_mailer_args + [any_args]
             elsif @mailer_class
@@ -88,12 +89,45 @@ module RSpec
           super(job)
         end
 
+        def process_arguments(job, given_mail_args)
+          # Old matcher behavior working with all builtin classes but ActionMailer::MailDeliveryJob
+          return given_mail_args if use_given_mail_args?(job)
+
+          # If matching args starts with a hash and job instance has params match with them
+          if given_mail_args.first.is_a?(Hash) && job[:args][3]['params'].present?
+            [hash_including(params: given_mail_args[0], args: given_mail_args.drop(1))]
+          else
+            [hash_including(args: given_mail_args)]
+          end
+        end
+
+        def use_given_mail_args?(job)
+          return true if defined?(ActionMailer::Parameterized::DeliveryJob) && job[:job] <= ActionMailer::Parameterized::DeliveryJob
+          return false if rails_6_1_and_ruby_3_1?
+
+          !(defined?(ActionMailer::MailDeliveryJob) && job[:job] <= ActionMailer::MailDeliveryJob)
+        end
+
+        def rails_6_1_and_ruby_3_1?
+          return false unless RUBY_VERSION >= "3.1"
+          return false unless ::Rails::VERSION::STRING >= '6.1'
+
+          ::Rails::VERSION::STRING < '7'
+        end
+
         def base_mailer_args
           [mailer_class_name, @method_name.to_s, MAILER_JOB_METHOD]
         end
 
         def yield_mail_args(block)
-          proc { |*job_args| block.call(*(job_args - base_mailer_args)) }
+          proc do |*job_args|
+            mailer_args = job_args - base_mailer_args
+            if mailer_args.first.is_a?(Hash)
+              block.call(*mailer_args.first[:args])
+            else
+              block.call(*mailer_args)
+            end
+          end
         end
 
         def check_active_job_adapter
@@ -120,18 +154,25 @@ module RSpec
 
         def mail_job_message(job)
           mailer_method = job[:args][0..1].join('.')
-
-          mailer_args = job[:args][3..-1]
+          mailer_args = deserialize_arguments(job)[3..-1]
+          mailer_args = mailer_args.first[:args] if unified_mail?(job)
           msg_parts = []
-          msg_parts << "with #{mailer_args}" if mailer_args.any?
+          display_args = display_mailer_args(mailer_args)
+          msg_parts << "with #{display_args}" if display_args.any?
           msg_parts << "on queue #{job[:queue]}" if job[:queue] && job[:queue] != 'mailers'
           msg_parts << "at #{Time.at(job[:at])}" if job[:at]
 
           "#{mailer_method} #{msg_parts.join(', ')}".strip
         end
 
+        def display_mailer_args(mailer_args)
+          return mailer_args unless mailer_args.first.is_a?(Hash) && mailer_args.first.key?(:args)
+
+          mailer_args.first[:args]
+        end
+
         def legacy_mail?(job)
-          job[:job] <= ActionMailer::DeliveryJob
+          RSpec::Rails::FeatureCheck.has_action_mailer_legacy_delivery_job? && job[:job] <= ActionMailer::DeliveryJob
         end
 
         def parameterized_mail?(job)
@@ -142,6 +183,8 @@ module RSpec
           RSpec::Rails::FeatureCheck.has_action_mailer_unified_delivery? && job[:job] <= ActionMailer::MailDeliveryJob
         end
       end
+      # rubocop: enable Metrics/ClassLength
+
       # @api public
       # Passes if an email has been enqueued inside block.
       # May chain with to specify expected arguments.

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -22,7 +22,12 @@ if RSpec::Rails::FeatureCheck.has_active_job?
       def email_with_args(arg1, arg2); end
     end
 
-    class DeliveryJobSubClass < ActionMailer::DeliveryJob
+    if RSpec::Rails::FeatureCheck.has_action_mailer_legacy_delivery_job?
+      class DeliveryJobSubClass < ActionMailer::DeliveryJob
+      end
+    else
+      class DeliveryJobSubClass < ActionMailer::MailDeliveryJob
+      end
     end
 
     class UnifiedMailerWithDeliveryJobSubClass < ActionMailer::Base
@@ -393,18 +398,22 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         }.to have_enqueued_mail(UnifiedMailer, :test_email).and have_enqueued_mail(UnifiedMailer, :email_with_args)
       end
 
-      it "passes with provided argument matchers" do
+      it "matches arguments when mailer has only args" do
+        expect {
+          UnifiedMailer.email_with_args(1, 2).deliver_later
+        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(1, 2)
+      end
+
+      it "matches arguments when mailer is parameterized" do
         expect {
           UnifiedMailer.with('foo' => 'bar').test_email.deliver_later
-        }.to have_enqueued_mail(UnifiedMailer, :test_email).with(
-          a_hash_including(params: {'foo' => 'bar'})
-        )
+        }.to have_enqueued_mail(UnifiedMailer, :test_email).with('foo' => 'bar')
+      end
 
+      it "matches arguments when mixing parameterized and non-parameterized emails" do
         expect {
           UnifiedMailer.with('foo' => 'bar').email_with_args(1, 2).deliver_later
-        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(
-          a_hash_including(params: {'foo' => 'bar'}, args: [1, 2])
-        )
+        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with({'foo' => 'bar'}, 1, 2)
       end
 
       it "passes when using a mailer with `delivery_job` set to a sub class of `ActionMailer::DeliveryJob`" do


### PR DESCRIPTION
This is not a cherry-pick, but it should give you the code changes required for the 5.1 maintenance branch to support Ruby 3.1 / Rails 6.1.

It's going to be really difficult to pull apart the parameter parsing in `have_enqueued_mail.rb` and I would recommend we not even try.  Just put it all in the `5-1-maintenance` branch.