### PR TITLE
Update to ruby 1.9 hash syntax

### DIFF
--- a/features/backtrace_filtering.feature
+++ b/features/backtrace_filtering.feature
@@ -21,7 +21,7 @@ Feature: backtrace filtering
       config.filter_rails_from_backtrace!
     end
 
-    RSpec.describe "Controller", :type => :controller do
+    RSpec.describe "Controller", type: :controller do
       controller do
         def index
           raise "Something went wrong."

--- a/features/channel_specs/channel_spec.feature
+++ b/features/channel_specs/channel_spec.feature
@@ -1,6 +1,6 @@
 Feature: channel spec
 
-  Channel specs are marked by `:type => :channel` or if you have set
+  Channel specs are marked by `type: :channel` or if you have set
   `config.infer_spec_type_from_file_location!` by placing them in `spec/channels`.
 
   A channel spec is a thin wrapper for an `ActionCable::Channel::TestCase`, and includes all
@@ -37,7 +37,7 @@ Feature: channel spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe ChatChannel, :type => :channel do
+      RSpec.describe ChatChannel, type: :channel do
         it "successfully subscribes" do
           subscribe room_id: 42
           expect(subscription).to be_confirmed
@@ -52,7 +52,7 @@ Feature: channel spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe ChatChannel, :type => :channel do
+      RSpec.describe ChatChannel, type: :channel do
         it "rejects subscription" do
           subscribe room_id: nil
           expect(subscription).to be_rejected
@@ -67,7 +67,7 @@ Feature: channel spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe ChatChannel, :type => :channel do
+      RSpec.describe ChatChannel, type: :channel do
         it "successfully subscribes" do
           subscribe room_id: 42
 
@@ -95,7 +95,7 @@ Feature: channel spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationCable::Connection, :type => :channel do
+      RSpec.describe ApplicationCable::Connection, type: :channel do
         it "successfully connects" do
           connect "/cable?user_id=323"
           expect(connection.user_id).to eq "323"
@@ -121,7 +121,7 @@ Feature: channel spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationCable::Connection, :type => :channel do
+      RSpec.describe ApplicationCable::Connection, type: :channel do
         it "successfully connects" do
           cookies.signed[:user_id] = "324"
 
@@ -149,7 +149,7 @@ Feature: channel spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationCable::Connection, :type => :channel do
+      RSpec.describe ApplicationCable::Connection, type: :channel do
         it "successfully connects" do
           connect "/cable", headers: { "X-USER-ID" => "325" }
           expect(connection.user_id).to eq "325"
@@ -175,7 +175,7 @@ Feature: channel spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationCable::Connection, :type => :channel do
+      RSpec.describe ApplicationCable::Connection, type: :channel do
         it "rejects connection" do
           expect { connect "/cable?user_id=" }.to have_rejected_connection
         end
@@ -204,7 +204,7 @@ Feature: channel spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationCable::Connection, :type => :channel do
+      RSpec.describe ApplicationCable::Connection, type: :channel do
         it "disconnects" do
           connect "/cable?user_id=42"
           expect { disconnect }.to output(/User 42 disconnected/).to_stdout

--- a/features/controller_specs/README.md
+++ b/features/controller_specs/README.md
@@ -1,4 +1,4 @@
-Controller specs are marked by `:type => :controller` or if you have set
+Controller specs are marked by `type: :controller` or if you have set
 `config.infer_spec_type_from_file_location!` by placing them in `spec/controllers`.
 
 A controller spec is an RSpec wrapper for a Rails functional test

--- a/features/controller_specs/anonymous_controller.feature
+++ b/features/controller_specs/anonymous_controller.feature
@@ -20,7 +20,7 @@ Feature: anonymous controller
     c.infer_base_class_for_anonymous_controllers = false
   end
 
-  RSpec.describe BaseController, :type => :controller do
+  RSpec.describe BaseController, type: :controller do
     controller do
       def index; end
 
@@ -48,7 +48,7 @@ Feature: anonymous controller
         end
       end
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
         controller do
           def index
             raise ApplicationController::AccessDenied
@@ -83,7 +83,7 @@ Feature: anonymous controller
         end
       end
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
         controller do
           def index
             raise ApplicationController::AccessDenied
@@ -122,7 +122,7 @@ Feature: anonymous controller
         end
       end
 
-      RSpec.describe FoosController, :type => :controller do
+      RSpec.describe FoosController, type: :controller do
         controller(FoosController) do
           def index
             raise ApplicationController::AccessDenied
