### PR TITLE
Prefer `Pathname#glob` to `Dir.[]` at spec/rails_helper.rb template

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
+# Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 
 <% if RSpec::Rails::FeatureCheck.has_active_record_migration? -%>
 # Checks for pending migrations and applies them before tests are run.


### PR DESCRIPTION
Since `Pathname#glob` was added in Ruby 2.5, I thought it would be more concise to use this on spec/rails_helper.rb template.

Unlike `Dir.[]`, `Pathname#glob` returns an array of `Pathname`, but `Kernel.#require` works the same way if you give an `Pathname` as an argument, so I think there should be no problem about this difference here. We could add `.map(&:to_s)`, but I think that would be a bit redundant.