### PR TITLE
Update RSpec gem versions to 3.12/3.13.pre

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -46,12 +46,12 @@ Gem::Specification.new do |s|
   # get released.
   %w[core expectations mocks support].each do |name|
     if ENV['RSPEC_CI']
-      s.add_runtime_dependency "rspec-#{name}", ENV.fetch('RSPEC_VERSION', '3.12.0.pre')
+      s.add_runtime_dependency "rspec-#{name}", ENV.fetch('RSPEC_VERSION', '3.13.0.pre')
     elsif RSpec::Rails::Version::STRING =~ /pre/ # prerelease builds
-      expected_rspec_version = "3.12.0.pre"
+      expected_rspec_version = "3.13.0.pre"
       s.add_runtime_dependency "rspec-#{name}", "= #{expected_rspec_version}"
     else
-      expected_rspec_version = "3.11.0"
+      expected_rspec_version = "3.12.0"
       s.add_runtime_dependency "rspec-#{name}", "~> #{expected_rspec_version.split(".")[0..1].join(".")}"
     end
   end


### PR DESCRIPTION
RSpec 3.12 was recently released.

PR builds fail, since in `rspec-*` repos we have 3.13.pre now, see e.g [this](https://github.com/rspec/rspec-rails/actions/runs/3336212627/jobs/5523226123)