@@ -149,7 +149,7 @@ Feature: anonymous controller
 
       class FoosController < ApplicationController; end
 
-      RSpec.describe FoosController, :type => :controller do
+      RSpec.describe FoosController, type: :controller do
         controller do
           def index
             render :plain => "Hello World"
@@ -172,7 +172,7 @@ Feature: anonymous controller
       class ApplicationController < ActionController::Base; end
       class FoosController < ApplicationController; end
 
-      RSpec.describe "Access controller names", :type => :controller do
+      RSpec.describe "Access controller names", type: :controller do
         controller FoosController do
           def index
             @name = self.class.name
@@ -211,7 +211,7 @@ Feature: anonymous controller
         end
       end
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
         controller do
           def index
             render :plain => ""
@@ -239,7 +239,7 @@ Feature: anonymous controller
         ExpectedRoutingError = ActionController::RoutingError
       end
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
         controller do
           def index
             render :plain => "index called"
@@ -417,7 +417,7 @@ Feature: anonymous controller
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
         controller do
           def custom
             render :plain => "custom called"
@@ -442,7 +442,7 @@ Feature: anonymous controller
       class OtherController < ActionController::Base
       end
 
-      RSpec.describe OtherController, :type => :controller do
+      RSpec.describe OtherController, type: :controller do
         controller do
           def custom
             render :plain => "custom called"
@@ -467,7 +467,7 @@ Feature: anonymous controller
 
       class FoosController < ApplicationController; end
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
         controller FoosController do
           def custom
             render :plain => "custom called"
@@ -498,7 +498,7 @@ Feature: anonymous controller
         end
       end
 
-      RSpec.describe Outer::Inner::FoosController, :type => :controller do
+      RSpec.describe Outer::Inner::FoosController, type: :controller do
         controller do
           def index
             @name = self.class.name
@@ -535,7 +535,7 @@ Feature: anonymous controller
         match "/login" => "sessions#new", :as => "login", :via => "get"
       end
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
         controller do
           def index
             redirect_to login_url

--- a/features/controller_specs/bypass_rescue.feature
+++ b/features/controller_specs/bypass_rescue.feature
@@ -30,7 +30,7 @@ Feature: bypass rescue
 
       require 'controllers/gadgets_controller_spec_context'
 
-      RSpec.describe GadgetsController, :type => :controller do
+      RSpec.describe GadgetsController, type: :controller do
         before do
           def controller.index
             raise AccessDenied
@@ -55,7 +55,7 @@ Feature: bypass rescue
 
       require 'controllers/gadgets_controller_spec_context'
 
-      RSpec.describe GadgetsController, :type => :controller do
+      RSpec.describe GadgetsController, type: :controller do
         before do
           def controller.index
             raise AccessDenied

--- a/features/controller_specs/controller_spec.feature
+++ b/features/controller_specs/controller_spec.feature
@@ -5,7 +5,7 @@ Feature: controller spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe WidgetsController, :type => :controller do
+      RSpec.describe WidgetsController, type: :controller do
         describe "GET index" do
           it "has a 200 status code" do
             get :index
@@ -24,7 +24,7 @@ Feature: controller spec
 
       RSpec.configure {|c| c.before { expect(controller).not_to be_nil }}
 
-      RSpec.describe WidgetsController, :type => :controller do
+      RSpec.describe WidgetsController, type: :controller do
         describe "GET index" do
           it "doesn't matter" do
           end
@@ -39,7 +39,7 @@ Feature: controller spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe WidgetsController, :type => :controller do
+    RSpec.describe WidgetsController, type: :controller do
       describe "responds to" do
         it "responds to html by default" do
           post :create, :params => { :widget => { :name => "Any Name" } }
@@ -61,7 +61,7 @@ Feature: controller spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe WidgetsController, :type => :controller do
+    RSpec.describe WidgetsController, type: :controller do
       describe "responds to" do
         it "responds to html by default" do
           post :create, :params => { :widget => { :name => "Any Name" } }

--- a/features/controller_specs/cookies.feature
+++ b/features/controller_specs/cookies.feature
@@ -11,7 +11,7 @@ Feature: Cookies
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
         controller do
           def clear_cookie
             cookies.delete(:user_name)

--- a/features/controller_specs/engine_routes.feature
+++ b/features/controller_specs/engine_routes.feature
@@ -33,7 +33,7 @@ Feature: engine routes for controllers
         end
       end
 
