### PR TITLE
Fix some typos

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ version: "{build}"
 
 # This will build all PRs targeting matching branches.
 # Without this, each PR builds twice -- once for the PR branch HEAD,
-# and once for the merge commit that github creates for each mergable PR.
+# and once for the merge commit that github creates for each mergeable PR.
 branches:
   only:
     - main

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 
 version: "{build}"
 
-# This will build all PRs targetting matching branches.
+# This will build all PRs targeting matching branches.
 # Without this, each PR builds twice -- once for the PR branch HEAD,
 # and once for the merge commit that github creates for each mergable PR.
 branches:

--- a/benchmarks/before_block_capture_block_vs_yield.rb
+++ b/benchmarks/before_block_capture_block_vs_yield.rb
@@ -71,7 +71,7 @@ and
 > Surprisingly, `flat_map(&block)` appears to be faster than
 > `flat_map { yield }` in spite of the fact that our array here
 > is smaller than the break-even point of 20-25 measured in the
-> `capture_block_vs_yield.rb` benchmark. In fact, the forwaded-block
+> `capture_block_vs_yield.rb` benchmark. In fact, the forwarded-block
 > version remains faster in my benchmarks here no matter how small
 > I shrink the `words` array. I'm not sure why!
 >

--- a/benchmarks/before_block_capture_block_vs_yield.rb
+++ b/benchmarks/before_block_capture_block_vs_yield.rb
@@ -54,7 +54,7 @@ The results are very interesting:
 > a high constant cost, taking about 5x longer than a single `yield`
 > (even if the block is never used!).
 >
-> However, fowarding a captured block can be faster than using `yield`
+> However, forwarding a captured block can be faster than using `yield`
 > if the block is used many times (the breakeven point is at about 20-25
 > invocations), so it appears that he per-invocation cost of `yield`
 > is higher than that of a captured-and-forwarded block.

--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -69,5 +69,5 @@ elsif defined?(::ActionMailer::Preview)
 end
 
 # This will force the loading of ActionMailer settings to ensure we do not
-# accicentally set something we should not
+# accidentally set something we should not
 ActionMailer::Base.smtp_settings

--- a/features/matchers/have_stream_from_matcher.feature
+++ b/features/matchers/have_stream_from_matcher.feature
@@ -4,7 +4,7 @@ Feature: have_stream_from matcher
   The `have_stream_from` matcher is used to check if a channel has been subscribed to a given stream specified as a String.
   If you use `stream_for` in you channel to subscribe to a model, use `have_stream_for` matcher instead.
 
-  The `have_no_streams` matcher is used to check if a channe hasn't been subscribed to any stream.
+  The `have_no_streams` matcher is used to check if a channel hasn't been subscribed to any stream.
 
   It is available only in channel specs.
 

--- a/lib/generators/rspec.rb
+++ b/lib/generators/rspec.rb
@@ -2,7 +2,7 @@ require 'rails/generators/named_base'
 require 'rspec/rails/feature_check'
 
 # @private
-# Weirdly named generators namespace (should be `RSpec`) for compatability with
+# Weirdly named generators namespace (should be `RSpec`) for compatibility with
 # rails loading.
 module Rspec
   # @private

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -48,7 +48,7 @@ RSpec.configure do |config|
   # Remove this line to enable support for ActiveRecord
   config.use_active_record = false
 
-  # If you enable ActiveRecord support you should unncomment these lines,
+  # If you enable ActiveRecord support you should uncomment these lines,
   # note if you'd prefer not to run each example within a transaction, you
   # should set use_transactional_fixtures to false.
   #

--- a/lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb
+++ b/lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb
@@ -159,7 +159,7 @@ module RSpec
           def check_channel_presence
             return if @channel.present? && @channel.respond_to?(:channel_name)
 
-            error_msg = "Broadcasting channel can't be infered. Please, specify it with `from_channel`"
+            error_msg = "Broadcasting channel can't be inferred. Please, specify it with `from_channel`"
             raise ArgumentError, error_msg
           end
         end

--- a/lib/rspec/rails/matchers/have_enqueued_mail.rb
+++ b/lib/rspec/rails/matchers/have_enqueued_mail.rb
@@ -134,7 +134,7 @@ module RSpec
         end
 
         # Ruby 3.1 changed how params were serialized on Rails 6.1
-        # so we override the active job implementation and customise it here.
+        # so we override the active job implementation and customize it here.
         def deserialize_arguments(job)
           args = super
 

--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -305,7 +305,7 @@ module RSpec
 
         private
 
-          # @return [String] formating the expected status and associated code(s)
+          # @return [String] formatting the expected status and associated code(s)
           def type_message
             @type_message ||= (expected == :error ? "an error" : "a #{expected}") +
               " status code (#{type_codes})"

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Configuration" do
     end
 
     describe "`#render_views=`" do
-      it "sets `render_views?` to the truthyness of the provided value" do
+      it "sets `render_views?` to the truthiness of the provided value" do
         expect {
           config.render_views = :a_value
         }.to change { config.render_views? }.from(false).to(true)

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
       }
     end
 
-    it "passess deserialized arguments to with block" do
+    it "passes deserialized arguments to with block" do
       global_id_object = GlobalIdModel.new("42")
 
       expect {
@@ -650,7 +650,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
       }
     end
 
-    it "passess deserialized arguments to with block" do
+    it "passes deserialized arguments to with block" do
       global_id_object = GlobalIdModel.new("42")
 
       expect {

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         )
       end
 
-      it "passes when given a global id serialised argument" do
+      it "passes when given a global id serialized argument" do
         expect {
           UnifiedMailer.with(inquiry: GlobalIDArgument.new).test_email.deliver_later
         }.to have_enqueued_email(UnifiedMailer, :test_email)

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -60,7 +60,7 @@ module RSpec::Rails
         end
       end
 
-      it 'propogates to examples in nested groups properly' do
+      it 'propagates to examples in nested groups properly' do
         value = :unset
 
         group.class_exec do


### PR DESCRIPTION
- Use "targeting" instead of "targetting"
- Use "mergeable" instead of "mergable"
- Use "forwarding" instead of "fowarding"
- Use "forwarded" instead of "forwaded"
- Use "accidentally" instead of "accicentally"
- Use "channel" instead of "channe"
- Use "compatibility" instead of "compatability"
- Use "uncomment" instead of "unncomment"
- Use "inferred" instead of "infered"
- Use "customize" instead of "customise"
- Use "formatting" instead of "formating"
- Use "truthiness" instead of "truthyness"
- Use "passes" instead of "passess"
- Use "serialized" instead of "serialised"
- Use "propagates" instead of "propogates"