### PR TITLE
Fix deprecated TestFixtures#fixture_path call

### DIFF
--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -21,7 +21,12 @@ module RSpec
           if RSpec.configuration.use_active_record?
             include Fixtures
 
-            self.fixture_path = RSpec.configuration.fixture_path
+            # TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2
+            if respond_to?(:fixture_paths=)
+              fixture_paths << RSpec.configuration.fixture_path
+            else
+              self.fixture_path = RSpec.configuration.fixture_path
+            end
             self.use_transactional_tests = RSpec.configuration.use_transactional_fixtures
             self.use_instantiated_fixtures = RSpec.configuration.use_instantiated_fixtures
 

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -164,8 +164,14 @@ RSpec.describe "Configuration" do
 
       group = RSpec.describe("Arbitrary Description", :use_fixtures)
 
-      expect(group).to respond_to(:fixture_path)
-      expect(group.fixture_path).to eq("custom/path")
+      if ::Rails::VERSION::MAJOR < 7
+        expect(group).to respond_to(:fixture_path)
+        expect(group.fixture_path).to eq("custom/path")
+      else
+        expect(group).to respond_to(:fixture_paths)
+        expect(group.fixture_paths).to include("custom/path")
+      end
+
       expect(group.new.respond_to?(:foo, true)).to be(true)
     end
   end

--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe "Configuration" do
 
       group = RSpec.describe("Arbitrary Description", :use_fixtures)
 
-      if ::Rails::VERSION::MAJOR < 7
+      if ::Rails::VERSION::STRING < '7.1.0'
         expect(group).to respond_to(:fixture_path)
         expect(group.fixture_path).to eq("custom/path")
       else


### PR DESCRIPTION
Fixes this error message from showing up when running Rails edge:

```
DEPRECATION WARNING: TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2. Use #fixture_paths instead. (called from block in <module:FixtureSupport> at /Users/nsimmons/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rspec-rails-6.0.1/lib/rspec/rails/fixture_support.rb:24)
```

Closes #2661 