-      RSpec.describe MyEngine::WidgetsController, :type => :controller do
+      RSpec.describe MyEngine::WidgetsController, type: :controller do
         routes { MyEngine::Engine.routes }
 
         it "redirects to a random widget" do

--- a/features/controller_specs/isolation_from_views.feature
+++ b/features/controller_specs/isolation_from_views.feature
@@ -12,7 +12,7 @@ Feature: views are stubbed by default
       """ruby
       require "rails_helper"
 
-      RSpec.describe WidgetsController, :type => :controller do
+      RSpec.describe WidgetsController, type: :controller do
         describe "index" do
           it "renders the index template" do
             get :index
@@ -35,7 +35,7 @@ Feature: views are stubbed by default
       """ruby
       require "rails_helper"
 
-      RSpec.describe WidgetsController, :type => :controller do
+      RSpec.describe WidgetsController, type: :controller do
         describe "index" do
           it "renders the 'new' template" do
             get :index
@@ -52,7 +52,7 @@ Feature: views are stubbed by default
       """ruby
       require "rails_helper"
 
-      RSpec.describe ThingsController, :type => :controller do
+      RSpec.describe ThingsController, type: :controller do
         describe "custom_action" do
           it "renders an empty custom_action template" do
             controller.prepend_view_path 'app/views'
@@ -83,7 +83,7 @@ Feature: views are stubbed by default
       """ruby
       require "rails_helper"
 
-      RSpec.describe ThingsController, :type => :controller do
+      RSpec.describe ThingsController, type: :controller do
         render_views
 
         it "renders the real custom_action template" do

--- a/features/controller_specs/render_views.feature
+++ b/features/controller_specs/render_views.feature
@@ -8,7 +8,7 @@ Feature: render_views
       """ruby
       require "rails_helper"
 
-      RSpec.describe WidgetsController, :type => :controller do
+      RSpec.describe WidgetsController, type: :controller do
         render_views
 
         describe "GET index" do
@@ -27,7 +27,7 @@ Feature: render_views
       """ruby
       require "rails_helper"
 
-      RSpec.describe WidgetsController, :type => :controller do
+      RSpec.describe WidgetsController, type: :controller do
         context "with render_views" do
           render_views
 
@@ -101,7 +101,7 @@ Feature: render_views
       require "rails_helper"
       require "support/render_views"
 
-      RSpec.describe WidgetsController, :type => :controller do
+      RSpec.describe WidgetsController, type: :controller do
         describe "GET index" do
           it "renders the index template" do
             get :index

--- a/features/directory_structure.feature
+++ b/features/directory_structure.feature
@@ -145,7 +145,7 @@ Feature: Directory Structure
       """ruby
       require "rails_helper"
 
-      RSpec.describe WidgetsController, :type => :controller do
+      RSpec.describe WidgetsController, type: :controller do
         it "responds successfully" do
           get :index
           expect(response.status).to eq(200)
@@ -205,7 +205,7 @@ Feature: Directory Structure
 
       # Due to limitations in the Rails routing test framework, routes that
       # perform redirects must actually be tested via request specs
-      RSpec.describe "/example", :type => :request do
+      RSpec.describe "/example", type: :request do
         it "redirects to example.com" do
           get "/example"
           expect(response).to redirect_to("http://example.com")

--- a/features/feature_specs/feature_spec.feature
+++ b/features/feature_specs/feature_spec.feature
@@ -4,7 +4,7 @@ Feature: Feature spec
   through an application. They should drive the application only via its external
   interface, usually web pages.
 
-  Feature specs are marked by `:type => :feature` or if you have set
+  Feature specs are marked by `type: :feature` or if you have set
   `config.infer_spec_type_from_file_location!` by placing them in
   `spec/features`.
 
@@ -15,7 +15,7 @@ Feature: Feature spec
   The `feature` and `scenario` DSL correspond to `describe` and `it`, respectively.
   These methods are simply aliases that allow feature specs to read more as
   [customer](http://c2.com/cgi/wiki?CustomerTest) and [acceptance](http://c2.com/cgi/wiki?AcceptanceTest) tests. When capybara is required it sets
-  `:type => :feature` automatically for you.
+  `type: :feature` automatically for you.
 
   @capybara
   Scenario: specify creating a Widget by driving the application with capybara
@@ -23,7 +23,7 @@ Feature: Feature spec
       """ruby
       require "rails_helper"
 
-      RSpec.feature "Widget management", :type => :feature do
+      RSpec.feature "Widget management", type: :feature do
         scenario "User creates a new widget" do
           visit "/widgets/new"
 

