### PR TITLE
Handle ActionView::PathSet immutability and strict type casting in Rails 7.1

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -119,11 +119,11 @@ module RSpec
       # @private
       module EmptyTemplates
         def prepend_view_path(new_path)
-          lookup_context.view_paths.unshift(*_path_decorator(*new_path))
+          super(_path_decorator(*new_path))
         end
 
         def append_view_path(new_path)
-          lookup_context.view_paths.push(*_path_decorator(*new_path))
+          super(_path_decorator(*new_path))
         end
 
       private

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -71,7 +71,15 @@ module RSpec
         # templates with modified source
         #
         # @private
-        class ResolverDecorator
+        class ResolverDecorator < ::ActionView::Resolver
+          (::ActionView::Resolver.instance_methods - Object.instance_methods).each do |method|
+            undef_method method
+          end
+
+          (::ActionView::Resolver.methods - Object.methods).each do |method|
+            singleton_class.undef_method method
+          end
+
           def initialize(resolver)
             @resolver = resolver
           end


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/45957, `ActionView::PathSet` is immutable, and only accepts subclasses of `ActionView::Resolver`. This necessitates changes to how RSpec Rails decorates resolvers to return blank templates when `render_views?` is false.

These changes fix the test suite when running against the Rails main branch:
https://github.com/rspec/rspec-rails/actions/runs/3340449858/jobs/5530555101

Co-authored by @ilianah 🍐 