### PR TITLE
Infer the spec type for generator specs

### DIFF
--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -28,6 +28,7 @@ module RSpec
     DIRECTORY_MAPPINGS = {
       channel:    %w[spec channels],
       controller: %w[spec controllers],
+      generator:  %w[spec generator],
       helper:     %w[spec helpers],
       job:        %w[spec jobs],
       mailer:     %w[spec mailers],


### PR DESCRIPTION
Generator specs are [generated to spec/generator](https://github.com/rspec/rspec-rails/blob/6f8e3ab154a1562919ff1c08b8d19ae5ff6152e9/lib/generators/rspec/generator/generator_generator.rb#L12)

Spec-type inferrence (based on file location) is not presently active for generator specs.

This adds `:generator ` spec type to the mapping for inference by file location.