--- a/features/helper_specs/helper_spec.feature
+++ b/features/helper_specs/helper_spec.feature
@@ -1,6 +1,6 @@
 Feature: helper spec
 
-  Helper specs are marked by `:type => :helper` or if you have set
+  Helper specs are marked by `type: :helper` or if you have set
   `config.infer_spec_type_from_file_location!` by placing them in `spec/helpers`.
 
   Helper specs expose a `helper` object, which includes the helper module being
@@ -18,7 +18,7 @@ Feature: helper spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationHelper, :type => :helper do
+      RSpec.describe ApplicationHelper, type: :helper do
         describe "#page_title" do
           it "returns the default title" do
             expect(helper.page_title).to eq("RSpec is your friend")
@@ -42,7 +42,7 @@ Feature: helper spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationHelper, :type => :helper do
+      RSpec.describe ApplicationHelper, type: :helper do
         describe "#page_title" do
           it "returns the instance variable" do
             assign(:title, "My Title")
@@ -67,7 +67,7 @@ Feature: helper spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe WidgetsHelper, :type => :helper do
+      RSpec.describe WidgetsHelper, type: :helper do
         describe "#widget_title" do
           it "includes the app name" do
             assign(:title, "This Widget")
@@ -100,7 +100,7 @@ Feature: helper spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe WidgetsHelper, :type => :helper do
+      RSpec.describe WidgetsHelper, type: :helper do
         describe "#link_to_widget" do
           it "links to a widget using its name" do
             widget = Widget.create!(:name => "This Widget")

--- a/features/job_specs/job_spec.feature
+++ b/features/job_specs/job_spec.feature
@@ -2,7 +2,7 @@ Feature: job spec
 
   Job specs provide alternative assertions to those available in `ActiveJob::TestHelper` and help assert behaviour of the jobs themselves and that other entities correctly enqueue them.
 
-  Job specs are marked by `:type => :job` or if you have set `config.infer_spec_type_from_file_location!` by placing them in `spec/jobs`.
+  Job specs are marked by `type: :job` or if you have set `config.infer_spec_type_from_file_location!` by placing them in `spec/jobs`.
 
   With job specs, you can:
 
@@ -26,7 +26,7 @@ Feature: job spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe UploadBackupsJob, :type => :job do
+    RSpec.describe UploadBackupsJob, type: :job do
       describe "#perform_later" do
         it "uploads a backup" do
           ActiveJob::Base.queue_adapter = :test
@@ -45,7 +45,7 @@ Feature: job spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe UploadBackupsJob, :type => :job do
+    RSpec.describe UploadBackupsJob, type: :job do
       describe "#perform_later" do
         it "uploads a backup" do
           ActiveJob::Base.queue_adapter = :test
@@ -64,7 +64,7 @@ Feature: job spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe UploadBackupsJob, :type => :job do
+    RSpec.describe UploadBackupsJob, type: :job do
       describe "#perform_later" do
         it "uploads a backup" do
           ActiveJob::Base.queue_adapter = :test
@@ -83,7 +83,7 @@ Feature: job spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe UploadBackupsJob, :type => :job do
+    RSpec.describe UploadBackupsJob, type: :job do
       describe "#perform_later" do
         it "uploads a backup" do
           ActiveJob::Base.queue_adapter = :test
@@ -102,7 +102,7 @@ Feature: job spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe UploadBackupsJob, :type => :job do
+    RSpec.describe UploadBackupsJob, type: :job do
       describe "#perform_later" do
         it "uploads a backup" do
           ActiveJob::Base.queue_adapter = :test
@@ -120,7 +120,7 @@ Feature: job spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe UploadBackupsJob, :type => :job do
+    RSpec.describe UploadBackupsJob, type: :job do
       describe "#perform_later" do
         it "uploads a backup" do
           ActiveJob::Base.queue_adapter = :test
@@ -138,7 +138,7 @@ Feature: job spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe UploadBackupsJob, :type => :job do
+    RSpec.describe UploadBackupsJob, type: :job do
       describe "#perform_later" do
         it "uploads a backup" do
           ActiveJob::Base.queue_adapter = :development

--- a/features/mailer_specs/README.md
+++ b/features/mailer_specs/README.md
@@ -1,5 +1,5 @@
 By default Mailer specs reside in the `spec/mailers` folder. Adding the metadata
