### PR TITLE
Don't mutate ActionView::PathSet [6-0-maintenance backport]

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -127,11 +127,11 @@ module RSpec
       # @private
       module EmptyTemplates
         def prepend_view_path(new_path)
-          lookup_context.view_paths.unshift(*_path_decorator(*new_path))
+          super(_path_decorator(*new_path))
         end
 
         def append_view_path(new_path)
-          lookup_context.view_paths.push(*_path_decorator(*new_path))
+          super(_path_decorator(*new_path))
         end
 
       private


### PR DESCRIPTION
https://github.com/rspec/rspec-rails/pull/2631 comprised two commits; the second was backported to 6-0-maintenance as https://github.com/rspec/rspec-rails/commit/bd2bb24373f2343b9d60027cf0aeb4ce791bd8df, but the first wasn't.

CI on 6-0-maintenance is still failing for Rails main:
https://github.com/rspec/rspec-rails/actions/runs/3345336900/jobs/5540735966#step:7:50