### PR TITLE
Prevent unrelated exceptions by requiring `rails_helper` at `.rspec`

### DIFF
--- a/lib/generators/rspec/install/install_generator.rb
+++ b/lib/generators/rspec/install/install_generator.rb
@@ -41,6 +41,9 @@ DESC
 
         replace_generator_command(spec_helper_path)
         remove_warnings_configuration(spec_helper_path)
+
+        dot_rspec_path = File.join(tmpdir, '.rspec')
+        prepend_require_rails_helper_option(dot_rspec_path)
       end
 
       def replace_generator_command(spec_helper_path)
@@ -57,6 +60,12 @@ DESC
                   /#{empty_line}(#{comment_line})+\s+config\.warnings = true\n/,
                   '',
                   verbose: false
+      end
+
+      def prepend_require_rails_helper_option(dot_rspec_path)
+        prepend_to_file dot_rspec_path,
+                        "--require rails_helper\n",
+                        verbose: false
       end
     end
   end

--- a/spec/generators/rspec/install/install_generator_spec.rb
+++ b/spec/generators/rspec/install/install_generator_spec.rb
@@ -47,11 +47,12 @@ RSpec.describe Rspec::Generators::InstallGenerator, type: :generator do
 
   let(:rails_helper) { content_for('spec/rails_helper.rb') }
   let(:spec_helper) { content_for('spec/spec_helper.rb') }
+  let(:dot_rspec) { content_for('.rspec') }
   let(:developmentrb) { content_for('config/environments/development.rb')  }
 
   it "generates .rspec" do
     run_generator
-    expect(file('.rspec')).to exist
+    expect(dot_rspec).to match(/\A--require rails_helper\n/)
   end
 
   it "generates spec/spec_helper.rb" do


### PR DESCRIPTION
When there is a bug in the code on the load,
RSpec catches the exception, aborts the spec file,
proceeds to the following spec file, and retries `require`
with partially loaded Rails application.

In some cases, we see many identical errors,
such as `NameError`, which are noisy but help developers
find the bug. In other cases, we see many unrelated errors,
typically `FrozenError` on finalized objects,
which push out the original exception raised only from the first spec.

The following comment describes this issue in detail.
https://github.com/thoughtbot/factory_bot_rails/issues/303#issuecomment-434560625

This patch prevents unrelated exceptions by the following rspec-core feature.
The reason why I edited the `.rspec` is that this feature is only applicable to
`--require` option.
https://github.com/rspec/rspec-core/pull/2568

This issue is a relatively well-known issue, and the well-known
workaround is to use `--fail-fast` when we see many errors.
https://stackoverflow.com/questions/47320772/rails-runtimeerror-cant-modify-frozen-array-when-running-rspec-in-rails

By introducing this patch, we no longer need the workaround.
All we need to do is run `bundle exec rspec` as usual.