### PR TITLE
Fix support for namespaced fixtures with rspec-rails 6.1.0 and rails 7.1

### DIFF
--- a/lib/rspec/rails/fixture_support.rb
+++ b/lib/rspec/rails/fixture_support.rb
@@ -43,14 +43,14 @@ module RSpec
             if ::Rails.version.to_f >= 7.1
               def fixtures(*args)
                 super.tap do
-                  fixture_sets.each_key do |fixture_name|
-                    proxy_method_warning_if_called_in_before_context_scope(fixture_name)
+                  fixture_sets.each_pair do |method_name, fixture_name|
+                    proxy_method_warning_if_called_in_before_context_scope(method_name, fixture_name)
                   end
                 end
               end
 
-              def proxy_method_warning_if_called_in_before_context_scope(fixture_name)
-                define_method(fixture_name) do |*args, **kwargs, &blk|
+              def proxy_method_warning_if_called_in_before_context_scope(method_name, fixture_name)
+                define_method(method_name) do |*args, **kwargs, &blk|
                   if RSpec.current_scope == :before_context_hook
                     RSpec.warn_with("Calling fixture method in before :context ")
                   else


### PR DESCRIPTION
This pull request fixes an issue with namespaced fixtures in Rails 7.1 and RSpec Rails 6.1 as described in #2715

The problem is related to [this change](https://github.com/rspec/rspec-rails/blob/b109337c1b60ce1882208b11f887f908b70edac8/lib/rspec/rails/fixture_support.rb#L44-L60) in `fixture_support.rb`. 

The `fixtures` method is only looking at the keys of fixture sets, but I think it also needs to look at the values. The keys seem to represent the method name, and the values represent the fixture names.

It works fine for not namespaced fixtures, but the values are different for namespaced ones:

```ruby 
{
  "accounts"=>"accounts",
  "users"=>"users",
  "oauth2_access_tokens"=>"oauth2/access_tokens",
  "oauth2_refresh_tokens"=>"oauth2/refresh_tokens",   
  "oauth2_applications"=>"oauth2/applications",
}
```

Calling `access_fixture` with the method name raises the error described above, because the fixture cache is based on the fixture name (with `/` in the values). 

This pull request changes the implementation to use both `method_name` and `fixture_name`.