-`:type => :mailer` to any context makes its examples be treated as mailer specs.
+`type: :mailer` to any context makes its examples be treated as mailer specs.
 
 A mailer spec is a thin wrapper for an ActionMailer::TestCase, and includes all
 of the behavior and assertions that it provides, in addition to RSpec's own
@@ -9,7 +9,7 @@ behavior and expectations.
 
     require "rails_helper"
 
-    RSpec.describe Notifications, :type => :mailer do
+    RSpec.describe Notifications, type: :mailer do
       describe "notify" do
         let(:mail) { Notifications.signup }
 

--- a/features/mailer_specs/mailer_spec.feature
+++ b/features/mailer_specs/mailer_spec.feature
@@ -5,7 +5,7 @@ Feature: mailer spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe NotificationsMailer, :type => :mailer do
+      RSpec.describe NotificationsMailer, type: :mailer do
         describe "notify" do
           let(:mail) { NotificationsMailer.signup }
 

--- a/features/mailer_specs/url_helpers.feature
+++ b/features/mailer_specs/url_helpers.feature
@@ -1,6 +1,6 @@
 Feature: URL helpers in mailer examples
 
-  Mailer specs are marked by `:type => :mailer` or if you have set
+  Mailer specs are marked by `type: :mailer` or if you have set
   `config.infer_spec_type_from_file_location!` by placing them in `spec/mailers`.
 
   Scenario: using URL helpers with default options
@@ -12,7 +12,7 @@ Feature: URL helpers in mailer examples
       """ruby
       require 'rails_helper'
 
-      RSpec.describe NotificationsMailer, :type => :mailer do
+      RSpec.describe NotificationsMailer, type: :mailer do
         it 'should have access to URL helpers' do
           expect { gadgets_url }.not_to raise_error
         end
@@ -30,7 +30,7 @@ Feature: URL helpers in mailer examples
       """ruby
       require 'rails_helper'
 
-      RSpec.describe NotificationsMailer, :type => :mailer do
+      RSpec.describe NotificationsMailer, type: :mailer do
         it 'should have access to URL helpers' do
           expect { gadgets_url :host => 'example.com' }.not_to raise_error
           expect { gadgets_url }.to raise_error

--- a/features/matchers/have_http_status_matcher.feature
+++ b/features/matchers/have_http_status_matcher.feature
@@ -15,7 +15,7 @@ Feature: `have_http_status` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
 
         controller do
           def index
@@ -40,7 +40,7 @@ Feature: `have_http_status` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
 
         controller do
           def index
@@ -65,7 +65,7 @@ Feature: `have_http_status` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe ApplicationController, :type => :controller do
+      RSpec.describe ApplicationController, type: :controller do
 
         controller do
           def index
@@ -90,7 +90,7 @@ Feature: `have_http_status` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe GadgetsController, :type => :controller do
+      RSpec.describe GadgetsController, type: :controller do
 
         describe "GET #index" do
           it "returns a 200 OK status" do
@@ -109,7 +109,7 @@ Feature: `have_http_status` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe "Widget management", :type => :request do
+      RSpec.describe "Widget management", type: :request do
 
         it "creates a Widget and redirects to the Widget's page" do
           get "/widgets/new"
@@ -134,7 +134,7 @@ Feature: `have_http_status` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.feature "Widget management", :type => :feature do
+      RSpec.feature "Widget management", type: :feature do
 
         scenario "User creates a new widget" do
           visit "/widgets/new"

--- a/features/matchers/have_stream_from_matcher.feature
+++ b/features/matchers/have_stream_from_matcher.feature
@@ -30,7 +30,7 @@ Feature: have_stream_from matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe ChatChannel, :type => :channel do
+      RSpec.describe ChatChannel, type: :channel do
         it "successfully subscribes" do
           subscribe room_id: 42
 
@@ -47,7 +47,7 @@ Feature: have_stream_from matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe ChatChannel, :type => :channel do
+      RSpec.describe ChatChannel, type: :channel do
         it "successfully subscribes" do
           subscribe(room_id: 42)
 
