### PR TITLE
Increase Aruba exit_timeout value for TruffleRuby

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -36,7 +36,11 @@ end
 World(ArubaExt)
 
 Aruba.configure do |config|
-  config.exit_timeout = 30
+  if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'truffleruby'
+    config.exit_timeout = 120
+  else
+    config.exit_timeout = 30
+  end
 end
 
 unless File.directory?('./tmp/example_app')


### PR DESCRIPTION
To allow enough time for subprocesses to complete when using TruffleRuby.