### PR TITLE
Use 'Rails.root.join' in rails_helper

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -34,7 +34,7 @@ end
 RSpec.configure do |config|
 <% if RSpec::Rails::FeatureCheck.has_active_record? -%>
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = Rails.root.join('spec/fixtures')
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
@@ -52,7 +52,7 @@ RSpec.configure do |config|
   # note if you'd prefer not to run each example within a transaction, you
   # should set use_transactional_fixtures to false.
   #
-  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = Rails.root.join('spec/fixtures')
   # config.use_transactional_fixtures = true
 
 <% end -%>

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -52,7 +52,7 @@ RSpec.configure do |config|
   # note if you'd prefer not to run each example within a transaction, you
   # should set use_transactional_fixtures to false.
   #
-  # config.fixture_path = Rails.root.join('spec/fixtures')
+  # config.fixture_path = Rails.root.join('spec', 'fixtures')
   # config.use_transactional_fixtures = true
 
 <% end -%>

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -34,7 +34,7 @@ end
 RSpec.configure do |config|
 <% if RSpec::Rails::FeatureCheck.has_active_record? -%>
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec/fixtures')
+  config.fixture_path = Rails.root.join('spec', 'fixtures')
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
I updated rubocop-rails gem to [v2.17.3](https://github.com/rubocop/rubocop-rails/releases/tag/v2.17.3) in my project recently.
By this update, Rubocop suggests to use `Rails.root.join` instead of string interpolation for [`Rails/FilePath`](https://www.rubydoc.info/gems/rubocop/0.47.1/RuboCop/Cop/Rails/FilePath) at 'rails_helper.rb'.

It might be better to use `Rails.root.join` than string interpolation too in rails_helper generator.

How do you think about this?
