### PR TITLE
Adding values_match? in have_broadcasted_to checker to accept anything as a hash value when data is provided

### DIFF
--- a/lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb
+++ b/lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb
@@ -112,7 +112,7 @@ module RSpec
               decoded = ActiveSupport::JSON.decode(msg)
               decoded = decoded.with_indifferent_access if decoded.is_a?(Hash)
 
-              if @data.nil? || @data === decoded
+              if @data.nil? || values_match?(@data, decoded)
                 @block.call(decoded)
                 true
               else

--- a/spec/rspec/rails/matchers/action_cable/have_broadcasted_to_spec.rb
+++ b/spec/rspec/rails/matchers/action_cable/have_broadcasted_to_spec.rb
@@ -170,6 +170,12 @@ RSpec.describe "have_broadcasted_to matchers", skip: !RSpec::Rails::FeatureCheck
       }.to have_broadcasted_to('stream').with(a_hash_including(name: "David", id: 42))
     end
 
+    it "passes with provided data matchers with anything" do
+      expect {
+        broadcast('stream', id: 42, name: "David", message_id: 123)
+      }.to have_broadcasted_to('stream').with({ name: anything, id: anything, message_id: anything })
+    end
+
     it "generates failure message when data not match" do
       expect {
         expect {


### PR DESCRIPTION
Yesterday, while I was working on my project, when I was doing a test, I wanted to do something like
```
let(:data) do
  { hash_key: anything }
end

it 'my test' do
  expect {
    some_process
  }.to have_broadcasted_to(object).from_channel(channel).with(data)
end
```
And I got the error:
```
Expected to broadcast exactly 1 messages to channel: with {"hash_key"=>#<RSpec::Mocks::ArgumentMatchers::AnyArgMatcher:0x000000011d833ee8> }, but broadcast 0
       Broadcasted messages to channel:
          {"hash_key": hash_value }
```
After doing some research with a partner we saw that the `check` method use `===` instead of using `Support::FuzzyMatcher.values_match?` as most of the checks in rspec. For example when we use `receive().with()` rspec uses the second one.

The idea of this PR is just to change it to support the same behavior.