### PR TITLE
Only include Minitest assertions when RSpec is configured to use them

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v6.0.1...main)
 
+Breaking Changes:
+
+* Only include Minitest assertions when RSpec is configured to use them. (Phil Pirozhkov, #????)
+
 Bug Fixes:
 
 * Fix ActionView::PathSet when `render_views` is off for Rails 7.1.

--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -10,7 +10,7 @@ module RSpec
       extend ActiveSupport::Concern
       include RSpec::Rails::SetupAndTeardownAdapter
       include RSpec::Rails::MinitestLifecycleAdapter
-      include RSpec::Rails::MinitestAssertionAdapter
+      include RSpec::Rails::MinitestAssertionAdapter if defined?(::RSpec::Core::MinitestAssertionsAdapter)
       include RSpec::Rails::FixtureSupport
       include RSpec::Rails::TaggedLoggingAdapter if ::Rails::VERSION::MAJOR >= 7
     end

--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -6,7 +6,7 @@ module RSpec
         extend ActiveSupport::Concern
         include RSpec::Rails::SetupAndTeardownAdapter
         include RSpec::Rails::MinitestLifecycleAdapter
-        include RSpec::Rails::MinitestAssertionAdapter
+        include RSpec::Rails::MinitestAssertionAdapter if defined?(::RSpec::Core::MinitestAssertionsAdapter)
         include ActiveRecord::TestFixtures
 
         # @private prevent ActiveSupport::TestFixtures to start a DB transaction.

--- a/snippets/with_minitest_expectation_framework.rb
+++ b/snippets/with_minitest_expectation_framework.rb
@@ -1,0 +1,60 @@
+if __FILE__ =~ /^snippets/
+  fail "Snippets are supposed to be run from their own directory to avoid side " \
+       "effects as e.g. the root `Gemfile`, or `spec/spec_helpers.rb` to be " \
+       "loaded by the root `.rspec`."
+end
+
+# We opt-out from using RubyGems, but `bundler/inline` requires it
+require 'rubygems'
+
+require "bundler/inline"
+
+# We pass `false` to `gemfile` to skip the installation of gems,
+# because it may install versions that would conflict with versions
+# from the main `Gemfile.lock`.
+gemfile(false) do
+  source "https://rubygems.org"
+
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+  # Those Gemfiles carefully pick the right versions depending on
+  # settings in the ENV, `.rails-version` and `maintenance-branch`.
+  Dir.chdir('..') do
+    # This Gemfile expects `maintenance-branch` file to be present
+    # in the current directory.
+    eval_gemfile 'Gemfile-rspec-dependencies'
+    # This Gemfile expects `.rails-version` file
+    eval_gemfile 'Gemfile-rails-dependencies'
+  end
+
+  gem "rspec-rails", path: "../"
+end
+
+# Run specs at exit
+require "rspec/autorun"
+
+# This snippet describes the case when ActiveRecord is loaded, but
+# `use_active_record` is set to `false` in RSpec configuration.
+
+# RSpec configuration
+RSpec.configure do |config|
+  config.expect_with :minitest
+  config.expect_with :rspec
+end
+
+# Typically, rails_helper is loading spec_helper before loading rspec-rails,
+# so by the time rspec-rails is loaded, expectation framework is configured.
+
+# Initialization
+require "active_record/railtie"
+require "rspec/rails"
+
+# This connection will do for database-independent bug reports
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+
+# Rails project specs
+RSpec.describe 'with Minitest assertions', type: :model do
+  it 'allows using Minitest assertions' do
+    assert_equal 1, 1
+  end
+end

--- a/snippets/without_minitest_expectation_framework.rb
+++ b/snippets/without_minitest_expectation_framework.rb
@@ -1,0 +1,61 @@
+if __FILE__ =~ /^snippets/
+  fail "Snippets are supposed to be run from their own directory to avoid side " \
+       "effects as e.g. the root `Gemfile`, or `spec/spec_helpers.rb` to be " \
+       "loaded by the root `.rspec`."
+end
+
+# We opt-out from using RubyGems, but `bundler/inline` requires it
+require 'rubygems'
+
+require "bundler/inline"
+
+# We pass `false` to `gemfile` to skip the installation of gems,
+# because it may install versions that would conflict with versions
+# from the main `Gemfile.lock`.
+gemfile(false) do
+  source "https://rubygems.org"
+
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+  # Those Gemfiles carefully pick the right versions depending on
+  # settings in the ENV, `.rails-version` and `maintenance-branch`.
+  Dir.chdir('..') do
+    # This Gemfile expects `maintenance-branch` file to be present
+    # in the current directory.
+    eval_gemfile 'Gemfile-rspec-dependencies'
+    # This Gemfile expects `.rails-version` file
+    eval_gemfile 'Gemfile-rails-dependencies'
+  end
+
+  gem "rspec-rails", path: "../"
+end
+
+# Run specs at exit
+require "rspec/autorun"
+
+# This snippet describes the case when ActiveRecord is loaded, but
+# `use_active_record` is set to `false` in RSpec configuration.
+
+# RSpec configuration
+RSpec.configure do |config|
+  config.expect_with :rspec
+end
+
+# Typically, rails_helper is loading spec_helper before loading rspec-rails,
+# so by the time rspec-rails is loaded, expectation framework is configured.
+
+# Initialization
+require "active_record/railtie"
+require "rspec/rails"
+
+# This connection will do for database-independent bug reports
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+
+# Rails project specs
+RSpec.describe 'without Minitest assertions', type: :model do
+  it 'provides no Minitest assertions' do
+    expect {
+      assert_equal 1, 1
+    }.to raise_error(NoMethodError, /undefined method `assert_equal' for/)
+  end
+end


### PR DESCRIPTION
This would only allow using [Minitest assertions (`assert_equal`)](docs.seattlerb.org/minitest/Minitest/Assertions.html) when RSpec is configured to allow them:
```ruby
RSpec.confige do |c|
  c.expect_with :minitest
  c.expect_with :rspec do
    # ...
  end
end
```