### PR TITLE
Allow to use have_http_status on HTTP.rb responses too

### DIFF
--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -33,7 +33,16 @@ module RSpec
         # @param obj [Object] object to convert to a response
         # @return [ActionDispatch::TestResponse]
         def as_test_response(obj)
-          if ::ActionDispatch::Response === obj
+          if defined?(::HTTP::Response) && ::HTTP::Response === obj
+            obj = ActionDispatch::Response.new.tap do |resp|
+              resp.status  = obj.status.code
+              resp.headers.clear
+              resp.headers.merge!(obj.headers.to_h)
+              resp.body    = obj.body.to_s
+              resp.request = ActionDispatch::Request.new({})
+            end
+            ::ActionDispatch::TestResponse.from_response(obj)
+          elsif ::ActionDispatch::Response === obj
             ::ActionDispatch::TestResponse.from_response(obj)
           elsif ::ActionDispatch::TestResponse === obj
             obj


### PR DESCRIPTION
I use http.rb and wanted to test some status codes. I have used have_status_code for a while and really enjoined it. 

I haved used this patch for a litle while and think I could ask if you want it upstream
```rb
module RSpec::Rails::Matchers::HaveHttpStatus
  # Example
  # Failure/Error: expect(HTTP.get("https://www.nrk.no")).to have_http_status(:created)
  #   expected the response to have status code :created (201) but it was :ok (200)

  alias as_test_response_before_httprb_support as_test_response
  def as_test_response(obj)
    if defined?(::HTTP::Response) && ::HTTP::Response === obj
      obj = ActionDispatch::Response.new.tap do |resp|
        resp.status  = obj.status.code
        resp.headers.clear
        resp.headers.merge!(obj.headers.to_h)
        resp.body    = obj.body.to_s
        resp.request = ActionDispatch::Request.new({})
      end
      ::ActionDispatch::TestResponse.from_response(obj)
    else
      as_test_response_before_httprb_support(obj)
    end
  end
end
```
If you don't I am 100% in on that.