@@ -87,7 +87,7 @@ Feature: have_stream_from matcher
     And a file named "spec/channels/user_channel_spec.rb" with:
       """ruby
       require "rails_helper"
-      RSpec.describe NotificationsChannel, :type => :channel do
+      RSpec.describe NotificationsChannel, type: :channel do
         it "successfully subscribes to user's stream" do
           stub_connection current_user: User.new(42)
           subscribe

--- a/features/model_specs/README.md
+++ b/features/model_specs/README.md
@@ -1,4 +1,4 @@
-Model specs are marked by `:type => :model` or if you have set
+Model specs are marked by `type: :model` or if you have set
 `config.infer_spec_type_from_file_location!` by placing them in `spec/models`.
 
 A model spec is a thin wrapper for an ActiveSupport::TestCase, and includes all
@@ -9,7 +9,7 @@ behavior and expectations.
 
     require "rails_helper"
 
-    RSpec.describe Post, :type => :model do
+    RSpec.describe Post, type: :model do
       context "with 2 or more comments" do
         it "orders them in reverse chronologically" do
           post = Post.create!

--- a/features/model_specs/transactional_examples.feature
+++ b/features/model_specs/transactional_examples.feature
@@ -10,7 +10,7 @@ Feature: transactional examples
       """ruby
       require "rails_helper"
 
-      RSpec.describe Widget, :type => :model do
+      RSpec.describe Widget, type: :model do
         it "has none to begin with" do
           expect(Widget.count).to eq 0
         end
@@ -37,7 +37,7 @@ Feature: transactional examples
         c.use_transactional_examples = true
       end
 
-      RSpec.describe Widget, :type => :model do
+      RSpec.describe Widget, type: :model do
         it "has none to begin with" do
           expect(Widget.count).to eq 0
         end
@@ -65,7 +65,7 @@ Feature: transactional examples
         c.order = "defined"
       end
 
-      RSpec.describe Widget, :type => :model do
+      RSpec.describe Widget, type: :model do
         it "has none to begin with" do
           expect(Widget.count).to eq 0
         end
@@ -90,7 +90,7 @@ Feature: transactional examples
       """ruby
       require "rails_helper"
 
-      RSpec.describe Thing, :type => :model do
+      RSpec.describe Thing, type: :model do
         fixtures :things
         it "fixture method defined" do
           things(:one)

--- a/features/model_specs/verified_doubles.feature
+++ b/features/model_specs/verified_doubles.feature
@@ -9,7 +9,7 @@ Feature: verified doubles
       """ruby
       require "rails_helper"
 
-      RSpec.describe Widget, :type => :model do
+      RSpec.describe Widget, type: :model do
         it "has one after adding one" do
           instance_double("Widget", :name => "my name")
         end

