### PR TITLE
Fix a spec on Rails edge

### DIFF
--- a/spec/rspec/rails/matchers/be_valid_spec.rb
+++ b/spec/rspec/rails/matchers/be_valid_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "be_valid matcher" do
   it "includes the error messages in the failure message" do
     expect {
       expect(post).to be_valid
-    }.to raise_exception(/Title can't be blank/)
+    }.to raise_exception(/Title can.t be blank/)
   end
 
   it "includes the error messages for simple implementations of error messages" do


### PR DESCRIPTION
E.g. https://github.com/rspec/rspec-rails/actions/runs/4737397779/jobs/8410153979?pr=2664

```
expected /Title can't be blank/, got #<RSpec::Expectations::ExpectationNotMetError: expected #<Post:0x000055d41c8941d0 @validation_context=nil, @errors=#<ActiveModel::Errors [#<ActiveModel::Error attribute=title, type=blank, options={}>]>> to be valid, but got errors: Title can’t be blank>
```

The difference is in the typographic quote:
https://github.com/rails/rails/commit/da82e587f2a3fdc7625e23ccc5ef2814bad74d8f#diff-78b236371af76b069c91eedb316bb68bfe71ab6bd1850f7c5a4c9291eaa13c79R16