### PR TITLE
Include ActiveSupport::Testing::TaggedLogging for Rails >= 7 (rebased)

### DIFF
--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -181,5 +181,15 @@ module RSpec
     #
     # @private
     TestUnitAssertionAdapter = MinitestAssertionAdapter
+
+    # @private
+    module TaggedLoggingAdapter
+      require 'active_support/testing/tagged_logging'
+      include ActiveSupport::Testing::TaggedLogging
+
+      # Just a stub as TaggedLogging is calling `name`
+      def name
+      end
+    end
   end
 end

--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -12,11 +12,7 @@ module RSpec
       include RSpec::Rails::MinitestLifecycleAdapter
       include RSpec::Rails::MinitestAssertionAdapter
       include RSpec::Rails::FixtureSupport
-
-      if ::Rails::VERSION::MAJOR >= 7
-        require 'active_support/testing/tagged_logging'
-        include ActiveSupport::Testing::TaggedLogging
-      end
+      include RSpec::Rails::TaggedLoggingAdapter if ::Rails::VERSION::MAJOR >= 7
     end
   end
 end

--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -12,6 +12,11 @@ module RSpec
       include RSpec::Rails::MinitestLifecycleAdapter
       include RSpec::Rails::MinitestAssertionAdapter
       include RSpec::Rails::FixtureSupport
+
+      if ::Rails::VERSION::MAJOR >= 7
+        require 'active_support/testing/tagged_logging'
+        include ActiveSupport::Testing::TaggedLogging
+      end
     end
   end
 end

--- a/snippets/include_activesupport_testing_tagged_logger.rb
+++ b/snippets/include_activesupport_testing_tagged_logger.rb
@@ -1,0 +1,71 @@
+if __FILE__ =~ /^snippets/
+  fail "Snippets are supposed to be run from their own directory to avoid side " \
+       "effects as e.g. the root `Gemfile`, or `spec/spec_helpers.rb` to be " \
+       "loaded by the root `.rspec`."
+end
+
+# We opt-out from using RubyGems, but `bundler/inline` requires it
+require 'rubygems'
+
+require "bundler/inline"
+
+# We pass `false` to `gemfile` to skip the installation of gems,
+# because it may install versions that would conflict with versions
+# from the main `Gemfile.lock`.
+gemfile(false) do
+  source "https://rubygems.org"
+
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+  # Those Gemfiles carefully pick the right versions depending on
+  # settings in the ENV, `.rails-version` and `maintenance-branch`.
+  Dir.chdir('..') do
+    eval_gemfile 'Gemfile-sqlite-dependencies'
+    # This Gemfile expects `maintenance-branch` file to be present
+    # in the current directory.
+    eval_gemfile 'Gemfile-rspec-dependencies'
+    # This Gemfile expects `.rails-version` file
+    eval_gemfile 'Gemfile-rails-dependencies'
+  end
+
+  gem "rspec-rails", path: "../"
+end
+
+# Run specs at exit
+require "rspec/autorun"
+
+require "rails"
+require "active_record/railtie"
+require "active_job/railtie"
+require "rspec/rails"
+
+ActiveJob::Base.queue_adapter = :test
+
+# This connection will do for database-independent bug reports
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+
+class TestJob < ActiveJob::Base
+  def perform; end
+end
+
+class TestError < StandardError; end
+
+RSpec.describe 'Foo', type: :job do
+  include ::ActiveJob::TestHelper
+
+  describe 'error raised in perform_enqueued_jobs with block' do
+    it 'raises the explicitly thrown error' do
+      allow_any_instance_of(TestJob).to receive(:perform).and_raise(TestError)
+
+      # Rails 6.1+ wraps unexpected errors in tests
+      expected_error = if Rails::VERSION::STRING.to_f >= 6.1
+                         Minitest::UnexpectedError.new(TestError)
+                       else
+                         TestError
+                       end
+
+      expect { perform_enqueued_jobs { TestJob.perform_later } }
+        .to raise_error(expected_error)
+    end
+  end
+end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -1,0 +1,10 @@
+module RSpec::Rails
+  RSpec.describe RailsExampleGroup do
+    if ::Rails::VERSION::MAJOR >= 7
+      it 'includes ActiveSupport::Testing::TaggedLogging' do
+        expect(described_class.include?(::ActiveSupport::Testing::TaggedLogging)).to eq(true)
+        expect(described_class.private_instance_methods).to include(:tagged_logger)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is #2580 rebased