### PR TITLE
Fixup `have_enqueued_job` matcher on job retries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@ Bug Fixes:
   (Eugene Kenny, Iliana, #2631)
 * Support Rails 7.1's `#fixtures_paths` in example groups (removes a deprecation warning).
   (Nicholas Simmons, #2664)
+* Fix `have_enqueued_job` to properly detect enqueued jobs when other jobs were
+  performed inside the expectation block. (Slava Kardakov, Phil Pirozhkov, #2573)
 
 ### 6.0.1 / 2022-10-18
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v6.0.0...v6.0.1)

--- a/lib/rspec/rails/matchers/active_job.rb
+++ b/lib/rspec/rails/matchers/active_job.rb
@@ -230,11 +230,26 @@ module RSpec
           def matches?(proc)
             raise ArgumentError, "have_enqueued_job and enqueue_job only support block expectations" unless Proc === proc
 
-            original_enqueued_jobs_count = queue_adapter.enqueued_jobs.count
-            proc.call
-            in_block_jobs = queue_adapter.enqueued_jobs.drop(original_enqueued_jobs_count)
+            original_enqueued_jobs_hashes = queue_adapter.enqueued_jobs.map(&:hash)
 
-            check(in_block_jobs)
+            proc.call
+
+            in_block_jobs = queue_adapter.enqueued_jobs.each_with_object({}) do |job, jobs|
+              jobs[job.hash] ||= { job: job, count: 0 }
+              jobs[job.hash][:count] += 1
+            end
+
+            original_enqueued_jobs_hashes.each do |job_hash|
+              in_block_jobs[job_hash][:count] -= 1 if in_block_jobs.key?(job_hash)
+            end
+
+            in_block_jobs = in_block_jobs.each_value.flat_map do |job_and_count|
+              count, job = job_and_count.values_at(:count, :job)
+
+              Array.new(count, job) if count.positive?
+            end
+
+            check(in_block_jobs.compact)
           end
 
           def does_not_match?(proc)

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -98,6 +98,31 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
       expect { }.not_to have_enqueued_job
     end
 
+    context "when job is retried" do
+      include ActiveJob::TestHelper
+
+      let(:retried_job) do
+        Class.new(ActiveJob::Base) do
+          retry_on StandardError, wait: 5, queue: :retry
+
+          def self.name; "RetriedJob"; end
+          def perform; raise StandardError; end
+        end
+      end
+
+      before do
+        stub_const("RetriedJob", retried_job)
+        queue_adapter.perform_enqueued_jobs = true
+      end
+
+      it "passes with reenqueued job" do
+        time = Time.current.change(usec: 0)
+        travel_to time do
+          expect  { retried_job.perform_later }.to have_enqueued_job(retried_job).on_queue(:retry).at(time + 5)
+        end
+      end
+    end
+
     it "fails when job is not enqueued" do
       expect {
         expect { }.to have_enqueued_job

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -98,6 +98,20 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
       expect { }.not_to have_enqueued_job
     end
 
+    context "when previously enqueued jobs were performed" do
+      include ActiveJob::TestHelper
+
+      before { stub_const("HeavyLiftingJob", heavy_lifting_job) }
+
+      it "counts newly enqueued jobs" do
+        heavy_lifting_job.perform_later
+        expect {
+          perform_enqueued_jobs
+          hello_job.perform_later
+        }.to have_enqueued_job(hello_job)
+      end
+    end
+
     context "when job is retried" do
       include ActiveJob::TestHelper
 


### PR DESCRIPTION
Previously we were checking only job counts, so if one job was
performed and one job was added - matcher failed. Check by unique
id (`#hash`) instead.
We cannot use `job['job_id']` here, because job retains `job_id` on retry.

This works only with `rails >= 6.1`, because `retry_on` was introduced in 6.0 and apparently `test` queue adapter is broken for retries in 6.0: it adds executed job back with added `exception_executions` along with actual retried job. So dunno how to proceed here, please advise /shrug

Test CI run: https://github.com/ojab/rspec-rails/runs/5183906574?check_suite_focus=true 

Also:
fixes #2668