### PR TITLE
Bypass using the `pre`release versions of rspec 

### DIFF
--- a/lib/rspec/rails/version.rb
+++ b/lib/rspec/rails/version.rb
@@ -3,7 +3,7 @@ module RSpec
     # Version information for RSpec Rails.
     module Version
       # Current version of RSpec Rails, in semantic versioning format.
-      STRING = '5.1.0.pre'
+      STRING = '5.1.1'
     end
   end
 end


### PR DESCRIPTION
Here, @pirj shows us how to use the Rails 7 compatible branch:
- https://github.com/rspec/rspec-rails/pull/2546#issuecomment-1009302646

Then, I got confused about what to do with the other changes:
- https://github.com/rspec/rspec-rails/pull/2546#issuecomment-1017228243

So, to make it a bit easier to just "drop in" a the ActionMailer fixes,
this branch makes rspec-rails "feel like" a released version of itself,
so bundling off of it doesn't incidentally pull in the pre-release
version of rspec.

There's nothing wrong with the pre-release version of rspec, but I'm not
particularly confident making the recommended other changes to my
consuming applications codebase; so a quick fork until a real 5.1.1 or
6.0 release comes out seems "safest"