### PR TITLE
Fix RuboCop offenses in rails_helper.rb template

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 <% if RSpec::Rails::FeatureCheck.has_active_record_migration? -%>
 # Checks for pending migrations and applies them before tests are run.

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+# Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 <% if RSpec::Rails::FeatureCheck.has_active_record_migration? -%>
 # Checks for pending migrations and applies them before tests are run.


### PR DESCRIPTION
Rubocop:

```Rails/FilePath: Prefer Rails.root.join('path/to').```
~```Lint/RedundantDirGlobSort: Remove redundant sort.```~