### PR TITLE
Fix deprecated use of `config.action_mailer.preview_path =` in favor of `...preview_paths <<` to support Rails 7.1 upgrade

### DIFF
--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -42,7 +42,7 @@ require_file_stub 'config/environment' do
         config.action_mailer.raise_delivery_errors = false unless ENV['NO_ACTION_MAILER']
 
         if ENV['CUSTOM_PREVIEW_PATH']
-          config.action_mailer.preview_path = ENV['CUSTOM_PREVIEW_PATH']
+          config.action_mailer.preview_paths << ENV['CUSTOM_PREVIEW_PATH']
         end
         if ENV['SHOW_PREVIEWS']
           config.action_mailer.show_previews = (ENV['SHOW_PREVIEWS'] == 'true')
@@ -63,7 +63,7 @@ exit if ENV['NO_ACTION_MAILER']
 if ENV['DEFAULT_URL']
   puts ActionMailer::Base.default_url_options[:host]
 elsif defined?(::ActionMailer::Preview)
-  puts Rails.application.config.action_mailer.preview_path
+  puts Rails.application.config.action_mailer.preview_paths
 end
 
 # This will force the loading of ActionMailer settings to ensure we do not

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -48,9 +48,16 @@ module RSpec
       end
 
       def config_default_preview_paths(options)
-        return unless options.preview_paths.blank?
+        if options.respond_to?(:preview_paths)
+          return unless options.preview_paths.blank?
 
-        options.preview_paths << "#{::Rails.root}/spec/mailers/previews"
+          options.preview_paths << "#{::Rails.root}/spec/mailers/previews"
+        else
+          return unless options.preview_path.blank?
+
+          options.preview_path = "#{::Rails.root}/spec/mailers/previews"
+
+        end
       end
 
       def supports_action_mailer_previews?(config)

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -22,22 +22,22 @@ module RSpec
       end
 
       # This is called after the environment has been loaded but before Rails
-      # sets the default for the `preview_path`
+      # sets the default for the `preview_paths`
       initializer "rspec_rails.action_mailer",
                   before: "action_mailer.set_configs" do |app|
-                    setup_preview_path(app)
+                    setup_preview_paths(app)
                   end
 
     private
 
-      def setup_preview_path(app)
+      def setup_preview_paths(app)
         return unless supports_action_mailer_previews?(app.config)
 
         options = app.config.action_mailer
-        config_default_preview_path(options) if config_preview_path?(options)
+        config_default_preview_paths(options) if config_preview_paths?(options)
       end
 
-      def config_preview_path?(options)
+      def config_preview_paths?(options)
         # We cannot use `respond_to?(:show_previews)` here as it will always
         # return `true`.
         if options.show_previews.nil?
@@ -47,10 +47,10 @@ module RSpec
         end
       end
 
-      def config_default_preview_path(options)
-        return unless options.preview_path.blank?
+      def config_default_preview_paths(options)
+        return unless options.preview_paths.blank?
 
-        options.preview_path = "#{::Rails.root}/spec/mailers/previews"
+        options.preview_paths << "#{::Rails.root}/spec/mailers/previews"
       end
 
       def supports_action_mailer_previews?(config)


### PR DESCRIPTION
Fixes #2703

Also see https://github.com/rails/rails/pull/31595, particularly [this comment](https://github.com/rails/rails/pull/31595#issuecomment-1769265335)