### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
       matrix:
        include:
          # Edge Rails (7.1) builds >= 2.7
+         - ruby: 3.2
+           allow_failure: true
+           env:
+             RAILS_VERSION: 'main'
          - ruby: 3.1
            allow_failure: true
            env:
@@ -47,6 +51,9 @@ jobs:
              RAILS_VERSION: 'main'
 
          # Rails 7.0 builds >= 2.7
+         - ruby: 3.2
+           env:
+             RAILS_VERSION: '~> 7.0.0'
          - ruby: 3.1
            env:
              RAILS_VERSION: '~> 7.0.0'

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -57,6 +57,14 @@ function is_mri_2plus {
   fi
 }
 
+function is_ruby_26_plus {
+  if ruby -e "exit(RUBY_VERSION.to_f >= 2.6)"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 function is_ruby_23_plus {
   if ruby -e "exit(RUBY_VERSION.to_f >= 2.3)"; then
     return 0

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -5,9 +5,13 @@
 set -e
 source script/functions.sh
 
-if is_ruby_23_plus; then
+if is_ruby_26_plus; then
   gem update --no-document --system
   gem install --no-document bundler
+elif is_ruby_23_plus; then
+  echo "Warning installing older versions of Rubygems / Bundler"
+  gem update --system '3.3.26'
+  gem install bundler -v '2.3.26'
 else
   echo "Warning installing older versions of Rubygems / Bundler"
   gem update --system '2.7.10'


### PR DESCRIPTION
This PR is add Ruby 3.2 to the CI matrix
Because Ruby 3.2.0 is now in general release, it makes sense to add Ruby 3.2 to the CI matrix.

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/