### PR TITLE
Fix variable name when generate scaffold with namespace & model-name

### DIFF
--- a/lib/generators/rspec/scaffold/templates/edit_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/edit_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
 RSpec.describe "<%= ns_table_name %>/edit", <%= type_metatag(:view) %> do
-  let(:<%= ns_file_name %>) {
+  let(:<%= singular_table_name %>) {
     <%= class_name %>.create!(<%= ')' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>
       <%= attribute.name %>: <%= attribute.default.inspect %><%= attribute_index == output_attributes.length - 1 ? '' : ','%>
@@ -11,13 +11,13 @@ RSpec.describe "<%= ns_table_name %>/edit", <%= type_metatag(:view) %> do
   }
 
   before(:each) do
-    assign(:<%= ns_file_name %>, <%= ns_file_name %>)
+    assign(:<%= singular_table_name %>, <%= singular_table_name %>)
   end
 
   it "renders the edit <%= ns_file_name %> form" do
     render
 
-    assert_select "form[action=?][method=?]", <%= ns_file_name %>_path(<%= ns_file_name %>), "post" do
+    assert_select "form[action=?][method=?]", <%= ns_file_name %>_path(<%= singular_table_name %>), "post" do
 <% for attribute in output_attributes -%>
       <%- name = attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>
       assert_select "<%= attribute.input_type -%>[name=?]", "<%= ns_file_name %>[<%= name %>]"

--- a/lib/generators/rspec/scaffold/templates/new_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/new_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
 RSpec.describe "<%= ns_table_name %>/new", <%= type_metatag(:view) %> do
   before(:each) do
-    assign(:<%= ns_file_name %>, <%= class_name %>.new(<%= '))' if output_attributes.empty? %>
+    assign(:<%= singular_table_name %>, <%= class_name %>.new(<%= '))' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>
       <%= attribute.name %>: <%= attribute.default.inspect %><%= attribute_index == output_attributes.length - 1 ? '' : ','%>
 <% end -%>

--- a/lib/generators/rspec/scaffold/templates/show_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/show_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
 RSpec.describe "<%= ns_table_name %>/show", <%= type_metatag(:view) %> do
   before(:each) do
-    assign(:<%= ns_file_name %>, <%= class_name %>.create!(<%= '))' if output_attributes.empty? %>
+    assign(:<%= singular_table_name %>, <%= class_name %>.create!(<%= '))' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>
       <%= attribute.name %>: <%= value_for(attribute) %><%= attribute_index == output_attributes.length - 1 ? '' : ','%>
 <% end -%>

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
         it { is_expected.to exist }
         it { is_expected.to contain(/require 'rails_helper'/) }
         it { is_expected.to contain(/^RSpec.describe "(.*)\/edit", #{type_metatag(:view)}/) }
+        it { is_expected.to contain(/assign\(:post, post\)/) }
         it { is_expected.to contain(/it "renders the edit (.*) form"/) }
       end
 
@@ -200,6 +201,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
         it { is_expected.to exist }
         it { is_expected.to contain(/require 'rails_helper'/) }
         it { is_expected.to contain(/^RSpec.describe "(.*)\/index", #{type_metatag(:view)}/) }
+        it { is_expected.to contain(/assign\(:posts, /) }
         it { is_expected.to contain(/it "renders a list of (.*)"/) }
       end
 
@@ -208,6 +210,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
         it { is_expected.to exist }
         it { is_expected.to contain(/require 'rails_helper'/) }
         it { is_expected.to contain(/^RSpec.describe "(.*)\/new", #{type_metatag(:view)}/) }
+        it { is_expected.to contain(/assign\(:post, /) }
         it { is_expected.to contain(/it "renders new (.*) form"/) }
       end
 
@@ -216,6 +219,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
         it { is_expected.to exist }
         it { is_expected.to contain(/require 'rails_helper'/) }
         it { is_expected.to contain(/^RSpec.describe "(.*)\/show", #{type_metatag(:view)}/) }
+        it { is_expected.to contain(/assign\(:post, /) }
         it { is_expected.to contain(/it "renders attributes in <p>"/) }
       end
     end
@@ -248,6 +252,62 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
         subject { file("spec/views/posts/new.html.erb_spec.rb") }
         it { is_expected.to contain(/assert_select "input\[name=\?\]", "post\[author_id\]"/) }
         it { is_expected.to contain(/assert_select "input\[name=\?\]", "post\[title\]/) }
+      end
+    end
+
+    describe 'with namespace' do
+      before { run_generator %w[admin/posts] }
+
+      describe 'edit' do
+        subject { file("spec/views/admin/posts/edit.html.erb_spec.rb") }
+        it { is_expected.to exist }
+        it { is_expected.to contain(/assign\(:admin_post, admin_post\)/) }
+      end
+
+      describe 'index' do
+        subject { file("spec/views/admin/posts/index.html.erb_spec.rb") }
+        it { is_expected.to exist }
+        it { is_expected.to contain(/assign\(:admin_posts, /) }
+      end
+
+      describe 'new' do
+        subject { file("spec/views/admin/posts/new.html.erb_spec.rb") }
+        it { is_expected.to exist }
+        it { is_expected.to contain(/assign\(:admin_post, /) }
+      end
+
+      describe 'show' do
+        subject { file("spec/views/admin/posts/show.html.erb_spec.rb") }
+        it { is_expected.to exist }
+        it { is_expected.to contain(/assign\(:admin_post, /) }
+      end
+    end
+
+    describe 'with namespace and --model-name' do
+      before { run_generator %w[admin/posts --model-name=Post] }
+
+      describe 'edit' do
+        subject { file("spec/views/admin/posts/edit.html.erb_spec.rb") }
+        it { is_expected.to exist }
+        it { is_expected.to contain(/assign\(:post, post\)/) }
+      end
+
+      describe 'index' do
+        subject { file("spec/views/admin/posts/index.html.erb_spec.rb") }
+        it { is_expected.to exist }
+        it { is_expected.to contain(/assign\(:posts, /) }
+      end
+
+      describe 'new' do
+        subject { file("spec/views/admin/posts/new.html.erb_spec.rb") }
+        it { is_expected.to exist }
+        it { is_expected.to contain(/assign\(:post, /) }
+      end
+
+      describe 'show' do
+        subject { file("spec/views/admin/posts/show.html.erb_spec.rb") }
+        it { is_expected.to exist }
+        it { is_expected.to contain(/assign\(:post, /) }
       end
     end
 


### PR DESCRIPTION
Fixes #2693 

Fix variable name in view spec when generate scaffold with namespace & model-name.