### PR TITLE
Request spec rails7

### DIFF
--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -90,10 +90,17 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     end
 
     context "with invalid params" do
+    <% if Rails.version.to_f < 7.0 %>
       it "returns a success response (i.e. to display the 'new' template)" do
         post :create, params: {<%= singular_table_name %>: invalid_attributes}, session: valid_session
         expect(response).to be_successful
       end
+    <% else %>
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        post :create, params: {<%= singular_table_name %>: invalid_attributes}, session: valid_session
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    <% end %>
     end
   end
 
@@ -118,11 +125,19 @@ RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:control
     end
 
     context "with invalid params" do
+    <% if Rails.version.to_f < 7.0 %>
       it "returns a success response (i.e. to display the 'edit' template)" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         put :update, params: {id: <%= file_name %>.to_param, <%= singular_table_name %>: invalid_attributes}, session: valid_session
         expect(response).to be_successful
       end
+    <% else %>
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        <%= file_name %> = <%= class_name %>.create! valid_attributes
+        put :update, params: {id: <%= file_name %>.to_param, <%= singular_table_name %>: invalid_attributes}, session: valid_session
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    <% end %>
     end
   end
 

--- a/lib/generators/rspec/scaffold/templates/request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/request_spec.rb
@@ -83,10 +83,17 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
         }.to change(<%= class_name %>, :count).by(0)
       end
 
+    <% if Rails.version.to_f < 7.0 %>
       it "renders a successful response (i.e. to display the 'new' template)" do
         post <%= index_helper %>_url, params: { <%= singular_table_name %>: invalid_attributes }
         expect(response).to be_successful
       end
+    <% else %>
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        post <%= index_helper %>_url, params: { <%= singular_table_name %>: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    <% end %>
     end
   end
 
@@ -112,11 +119,19 @@ RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %
     end
 
     context "with invalid parameters" do
+    <% if Rails.version.to_f < 7.0 %>
       it "renders a successful response (i.e. to display the 'edit' template)" do
         <%= file_name %> = <%= class_name %>.create! valid_attributes
         patch <%= show_helper %>, params: { <%= singular_table_name %>: invalid_attributes }
         expect(response).to be_successful
       end
+    <% else %>
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        <%= file_name %> = <%= class_name %>.create! valid_attributes
+        patch <%= show_helper %>, params: { <%= singular_table_name %>: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    <% end %>
     end
   end
 


### PR DESCRIPTION
Fixes #2584

Fixed template of request spec and controller spec when #create and #update method with invalid params.
It only influence in rails ver over 7.0.0.