--- a/features/request_specs/request_spec.feature
+++ b/features/request_specs/request_spec.feature
@@ -4,7 +4,7 @@ Feature: request spec
   designed to drive behavior through the full stack, including routing
   (provided by Rails) and without stubbing (that's up to you).
 
-  Request specs are marked by `:type => :request` or if you have set
+  Request specs are marked by `type: :request` or if you have set
   `config.infer_spec_type_from_file_location!` by placing them in `spec/requests`.
 
   With request specs, you can:
@@ -31,7 +31,7 @@ Feature: request spec
       """ruby
       require "rails_helper"
 
-      RSpec.describe "Widget management", :type => :request do
+      RSpec.describe "Widget management", type: :request do
 
         it "creates a Widget and redirects to the Widget's page" do
           get "/widgets/new"
@@ -60,7 +60,7 @@ Feature: request spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe "Widget management", :type => :request do
+    RSpec.describe "Widget management", type: :request do
       it "creates a Widget" do
         headers = { "ACCEPT" => "application/json" }
         post "/widgets", :params => { :widget => {:name => "My Widget"} }, :headers => headers
@@ -78,7 +78,7 @@ Feature: request spec
     """ruby
     require "rails_helper"
 
-    RSpec.describe "Widget management", :type => :request do
+    RSpec.describe "Widget management", type: :request do
 
       it "creates a Widget and redirects to the Widget's page" do
         headers = { "CONTENT_TYPE" => "application/json" }
@@ -118,7 +118,7 @@ Feature: request spec
       end
 
       module MyEngine
-        RSpec.describe "Links", :type => :request do
+        RSpec.describe "Links", type: :request do
           include Engine.routes.url_helpers
 
           it "redirects to a random widget" do
@@ -140,7 +140,7 @@ Feature: request spec
         resources :widgets, constraints: { subdomain: "api" }
       end
 
-      RSpec.describe "Widget management", :type => :request do
+      RSpec.describe "Widget management", type: :request do
         before { host! "api.example.com" }
 
         it "creates a Widget" do

--- a/features/routing_specs/README.md
+++ b/features/routing_specs/README.md
@@ -1,4 +1,4 @@
-Routing specs are marked by `:type => :routing` or if you have set
+Routing specs are marked by `type: :routing` or if you have set
 `config.infer_spec_type_from_file_location!` by placing them in `spec/routing`.
 
 Simple apps with nothing but standard RESTful routes won't get much value from

--- a/features/routing_specs/be_routable_matcher.feature
+++ b/features/routing_specs/be_routable_matcher.feature
@@ -9,7 +9,7 @@ Feature: be_routable matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe "routes for Widgets", :type => :routing do
+      RSpec.describe "routes for Widgets", type: :routing do
         it "does not route to widgets" do
           expect(:get => "/widgets").not_to be_routable
         end
@@ -24,7 +24,7 @@ Feature: be_routable matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe "routes for Widgets", :type => :routing do
+      RSpec.describe "routes for Widgets", type: :routing do
         it "does not route to widgets/foo/bar" do
           expect(:get => "/widgets/foo/bar").not_to be_routable
         end
@@ -39,7 +39,7 @@ Feature: be_routable matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe "routes for Widgets", :type => :routing do
+      RSpec.describe "routes for Widgets", type: :routing do
         it "routes to /widgets" do
           expect(:get => "/widgets").to be_routable
         end
@@ -54,7 +54,7 @@ Feature: be_routable matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe "routes for Widgets", :type => :routing do
+      RSpec.describe "routes for Widgets", type: :routing do
         it "routes to widgets/foo/bar" do
           expect(:get => "/widgets/foo/bar").to be_routable
         end
@@ -69,7 +69,7 @@ Feature: be_routable matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe WidgetsController, :type => :controller do
+      RSpec.describe WidgetsController, type: :controller do
         it "routes to /widgets" do
           expect(:get => "/widgets").to be_routable
         end

--- a/features/routing_specs/engine_routes.feature
+++ b/features/routing_specs/engine_routes.feature
@@ -24,7 +24,7 @@ Feature: engine routes
         end
       end
 
-      RSpec.describe MyEngine::WidgetsController, :type => :routing do
+      RSpec.describe MyEngine::WidgetsController, type: :routing do
         routes { MyEngine::Engine.routes }
 
         it "routes to the list of all widgets" do

--- a/features/routing_specs/named_routes.feature
+++ b/features/routing_specs/named_routes.feature
@@ -7,7 +7,7 @@ Feature: named routes
       """ruby
       require "rails_helper"
 
-      RSpec.describe "routes to the widgets controller", :type => :routing do
+      RSpec.describe "routes to the widgets controller", type: :routing do
         it "routes a named route" do
           expect(:get => new_widget_path).
             to route_to(:controller => "widgets", :action => "new")

--- a/features/routing_specs/route_to_matcher.feature
+++ b/features/routing_specs/route_to_matcher.feature
@@ -15,7 +15,7 @@ Feature: route_to matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe "routes for Widgets", :type => :routing do
+      RSpec.describe "routes for Widgets", type: :routing do
         it "routes /widgets to the widgets controller" do
           expect(get("/widgets")).
             to route_to("widgets#index")
@@ -31,7 +31,7 @@ Feature: route_to matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe "routes for Widgets", :type => :routing do
+      RSpec.describe "routes for Widgets", type: :routing do
         it "routes /widgets to the widgets controller" do
           expect(:get => "/widgets").
             to route_to(:controller => "widgets", :action => "index")
@@ -47,7 +47,7 @@ Feature: route_to matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe "routes for Widgets", :type => :routing do
+      RSpec.describe "routes for Widgets", type: :routing do
         it "routes /widgets/foo to the /foo action" do
           expect(get("/widgets/foo")).to route_to("widgets#foo")
         end
@@ -62,7 +62,7 @@ Feature: route_to matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe "routes for Widgets", :type => :routing do
+      RSpec.describe "routes for Widgets", type: :routing do
         it "routes /admin/accounts to the admin/accounts controller" do
           expect(get("/admin/accounts")).
             to route_to("admin/accounts#index")
@@ -78,7 +78,7 @@ Feature: route_to matcher
      """ruby
      require "rails_helper"
 
-     RSpec.describe "routes for Widgets", :type => :routing do
+     RSpec.describe "routes for Widgets", type: :routing do
        it "routes /admin/accounts to the admin/accounts controller" do
          expect(get("/admin/accounts")).
            to route_to(:controller => "admin/accounts", :action => "index")

--- a/features/system_specs/system_specs.feature
+++ b/features/system_specs/system_specs.feature
@@ -11,7 +11,7 @@ Feature: System spec
     > Chrome browser, and a screen size of 1400x1400. The next section explains
     > how to change the default settings.
 
-    System specs are marked by setting type to :system, e.g. `:type => :system`.
+    System specs are marked by setting type to :system, e.g. `type: :system`.
 
     The Capybara gem is automatically required, and Rails includes it in
     generated application Gemfiles. Configure a webserver (e.g.
@@ -30,7 +30,7 @@ Feature: System spec
           """ruby
           require "rails_helper"
 
-          RSpec.describe "Widget management", :type => :system do
+          RSpec.describe "Widget management", type: :system do
             before do
               driven_by(:rack_test)
             end
@@ -63,7 +63,7 @@ Feature: System spec
         end
       end
 
-      RSpec.describe "spec/system/some_job_system_spec.rb", :type => :system do
+      RSpec.describe "spec/system/some_job_system_spec.rb", type: :system do
         describe "#perform_later" do
           before do
             ActiveJob::Base.queue_adapter = :inline
@@ -88,7 +88,7 @@ Feature: System spec
           """ruby
           require "rails_helper"
 
-          RSpec.describe "Widget management", :type => :system do
+          RSpec.describe "Widget management", type: :system do
             before do
               driven_by(:selenium_chrome_headless)
             end

--- a/features/view_specs/view_spec.feature
+++ b/features/view_specs/view_spec.feature
@@ -1,6 +1,6 @@
 Feature: view spec
 
-  View specs are marked by `:type => :view`
+  View specs are marked by `type: :view`
   or if you have set `config.infer_spec_type_from_file_location!`
   by placing them in `spec/views`.
 

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "Configuration" do
     end
   end
 
-  it "metadata `:type => :controller` sets up controller example groups" do
+  it "metadata `type: :controller` sets up controller example groups" do
     a_controller_class = Class.new
     stub_const "SomeController", a_controller_class
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -43,18 +43,18 @@ RSpec.shared_examples_for "an rspec-rails example group mixin" do |type, *paths|
           expect(group.included_modules).to include(mixin)
         end
 
-        it "tags groups in that directory with `:type => #{type.inspect}`" do
+        it "tags groups in that directory with `type: #{type.inspect}`" do
           group = define_group_in path, "RSpec.describe"
           expect(group.metadata).to include(type: type)
         end
 
         it "allows users to override the type" do
-          group = define_group_in path, "RSpec.describe 'group', :type => :other"
+          group = define_group_in path, "RSpec.describe 'group', type: :other"
           expect(group.metadata).to include(type: :other)
           expect(group.included_modules).not_to include(mixin)
         end
 
-        it "applies configured `before(:context)` hooks with `:type => #{type.inspect}` metadata" do
+        it "applies configured `before(:context)` hooks with `type: #{type.inspect}` metadata" do
           block_run = false
           RSpec.configuration.before(:context, type: type) { block_run = true }
 
@@ -66,15 +66,15 @@ RSpec.shared_examples_for "an rspec-rails example group mixin" do |type, *paths|
       end
     end
 
-    it "includes itself in example groups tagged with `:type => #{type.inspect}`" do
-      group = define_group_in "spec/other", "RSpec.describe 'group', :type => #{type.inspect}"
+    it "includes itself in example groups tagged with `type: #{type.inspect}`" do
+      group = define_group_in "spec/other", "RSpec.describe 'group', type: #{type.inspect}"
       expect(group.included_modules).to include(mixin)
     end
   end
 
   context 'when `infer_spec_type_from_file_location!` is not configured' do
-    it "includes itself in example groups tagged with `:type => #{type.inspect}`" do
-      group = define_group_in "spec/other", "RSpec.describe 'group', :type => #{type.inspect}"
+    it "includes itself in example groups tagged with `type: #{type.inspect}`" do
+      group = define_group_in "spec/other", "RSpec.describe 'group', type: #{type.inspect}"
       expect(group.included_modules).to include(mixin)
     end
 
@@ -85,7 +85,7 @@ RSpec.shared_examples_for "an rspec-rails example group mixin" do |type, *paths|
           expect(group.included_modules).not_to include(mixin)
         end
 
-        it "does not tag groups in that directory with `:type => #{type.inspect}`" do
+        it "does not tag groups in that directory with `type: #{type.inspect}`" do
           group = define_group_in path, "RSpec.describe"
           expect(group.metadata).not_to include(:type)
         end


### PR DESCRIPTION
Fixed rockets syntax that was still in use.