### PR TITLE
Fix action mailer check

### DIFF
--- a/lib/rspec/rails/example/mailer_example_group.rb
+++ b/lib/rspec/rails/example/mailer_example_group.rb
@@ -10,7 +10,7 @@ module RSpec
   end
 end
 
-if defined?(ActionMailer)
+if defined?(ActionMailer::TestCase)
   module RSpec
     module Rails
       # Container module for mailer spec functionality.


### PR DESCRIPTION
In some cases, `ActionMailer` migth be defined, but `ActionMailer::TestCase` not.