### PR TITLE
Remove instance variables in generated specs

### DIFF
--- a/lib/generators/rspec/scaffold/templates/edit_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/edit_spec.rb
@@ -2,18 +2,22 @@ require 'rails_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
 RSpec.describe "<%= ns_table_name %>/edit", <%= type_metatag(:view) %> do
-  before(:each) do
-    @<%= ns_file_name %> = assign(:<%= ns_file_name %>, <%= class_name %>.create!(<%= '))' if output_attributes.empty? %>
+  let(:<%= ns_file_name %>) {
+    <%= class_name %>.create!(<%= ')' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>
       <%= attribute.name %>: <%= attribute.default.inspect %><%= attribute_index == output_attributes.length - 1 ? '' : ','%>
 <% end -%>
-<%= output_attributes.empty? ? "" : "    ))\n" -%>
+<%= "    )\n" unless output_attributes.empty? -%>
+  }
+
+  before(:each) do
+    assign(:<%= ns_file_name %>, <%= ns_file_name %>)
   end
 
   it "renders the edit <%= ns_file_name %> form" do
     render
 
-    assert_select "form[action=?][method=?]", <%= ns_file_name %>_path(@<%= ns_file_name %>), "post" do
+    assert_select "form[action=?][method=?]", <%= ns_file_name %>_path(<%= ns_file_name %>), "post" do
 <% for attribute in output_attributes -%>
       <%- name = attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>
       assert_select "<%= attribute.input_type -%>[name=?]", "<%= ns_file_name %>[<%= name %>]"

--- a/lib/generators/rspec/scaffold/templates/show_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/show_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
 RSpec.describe "<%= ns_table_name %>/show", <%= type_metatag(:view) %> do
   before(:each) do
-    @<%= ns_file_name %> = assign(:<%= ns_file_name %>, <%= class_name %>.create!(<%= '))' if output_attributes.empty? %>
+    assign(:<%= ns_file_name %>, <%= class_name %>.create!(<%= '))' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>
       <%= attribute.name %>: <%= value_for(attribute) %><%= attribute_index == output_attributes.length - 1 ? '' : ','%>
 <% end -%>


### PR DESCRIPTION
## Problem

I noticed some generated scaffold specs contain explicit instance variable gets and sets. But rubocop-rspec gem, at least v2.10.0, prefers no instance variable usages in specs by default ([RSpec/InstanceVariable cop](https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecinstancevariable), introduced in 2014 <https://github.com/rubocop/rubocop-rspec/pull/3>).

In fact, I confirmed that some specs such as `spec/views/posts/edit.html.erb_spec.rb` generated by `bin/rails g scaffold post` are offended by rubocop.

## What I Changed

Therefore, I removed usage of instance variables from generated specs.

For historians, commits in 2010 (f06aa507280f8f9e6316c9bd5f72e640269a49b1 and 0d244a1fbd43427a83021c189f7bf6cc7d085457) introduce the use of instance variables, maybe without strong reasons.

### Changes to Specs

The following table is a summary of changes to generated `edit_spec.rb`. I generated these results on my local environment with Rails 7.0.2.4 and rspec-{core,expectations,mocks,support} 3.12.0.pre. Specs in "After" column do not contain `@post`.

<table>
<tr>
  <th>Context</th>
  <th>Before</th>
  <th>After</th>
</tr>
<tr>
  <td>Without attributes</td>
  <td>

```ruby
require 'rails_helper'

RSpec.describe "posts/edit", type: :view do
  before(:each) do
    @post = assign(:post, Post.create!())
  end

  it "renders the edit post form" do
    render

    assert_select "form[action=?][method=?]", post_path(@post), "post" do
    end
  end
end
```

  </td>
  <td>

```ruby
require 'rails_helper'

RSpec.describe "posts/edit", type: :view do
  let(:post) {
    Post.create!()
  }

  before(:each) do
    assign(:post, post)
  end

  it "renders the edit post form" do
    render

    assert_select "form[action=?][method=?]", post_path(post), "post" do
    end
  end
end
```

  </td>
</tr>
<tr>
  <td>With an attribute</td>
  <td>

```ruby
require 'rails_helper'

RSpec.describe "posts/edit", type: :view do
  before(:each) do
    @post = assign(:post, Post.create!(
      content: "MyText"
    ))
  end

  it "renders the edit post form" do
    render

    assert_select "form[action=?][method=?]", post_path(@post), "post" do

      assert_select "textarea[name=?]", "post[content]"
    end
  end
end
```

  </td>
  <td>

```ruby
require 'rails_helper'

RSpec.describe "posts/edit", type: :view do
  let(:post) {
    Post.create!(
      content: "MyText"
    )
  }

  before(:each) do
    assign(:post, post)
  end

  it "renders the edit post form" do
    render

    assert_select "form[action=?][method=?]", post_path(post), "post" do

      assert_select "textarea[name=?]", "post[content]"
    end
  end
end
```

  </td>
</tr>
<tr>
  <td>With two attributes</td>
  <td>

```ruby
require 'rails_helper'

RSpec.describe "posts/edit", type: :view do
  before(:each) do
    @post = assign(:post, Post.create!(
      content: "MyText",
      priority: 1
    ))
  end

  it "renders the edit post form" do
    render

    assert_select "form[action=?][method=?]", post_path(@post), "post" do

      assert_select "textarea[name=?]", "post[content]"

      assert_select "input[name=?]", "post[priority]"
    end
  end
end
```

  </td>
  <td>

```ruby
require 'rails_helper'

RSpec.describe "posts/edit", type: :view do
  let(:post) {
    Post.create!(
      content: "MyText",
      priority: 1
    )
  }

  before(:each) do
    assign(:post, post)
  end

  it "renders the edit post form" do
    render

    assert_select "form[action=?][method=?]", post_path(post), "post" do

      assert_select "textarea[name=?]", "post[content]"

      assert_select "input[name=?]", "post[priority]"
    end
  end
end
```

  </td>
</tr>
</table>
