### PR TITLE
Fix Rails edge deprecation warning

### DIFF
--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -48,7 +48,7 @@ require_file_stub 'config/environment' do
           config.action_mailer.show_previews = (ENV['SHOW_PREVIEWS'] == 'true')
         end
 
-        config.active_record.legacy_connection_handling = false if Rails::VERSION::STRING >= '7'
+        config.active_record.legacy_connection_handling = false if Rails::VERSION::STRING.start_with?('7.0')
       end
     end
 


### PR DESCRIPTION
See e.g. https://github.com/rspec/rspec-rails/actions/runs/4746930554/jobs/8431194845

```
       -:io => (be blank),
       +:io => "/home/runner/work/rspec-rails/bundle/ruby/3.2.0/gems/rack-3.0.7/lib/rack/chunked.rb:6: warning: Rack::Chunked is deprecated and will be removed in Rack 3.1\n/home/runner/work/rspec-rails/bundle/ruby/3.2.0/bundler/gems/rails-795d52473740/activerecord/lib/active_record.rb:242:in `legacy_connection_handling=': The `legacy_connection_handling` setter was deprecated in 7.0 and removed in 7.1, but is still defined in your configuration. Please remove this call as it no longer has any effect.\" (ArgumentError)\n\tfrom /home/runner/work/rspec-rails/bundle/ruby/3.2.0/bundler/gems/rails-795d52473740/activerecord/lib/active_record/railtie.rb:270:in `block (3 levels) in <class:Railtie>'\n\tfrom /home/runner/work/rspec-rails/bundle/ruby/3.2.0
```

According to
https://guides.rubyonrails.org/configuring.html#default-values-for-target-version-6-1,
it would have been `false` by default anyway.