### PR TITLE
use the tag itself instead of the variable

### DIFF
--- a/lib/generators/rspec/scaffold/templates/index_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/index_spec.rb
@@ -18,9 +18,10 @@ RSpec.describe "<%= ns_table_name %>/index", <%= type_metatag(:view) %> do
 
   it "renders a list of <%= ns_table_name %>" do
     render
-    cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td'
+
+<% cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td' -%>
 <% for attribute in output_attributes -%>
-    assert_select cell_selector, text: Regexp.new(<%= value_for(attribute) %>.to_s), count: 2
+    assert_select <%= cell_selector %>, text: Regexp.new(<%= value_for(attribute) %>.to_s), count: 2
 <% end -%>
   end
 end

--- a/lib/generators/rspec/scaffold/templates/index_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/index_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe "<%= ns_table_name %>/index", <%= type_metatag(:view) %> do
   it "renders a list of <%= ns_table_name %>" do
     render
 
-<% cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td' -%>
+<% cell_selector = Rails::VERSION::STRING.to_f >= 7.0 ? 'div>p' : 'tr>td' -%>
 <% for attribute in output_attributes -%>
-    assert_select <%= cell_selector %>, text: Regexp.new(<%= value_for(attribute) %>.to_s), count: 2
+    assert_select <%= cell_selector %>.to_s, text: Regexp.new(<%= value_for(attribute) %>.to_s), count: 2
 <% end -%>
   end
 end

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -224,16 +224,22 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
       before { run_generator %w[posts upvotes:integer downvotes:integer] }
       subject { file("spec/views/posts/index.html.erb_spec.rb") }
       it { is_expected.to exist }
-      it { is_expected.to contain('assert_select div>p, text: Regexp.new(2.to_s), count: 2') }
-      it { is_expected.to contain('assert_select div>p, text: Regexp.new(3.to_s), count: 2') }
+      context "rails 7 or greater" do
+        before { allow(Rails::VERSION::STRING).to receive(:to_f).and_return(7.0) }
+        it { is_expected.to contain('assert_select div>p.to_s, text: Regexp.new(2.to_s), count: 2') }
+        it { is_expected.to contain('assert_select div>p.to_s, text: Regexp.new(3.to_s), count: 2') }
+      end
     end
 
     describe 'with multiple float attributes index' do
       before { run_generator %w[posts upvotes:float downvotes:float] }
       subject { file("spec/views/posts/index.html.erb_spec.rb") }
       it { is_expected.to exist }
-      it { is_expected.to contain('assert_select div>p, text: Regexp.new(2.5.to_s), count: 2') }
-      it { is_expected.to contain('assert_select div>p, text: Regexp.new(3.5.to_s), count: 2') }
+      context "rails 7 or greater" do
+        before { allow(Rails::VERSION::STRING).to receive(:to_f).and_return(7.0) }
+        it { is_expected.to contain('assert_select div>p.to_s, text: Regexp.new(2.5.to_s), count: 2') }
+        it { is_expected.to contain('assert_select div>p.to_s, text: Regexp.new(3.5.to_s), count: 2') }
+      end
     end
 
     describe 'with reference attribute' do

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -224,16 +224,16 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
       before { run_generator %w[posts upvotes:integer downvotes:integer] }
       subject { file("spec/views/posts/index.html.erb_spec.rb") }
       it { is_expected.to exist }
-      it { is_expected.to contain('assert_select cell_selector, text: Regexp.new(2.to_s), count: 2') }
-      it { is_expected.to contain('assert_select cell_selector, text: Regexp.new(3.to_s), count: 2') }
+      it { is_expected.to contain('assert_select div>p, text: Regexp.new(2.to_s), count: 2') }
+      it { is_expected.to contain('assert_select div>p, text: Regexp.new(3.to_s), count: 2') }
     end
 
     describe 'with multiple float attributes index' do
       before { run_generator %w[posts upvotes:float downvotes:float] }
       subject { file("spec/views/posts/index.html.erb_spec.rb") }
       it { is_expected.to exist }
-      it { is_expected.to contain('assert_select cell_selector, text: Regexp.new(2.5.to_s), count: 2') }
-      it { is_expected.to contain('assert_select cell_selector, text: Regexp.new(3.5.to_s), count: 2') }
+      it { is_expected.to contain('assert_select div>p, text: Regexp.new(2.5.to_s), count: 2') }
+      it { is_expected.to contain('assert_select div>p, text: Regexp.new(3.5.to_s), count: 2') }
     end
 
     describe 'with reference attribute' do


### PR DESCRIPTION
[while testing rails 7](https://github.com/JuanVqz/lalo/blob/acbc3a62d0d091e82e4c136746e2408b9ca496b7/spec/views/orders/index.html.erb_spec.rb#L14-L18) I did notice the following test has a variable called `cell_selector` then I asked my self why do we need to know what rails version are we working on. could we generate only the tag without telling everybody how to do it?
and here we are, trying to implement it. if you think this is not useful please let me know.


```rb
  # before
  it "renders a list of orders" do
    render
    cell_selector = Rails::VERSION::STRING >= "7" ? "div>p" : "tr>td"
    assert_select cell_selector, text: Regexp.new("MyText".to_s), count: 2
  end
  
  # after, >= rails 7
  it "renders a list of orders" do
      render

      assert_select "div>p", text: Regexp.new("MyText"), count: 2
  end

  # after <= rails 6 
  it "renders a list of orders" do
    render

    assert_select "tr>td", text: Regexp.new("MyText".to_s), count: 2
  end
```

