### PR TITLE
Fix failure screenshots on Rails 7.1

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -44,6 +44,49 @@ module RSpec
         ].join("_").tr(CHARS_TO_TRANSLATE.join, "_").byteslice(0...200).scrub("") + "_#{rand(1000)}"
       end
 
+      if ::Rails::VERSION::STRING.to_f >= 7.1
+        class SuppressRailsScreenshotMetadata
+          def initialize
+            @example_data = {}
+          end
+
+          def [](key)
+            if @example_data.key?(key)
+              @example_data[key]
+            else
+              raise_wrong_scope_error
+            end
+          end
+
+          def []=(key, value)
+            if key == :failure_screenshot_path
+              @example_data[key] = value
+            else
+              raise_wrong_scope_error
+            end
+          end
+
+          def method_missing(_name, *_args, &_block)
+            raise_wrong_scope_error
+          end
+
+          private
+
+          def raise_wrong_scope_error
+            raise RSpec::Core::ExampleGroup::WrongScopeError,
+                  "`metadata` is not available on an example group (e.g. a " \
+                  "`describe` or `context` block). It is only available from " \
+                  "within individual examples (e.g. `it` blocks) or from " \
+                  "constructs that run in the scope of an example (e.g. " \
+                  "`before`, `let`, etc)."
+          end
+        end
+
+        def metadata
+          @metadata ||= SuppressRailsScreenshotMetadata.new
+        end
+      end
+
       # Delegates to `Rails.application`.
       def app
         ::Rails.application


### PR DESCRIPTION
On Rails 7.1 they access metadata directly to store the failure screenshot path, we don't allow metadata access like this and it throws an error, this patch makes a dummy metadata available for this purpose, whilst still maintaining our friendly error.