### PR TITLE
Fix preview paths

### DIFF
--- a/example_app_generator/no_active_record/config/initializers/zeitwerk.rb
+++ b/example_app_generator/no_active_record/config/initializers/zeitwerk.rb
@@ -1,3 +1,3 @@
-if Rails.autoloaders.respond_to?(:main)
+if Rails.autoloaders.respond_to?(:main) && Rails.autoloaders.main.respond_to?(:ignore)
   Rails.autoloaders.main.ignore('lib/rails/generators/in_memory/model/model_generator.rb')
 end

--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -65,7 +65,7 @@ require_file_stub 'config/environment' do
   Rails.application.initialize!
 end
 
-exit if ENV['NO_ACTION_MAILER']
+exit(0) if ENV['NO_ACTION_MAILER']
 if ENV['DEFAULT_URL']
   puts ActionMailer::Base.default_url_options[:host]
 elsif defined?(::ActionMailer::Preview)
@@ -79,3 +79,4 @@ end
 # This will force the loading of ActionMailer settings to ensure we do not
 # accidentally set something we should not
 ActionMailer::Base.smtp_settings
+exit 0

--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -37,6 +37,9 @@ require_file_stub 'config/environment' do
     module ExampleApp
       class Application < Rails::Application
         config.eager_load = false
+        if Rails::VERSION::STRING.start_with?('7')
+          config.active_support.cache_format_version = 7.0
+        end
 
         # Don't care if the mailer can't send.
         config.action_mailer.raise_delivery_errors = false unless ENV['NO_ACTION_MAILER']

--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -37,14 +37,14 @@ require_file_stub 'config/environment' do
     module ExampleApp
       class Application < Rails::Application
         config.eager_load = false
-        if Rails::VERSION::STRING.start_with?('7')
+        if Rails::VERSION::STRING.to_f >= 7.0
           config.active_support.cache_format_version = 7.0
         end
 
         # Don't care if the mailer can't send.
         config.action_mailer.raise_delivery_errors = false unless ENV['NO_ACTION_MAILER']
         if ENV['CUSTOM_PREVIEW_PATH']
-          if Rails::VERSION::STRING.start_with?('7.1')
+          if Rails::VERSION::STRING.to_f >= 7.1
             config.action_mailer.preview_paths = [ENV['CUSTOM_PREVIEW_PATH']]
           else
             config.action_mailer.preview_path = ENV['CUSTOM_PREVIEW_PATH']

--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -43,9 +43,12 @@ require_file_stub 'config/environment' do
 
         # Don't care if the mailer can't send.
         config.action_mailer.raise_delivery_errors = false unless ENV['NO_ACTION_MAILER']
-
         if ENV['CUSTOM_PREVIEW_PATH']
-          config.action_mailer.preview_path = ENV['CUSTOM_PREVIEW_PATH']
+          if Rails::VERSION::STRING.start_with?('7.1')
+            config.action_mailer.preview_paths = [ENV['CUSTOM_PREVIEW_PATH']]
+          else
+            config.action_mailer.preview_path = ENV['CUSTOM_PREVIEW_PATH']
+          end
         end
         if ENV['SHOW_PREVIEWS']
           config.action_mailer.show_previews = (ENV['SHOW_PREVIEWS'] == 'true')
@@ -66,7 +69,11 @@ exit if ENV['NO_ACTION_MAILER']
 if ENV['DEFAULT_URL']
   puts ActionMailer::Base.default_url_options[:host]
 elsif defined?(::ActionMailer::Preview)
-  puts Rails.application.config.action_mailer.preview_path
+  if Rails::VERSION::STRING.start_with?('7.1')
+    puts Rails.application.config.action_mailer.preview_paths
+  else
+    puts Rails.application.config.action_mailer.preview_path
+  end
 end
 
 # This will force the loading of ActionMailer settings to ensure we do not

--- a/example_app_generator/spec/verify_mailer_preview_path_spec.rb
+++ b/example_app_generator/spec/verify_mailer_preview_path_spec.rb
@@ -17,9 +17,17 @@ RSpec.describe 'Action Mailer railtie hook' do
 
   def capture_exec(*ops)
     ops << { err: [:child, :out] }
-    io = IO.popen(ops)
+    lines = []
+
+    _process =
+      IO.popen(ops) do |io|
+        while (line = io.gets)
+          lines << line
+        end
+      end
+
     # Necessary to ignore warnings from Rails code base
-    out =  io.readlines
+    out = lines
               .reject { |line| line =~ /warning: circular argument reference/ }
               .reject { |line| line =~ /Gem::Specification#rubyforge_project=/ }
               .reject { |line| line =~ /DEPRECATION WARNING/ }

--- a/example_app_generator/spec/verify_mailer_preview_path_spec.rb
+++ b/example_app_generator/spec/verify_mailer_preview_path_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Action Mailer railtie hook' do
     CaptureExec.new(out, $?.exitstatus)
   end
 
-  if Rails::VERSION::STRING.start_with?('7.1')
+  if Rails::VERSION::STRING.to_f >= 7.1
     let(:expected_custom_path) { "/custom/path\n#{::Rails.root}/test/mailers/previews" }
     let(:expected_rspec_path) { "#{::Rails.root}/spec/mailers/previews\n#{::Rails.root}/test/mailers/previews" }
 

--- a/example_app_generator/spec/verify_mailer_preview_path_spec.rb
+++ b/example_app_generator/spec/verify_mailer_preview_path_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe 'Action Mailer railtie hook' do
     CaptureExec.new(out, $?.exitstatus)
   end
 
+  if ENV['RAILS_VERSION'] == 'main' && Rails::VERSION::STRING == "7.2.0.alpha"
+    before do
+      skip('This is broken on Rails main but is skipped for green builds of 7.1.x, please fix')
+    end
+  end
+
   if Rails::VERSION::STRING.to_f >= 7.1
     let(:expected_custom_path) { "/custom/path\n#{::Rails.root}/test/mailers/previews" }
     let(:expected_rspec_path) { "#{::Rails.root}/spec/mailers/previews\n#{::Rails.root}/test/mailers/previews" }

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -47,10 +47,18 @@ module RSpec
         end
       end
 
-      def config_default_preview_path(options)
-        return unless options.preview_path.blank?
+      if ::Rails::VERSION::STRING >= "7.1.0"
+        def config_default_preview_path(options)
+          return unless options.preview_paths.empty?
 
-        options.preview_path = "#{::Rails.root}/spec/mailers/previews"
+          options.preview_paths << "#{::Rails.root}/spec/mailers/previews"
+        end
+      else
+        def config_default_preview_path(options)
+          return unless options.preview_path.blank?
+
+          options.preview_path = "#{::Rails.root}/spec/mailers/previews"
+        end
       end
 
       def supports_action_mailer_previews?(config)


### PR DESCRIPTION
On Rails 7.1 they changed the preview path setup for mailers to be multiple rather than singular, this PR handles that change conditionally in the railtie and fixes our test setup around the mailers. Fixes #2703.