### PR TITLE
Implement tagged_logger by hand

### DIFF
--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -184,11 +184,12 @@ module RSpec
 
     # @private
     module TaggedLoggingAdapter
-      require 'active_support/testing/tagged_logging'
-      include ActiveSupport::Testing::TaggedLogging
-
-      # Just a stub as TaggedLogging is calling `name`
-      def name
+      private
+      # Vendored from activesupport/lib/active_support/testing/tagged_logging.rb
+      # This implements the tagged_logger method where it is expected, but
+      # doesn't call `name` or set it up like Rails does.
+      def tagged_logger
+        @tagged_logger ||= (defined?(Rails.logger) && Rails.logger)
       end
     end
   end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -1,8 +1,7 @@
 module RSpec::Rails
   RSpec.describe RailsExampleGroup do
     if ::Rails::VERSION::MAJOR >= 7
-      it 'includes ActiveSupport::Testing::TaggedLogging' do
-        expect(described_class.include?(::ActiveSupport::Testing::TaggedLogging)).to eq(true)
+      it 'supports tagged_logger' do
         expect(described_class.private_instance_methods).to include(:tagged_logger)
       end
     end


### PR DESCRIPTION
Similar to #2461, rather than use Rails modules verbatim, vendor the import part of what they do (in this case define the private `tagged_logger` method) so we have less of an overlap. In particular the actual module does this:

```
def before_setup
  if tagged_logger && tagged_logger.info?
    heading = "#{self.class}: #{name}"
    divider = "-" * heading.size
    tagged_logger.info divider
    tagged_logger.info heading
    tagged_logger.info divider
  end
  super
end
```

Which is what is causing issues for #2624