### PR TITLE
Fix tests to expect a non-match, not an error

### DIFF
--- a/spec/rspec/rails/matchers/be_a_new_spec.rb
+++ b/spec/rspec/rails/matchers/be_a_new_spec.rb
@@ -79,12 +79,7 @@ RSpec.describe "be_a_new matcher" do
 
           context "matcher is wrong type" do
             it "fails" do
-              expect {
-                expect(record).to be_a_new(record.class).with(
-                  foo: a_hash_including({ no_foo: "foo" }))
-              }.to raise_error { |e|
-                expect(e.message).to eq("no implicit conversion of Hash into String").or eq("can't convert Hash into String")
-              }
+              expect(record).not_to be_a_new(record.class).with(foo: a_hash_including({ no_foo: "foo" }))
             end
           end
         end


### PR DESCRIPTION
In https://github.com/rspec/rspec-expectations/pull/1449, the `Include`
matcher is fixed so that it doesn't raise an error when types don't
match. Instead, the actual and expected will be deemed to not match.
