### PR TITLE
Add fixture_paths configuration setting

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -36,6 +36,10 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
 <% if ::Rails::VERSION::STRING < "7.1.0" -%>
   config.fixture_path = Rails.root.join('spec/fixtures')
+  # Starting with Rails 7.1, use this instead:
+  # config.fixture_paths = [
+  #  Rails.root.join('spec/fixtures')
+  # ]
 <% else -%>
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -34,7 +34,13 @@ end
 RSpec.configure do |config|
 <% if RSpec::Rails::FeatureCheck.has_active_record? -%>
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+<% if ::Rails::VERSION::STRING < "7.1.0" -%>
   config.fixture_path = Rails.root.join('spec/fixtures')
+<% else -%>
+  config.fixture_paths = [
+    Rails.root.join('spec/fixtures')
+  ]
+<% end -%>
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -166,7 +166,7 @@ module RSpec
 
         # @deprecated TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2
         if ::Rails::VERSION::STRING >= "7.1.0"
-          def config.fixture_path=(path)
+          def fixture_path=(path)
             RSpec.deprecate(
               "config.fixture_path =  #{path.inspect}",
               replacement: "config.fixture_paths = [#{path.inspect}]",

--- a/lib/rspec/rails/fixture_file_upload_support.rb
+++ b/lib/rspec/rails/fixture_file_upload_support.rb
@@ -14,6 +14,8 @@ module RSpec
         resolved_fixture_path =
           if respond_to?(:file_fixture_path) && !file_fixture_path.nil?
             file_fixture_path.to_s
+          elsif respond_to?(:fixture_paths)
+            (RSpec.configuration.fixture_paths&.first || '').to_s
           else
             (RSpec.configuration.fixture_path || '').to_s
           end
@@ -26,7 +28,11 @@ module RSpec
         include ActiveSupport::Testing::FileFixtures
 
         class << self
-          attr_accessor :fixture_path
+          if ::Rails::VERSION::STRING < "7.1.0"
+            attr_accessor :fixture_path
+          else
+            attr_accessor :fixture_paths
+          end
 
           # Get instance of wrapper
           def instance

--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -23,10 +23,11 @@ module RSpec
 
             # TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2
             if respond_to?(:fixture_paths=)
-              fixture_paths << RSpec.configuration.fixture_path
+              self.fixture_paths = RSpec.configuration.fixture_paths
             else
               self.fixture_path = RSpec.configuration.fixture_path
             end
+
             self.use_transactional_tests = RSpec.configuration.use_transactional_fixtures
             self.use_instantiated_fixtures = RSpec.configuration.use_instantiated_fixtures
 

--- a/spec/generators/rspec/install/install_generator_spec.rb
+++ b/spec/generators/rspec/install/install_generator_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Rspec::Generators::InstallGenerator, type: :generator do
     match(/^  config\.fixture_path = /m)
   end
 
+  def have_fixture_paths
+    match(/^  config\.fixture_paths = /m)
+  end
+
   def maintain_test_schema
     match(/ActiveRecord::Migration\.maintain_test_schema!/m)
   end
@@ -84,7 +88,11 @@ RSpec.describe Rspec::Generators::InstallGenerator, type: :generator do
 
     specify "with default fixture path" do
       run_generator
-      expect(rails_helper).to have_a_fixture_path
+      if ::Rails::VERSION::STRING < "7.1.0"
+        expect(rails_helper).to have_a_fixture_path
+      else
+        expect(rails_helper).to have_fixture_paths
+      end
     end
 
     specify "with transactional fixtures" do
@@ -127,6 +135,7 @@ RSpec.describe Rspec::Generators::InstallGenerator, type: :generator do
     specify "without fixture path" do
       run_generator
       expect(rails_helper).not_to have_a_fixture_path
+      expect(rails_helper).not_to have_fixture_paths
     end
 
     specify "without transactional fixtures" do

--- a/spec/rspec/rails/fixture_file_upload_support_spec.rb
+++ b/spec/rspec/rails/fixture_file_upload_support_spec.rb
@@ -1,27 +1,54 @@
 module RSpec::Rails
   RSpec.describe FixtureFileUploadSupport do
-    context 'with fixture path set in config' do
-      it 'resolves fixture file' do
-        RSpec.configuration.fixture_path = File.dirname(__FILE__)
-        expect_to_pass fixture_file_upload_resolved('fixture_file_upload_support_spec.rb')
+    if ::Rails::VERSION::STRING < "7.1.0"
+      context 'with fixture path set in config' do
+        it 'resolves fixture file' do
+          RSpec.configuration.fixture_path = File.dirname(__FILE__)
+          expect_to_pass fixture_file_upload_resolved('fixture_file_upload_support_spec.rb')
+        end
+
+        it 'resolves supports `Pathname` objects' do
+          RSpec.configuration.fixture_path = Pathname(File.dirname(__FILE__))
+          expect_to_pass fixture_file_upload_resolved('fixture_file_upload_support_spec.rb')
+        end
       end
 
-      it 'resolves supports `Pathname` objects' do
-        RSpec.configuration.fixture_path = Pathname(File.dirname(__FILE__))
-        expect_to_pass fixture_file_upload_resolved('fixture_file_upload_support_spec.rb')
+      context 'with fixture path set in spec' do
+        it 'resolves fixture file' do
+          expect_to_pass fixture_file_upload_resolved('fixture_file_upload_support_spec.rb', File.dirname(__FILE__))
+        end
       end
-    end
 
-    context 'with fixture path set in spec' do
-      it 'resolves fixture file' do
-        expect_to_pass fixture_file_upload_resolved('fixture_file_upload_support_spec.rb', File.dirname(__FILE__))
+      context 'with fixture path not set' do
+        it 'resolves fixture using relative path' do
+          RSpec.configuration.fixture_path = nil
+          expect_to_pass fixture_file_upload_resolved('spec/rspec/rails/fixture_file_upload_support_spec.rb')
+        end
       end
-    end
+    else
+      context 'with fixture paths set in config' do
+        it 'resolves fixture file' do
+          RSpec.configuration.fixture_paths = [File.dirname(__FILE__)]
+          expect_to_pass fixture_file_upload_resolved('fixture_file_upload_support_spec.rb')
+        end
 
-    context 'with fixture path not set' do
-      it 'resolves fixture using relative path' do
-        RSpec.configuration.fixture_path = nil
-        expect_to_pass fixture_file_upload_resolved('spec/rspec/rails/fixture_file_upload_support_spec.rb')
+        it 'resolves supports `Pathname` objects' do
+          RSpec.configuration.fixture_paths = [Pathname(File.dirname(__FILE__))]
+          expect_to_pass fixture_file_upload_resolved('fixture_file_upload_support_spec.rb')
+        end
+      end
+
+      context 'with fixture path set in spec' do
+        it 'resolves fixture file' do
+          expect_to_pass fixture_file_upload_resolved('fixture_file_upload_support_spec.rb', File.dirname(__FILE__))
+        end
+      end
+
+      context 'with fixture path not set' do
+        it 'resolves fixture using relative path' do
+          RSpec.configuration.fixture_path = nil
+          expect_to_pass fixture_file_upload_resolved('spec/rspec/rails/fixture_file_upload_support_spec.rb')
+        end
       end
     end
 
@@ -31,11 +58,11 @@ module RSpec::Rails
       expect(result).to be true
     end
 
-    def fixture_file_upload_resolved(fixture_name, fixture_path = nil)
+    def fixture_file_upload_resolved(fixture_name, file_fixture_path = nil)
       RSpec::Core::ExampleGroup.describe do
         include RSpec::Rails::FixtureFileUploadSupport
 
-        self.file_fixture_path = fixture_path
+        self.file_fixture_path = file_fixture_path
 
         it 'supports fixture file upload' do
           file = fixture_file_upload(fixture_name)

--- a/spec/rspec/rails/fixture_support_spec.rb
+++ b/spec/rspec/rails/fixture_support_spec.rb
@@ -1,14 +1,19 @@
 module RSpec::Rails
   RSpec.describe FixtureSupport do
     context "with use_transactional_fixtures set to false" do
-      it "still supports fixture_path" do
+      it "still supports fixture_path and fixture_paths" do
         allow(RSpec.configuration).to receive(:use_transactional_fixtures) { false }
         group = RSpec::Core::ExampleGroup.describe do
           include FixtureSupport
         end
 
-        expect(group).to respond_to(:fixture_path)
-        expect(group).to respond_to(:fixture_path=)
+        if ::Rails::VERSION::STRING < "7.1.0"
+          expect(group).to respond_to(:fixture_path)
+          expect(group).to respond_to(:fixture_path=)
+        else
+          expect(group).to respond_to(:fixture_paths)
+          expect(group).to respond_to(:fixture_paths=)
+        end
       end
     end
 

--- a/spec/rspec/rails/fixture_support_spec.rb
+++ b/spec/rspec/rails/fixture_support_spec.rb
@@ -1,7 +1,7 @@
 module RSpec::Rails
   RSpec.describe FixtureSupport do
     context "with use_transactional_fixtures set to false" do
-      it "still supports fixture_path and fixture_paths" do
+      it "still supports fixture_path/fixture_paths" do
         allow(RSpec.configuration).to receive(:use_transactional_fixtures) { false }
         group = RSpec::Core::ExampleGroup.describe do
           include FixtureSupport


### PR DESCRIPTION
`ActiveRecord::TestFixtures#fixture_path` was [deprecated](https://github.com/rails/rails/commit/6902cbce1b3ea7babab588171d413b9b78cb3f0f) by Rails in 7.1 and will be removed from version 7.2.

https://github.com/rspec/rspec-rails/pull/2664 fixed the deprecation message. Here a new setting is added to the config to allow multiple paths. 
