### PR TITLE
Fixes issue with ActiveStorage::FixtureSet.blob causing a TypeError

### DIFF
--- a/features/file_fixture.feature
+++ b/features/file_fixture.feature
@@ -36,3 +36,22 @@ Feature: Using `file_fixture`
       """
     When I run `rspec spec/lib/file_spec.rb`
     Then the examples should all pass
+
+  @rails_post_7
+  Scenario: Creating a ActiveStorage::Blob from a file fixture
+    Given a file named "spec/fixtures/files/sample.txt" with:
+      """
+      Hello
+      """
+    And a file named "spec/lib/fixture_set_blob.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe "blob" do
+        it "creates a blob from a sample file" do
+          expect(ActiveStorage::FixtureSet.blob(filename: "sample.txt")).to include("sample.txt")
+        end
+      end
+      """
+    When I run `rspec spec/lib/fixture_set_blob.rb`
+    Then the examples should all pass

--- a/features/support/rails_versions.rb
+++ b/features/support/rails_versions.rb
@@ -1,0 +1,15 @@
+def rails_version
+  string_version = ENV.fetch("RAILS_VERSION", "~> 7.0.0")
+  if string_version == "main" || string_version.nil?
+    Float::INFINITY
+  else
+    string_version[/\d[.-]\d/].tr('-', '.')
+  end
+end
+
+Before "@rails_post_7" do |scenario|
+  if rails_version.to_f < 7.0
+    warn "Skipping scenario #{scenario.name} on Rails v#{rails_version}"
+    skip_this_scenario
+  end
+end

--- a/lib/rspec/rails/file_fixture_support.rb
+++ b/lib/rspec/rails/file_fixture_support.rb
@@ -9,6 +9,9 @@ module RSpec
 
       included do
         self.file_fixture_path = RSpec.configuration.file_fixture_path
+        if defined?(ActiveStorage::FixtureSet)
+          ActiveStorage::FixtureSet.file_fixture_path = RSpec.configuration.file_fixture_path
+        end
       end
     end
   end


### PR DESCRIPTION
This PR fixes an issue where calling `ActiveStorage::FixtureSet.blob` will error with `TypeError: no implicit conversion of nil into String` because the `blob` method expects `ActiveStorage::FixtureSet.file_fixture_path` to be set.

This PR adds a default value to `ActiveStorage::FixtureSet.file_fixture_path`, fixing the issue. It checks to see if it is defined because this is a new feature of Rails 7.

More information can be found in  #2637.
fixes #2637