### PR TITLE
Fix for build auto-cancel: limit to only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 permissions:
   contents: read
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Multiple `main` builds were also cancelled.

See https://github.com/rubocop/rubocop/pull/11414 for more context.

Follow-up to https://github.com/rspec/rspec-rails/pull/2652