### PR TITLE
Setup 5-1-maintenance without Rails 7 but with Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,31 +29,10 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         # Edge Rails (7.1) builds >= 2.7
-         - ruby: '3.0'
-           allow_failure: true
-           env:
-             RAILS_VERSION: 'main'
-         - ruby: 2.7
-           allow_failure: true
-           env:
-             RAILS_VERSION: 'main'
-
-         # Rails 7.0 builds >= 2.7
-         - ruby: 3.1
-           allow_failure: true
-           env:
-             RAILS_VERSION: '~> 7.0.0'
-         - ruby: '3.0'
-           allow_failure: true
-           env:
-             RAILS_VERSION: '~> 7.0.0'
-         - ruby: 2.7
-           allow_failure: true
-           env:
-             RAILS_VERSION: '~> 7.0.0'
-
          # Rails 6.1 builds >= 2.5
+         - ruby: '3.1'
+           env:
+             RAILS_VERSION: '~> 6.1.0'
          - ruby: '3.0'
            env:
              RAILS_VERSION: '~> 6.1.0'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,3 +9,7 @@ Layout/LineLength:
 # Over time we'd like to get this down, but this is what we're at now.
 Metrics/MethodLength:
   Max: 43 # default: 10
+
+Metrics/ClassLength:
+  Exclude:
+    - lib/rspec/rails/matchers/have_enqueued_mail.rb

--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -39,6 +39,10 @@ module RSpec
         defined?(::ActionMailbox)
       end
 
+      def ruby_3_1?
+        RUBY_VERSION >= "3.1"
+      end
+
       def type_metatag(type)
         "type: :#{type}"
       end

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -393,18 +393,22 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         }.to have_enqueued_mail(UnifiedMailer, :test_email).and have_enqueued_mail(UnifiedMailer, :email_with_args)
       end
 
-      it "passes with provided argument matchers" do
+      it "matches arguments when mailer has only args" do
+        expect {
+          UnifiedMailer.email_with_args(1, 2).deliver_later
+        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(1, 2)
+      end
+
+      it "matches arguments when mailer is parameterized" do
         expect {
           UnifiedMailer.with('foo' => 'bar').test_email.deliver_later
-        }.to have_enqueued_mail(UnifiedMailer, :test_email).with(
-          a_hash_including(params: {'foo' => 'bar'})
-        )
+        }.to have_enqueued_mail(UnifiedMailer, :test_email).with('foo' => 'bar')
+      end
 
+      it "matches arguments when mixing parameterized and non-parameterized emails" do
         expect {
           UnifiedMailer.with('foo' => 'bar').email_with_args(1, 2).deliver_later
-        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(
-          a_hash_including(params: {'foo' => 'bar'}, args: [1, 2])
-        )
+        }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with({'foo' => 'bar'}, 1, 2)
       end
 
       it "passes when using a mailer with `delivery_job` set to a sub class of `ActionMailer::DeliveryJob`" do


### PR DESCRIPTION
Rails 7 will be supported in rspec-rails 6 via `main`, this just tracks Ruby 3.1 support into the upcoming 5.1.x release.