### PR TITLE
fix deprecation failure with rails 7.1

### DIFF
--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -21,7 +21,7 @@ module RSpec
           if RSpec.configuration.use_active_record?
             include Fixtures
 
-            self.fixture_path = RSpec.configuration.fixture_path
+            self.fixture_paths = RSpec.configuration.fixture_path
             self.use_transactional_tests = RSpec.configuration.use_transactional_fixtures
             self.use_instantiated_fixtures = RSpec.configuration.use_instantiated_fixtures
 


### PR DESCRIPTION
DEPRECATION WARNING: TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2. Use #fixture_paths instead. (called from block in <module:FixtureSupport> at /home/mathieu/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/bundler/gems/rspec-rails-70984c1ab6a2/lib/rspec/rails/fixture_support.rb:24)