### PR TITLE
Allow view specs to use implicit `render locals: {...}` calls.

### DIFF
--- a/features/view_specs/view_spec.feature
+++ b/features/view_specs/view_spec.feature
@@ -153,6 +153,28 @@ Feature: View specs
     When I run `rspec spec/views`
     Then the examples should all pass
 
+  Scenario: View specs can render a template with locals
+    Given a file named "spec/views/widgets/_widget.html.erb_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe "widgets/index" do
+        it "displays the widget" do
+          widget = Widget.create!(:name => "slicer")
+
+          render :locals => {:widget => widget}
+
+          expect(rendered).to match /slicer/
+        end
+      end
+      """
+    And a file named "app/views/widgets/index.html.erb" with:
+      """
+      <h3><%= widget.name %></h3>
+      """
+    When I run `rspec spec/views`
+    Then the examples should all pass
+
   Scenario: View specs can render locals in a partial
     Given a file named "spec/views/widgets/_widget.html.erb_spec.rb" with:
       """ruby

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -65,6 +65,7 @@ module RSpec
         #     end
         def render(options = {}, local_assigns = {}, &block)
           options = _default_render_options if Hash === options && options.empty?
+          options = options.merge(_default_render_options) if Hash === options && options.keys == [:locals]
           super(options, local_assigns, &block)
         end
 


### PR DESCRIPTION
If only locals are provided when rendering a view spec, we can use _default_render_options to provide the view to render, this allows bare `render locals: {}` style calls.