### PR TITLE
Allow to use symbols for broadcasting target

### DIFF
--- a/lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb
+++ b/lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb
@@ -96,8 +96,11 @@ module RSpec
         private
 
           def stream
-            @stream ||= if @target.is_a?(String)
+            @stream ||= case @target
+                        when String
                           @target
+                        when Symbol
+                          @target.to_s
                         else
                           check_channel_presence
                           @channel.broadcasting_for(@target)

--- a/spec/rspec/rails/matchers/action_cable/have_broadcasted_to_spec.rb
+++ b/spec/rspec/rails/matchers/action_cable/have_broadcasted_to_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe "have_broadcasted_to matchers", skip: !RSpec::Rails::FeatureCheck
       }.to have_broadcasted_to('stream')
     end
 
+    it "passes when using symbol target" do
+      expect {
+        broadcast(:stream, 'hello')
+      }.to have_broadcasted_to(:stream)
+    end
+
     it "passes when using alias" do
       expect {
         broadcast('stream', 'hello')


### PR DESCRIPTION
# Problem

Test below will not pass:
```ruby
# some_service.rb

class SomeService
  def call(record)
    record.broadcast_append_to(:some_records)
  end
end

# some_service_spec.rb

it "broadcasts to :some_records" do
  expect { SomeService.call(record) }.to broadcast_to(:some_records)
end
```

That is because internally rails does `String(broadcasting)`, so test below would actually pass:
```ruby
it "broadcasts to :some_records" do
  expect { SomeService.call(record) }.to broadcast_to("some_records")
end
```

Which is a bit counterintuitive.

# Proposed solution

Just `to_s` if the channel passed is a symbol. Can possibly break if someone internally checks for symbolized channel, but the matcher should work.