### PR TITLE
run after_teardown in system specs after around (like in other specs)

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -108,9 +108,7 @@ module RSpec
           orig_stdout = $stdout
           $stdout = StringIO.new
           begin
-            if ::Rails::VERSION::STRING >= '6.0'
-              original_before_teardown.bind(self).call
-            end
+            original_before_teardown.bind(self).call
             original_after_teardown.bind(self).call
           ensure
             myio = $stdout

--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -109,13 +109,17 @@ module RSpec
           $stdout = StringIO.new
           begin
             original_before_teardown.bind(self).call
-            original_after_teardown.bind(self).call
           ensure
             myio = $stdout
             myio.rewind
             RSpec.current_example.metadata[:extra_failure_lines] = myio.readlines
             $stdout = orig_stdout
           end
+        end
+
+        around do |example|
+          example.run
+          original_after_teardown.bind(self).call
         end
       end
     end


### PR DESCRIPTION
This will only work as expected (print out screenshot location after failed tests)
in >= rails 6.0 but 5.2 is no longer supported in main.

This may possibly change behaviour, but can be included in major
revision?

This should enable easier integration of other libraries such as
capybara-screenshot which require predictable (and late) running of
Capybara.reset_sessions!

This is an illustration (or possible candidate to fix) #2595