### PR TITLE
Remove type metadata from templates

### DIFF
--- a/lib/generators/rspec/channel/templates/channel_spec.rb.erb
+++ b/lib/generators/rspec/channel/templates/channel_spec.rb.erb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>Channel, <%= type_metatag(:channel) %> do
+RSpec.describe <%= class_name %>Channel do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/lib/generators/rspec/controller/templates/controller_spec.rb
+++ b/lib/generators/rspec/controller/templates/controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>Controller, <%= type_metatag(:controller) %> do
+RSpec.describe <%= class_name %>Controller do
 
 <% for action in actions -%>
   describe "GET #<%= action %>" do

--- a/lib/generators/rspec/controller/templates/request_spec.rb
+++ b/lib/generators/rspec/controller/templates/request_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "<%= class_name.pluralize %>", <%= type_metatag(:request) %> do
+RSpec.describe "<%= class_name.pluralize %>" do
 <% namespaced_path = regular_class_path.join('/') -%>
 <% if actions.empty? -%>
   describe "GET /index" do

--- a/lib/generators/rspec/controller/templates/routing_spec.rb
+++ b/lib/generators/rspec/controller/templates/routing_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe '<%= class_name %>Controller', <%= type_metatag(:routing) %> do
+RSpec.describe '<%= class_name %>Controller' do
   describe 'routing' do
 <% for action in actions -%>
     it 'routes to #<%= action %>' do

--- a/lib/generators/rspec/controller/templates/view_spec.rb
+++ b/lib/generators/rspec/controller/templates/view_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "<%= file_name %>/<%= @action %>.html.<%= options[:template_engine] %>", <%= type_metatag(:view) %> do
+RSpec.describe "<%= file_name %>/<%= @action %>.html.<%= options[:template_engine] %>" do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/lib/generators/rspec/feature/templates/feature_singular_spec.rb
+++ b/lib/generators/rspec/feature/templates/feature_singular_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.feature "<%= class_name.singularize %>", <%= type_metatag(:feature) %> do
+RSpec.feature "<%= class_name.singularize %>" do
   pending "add some scenarios (or delete) #{__FILE__}"
 end

--- a/lib/generators/rspec/feature/templates/feature_spec.rb
+++ b/lib/generators/rspec/feature/templates/feature_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.feature "<%= class_name.pluralize %>", <%= type_metatag(:feature) %> do
+RSpec.feature "<%= class_name.pluralize %>" do
   pending "add some scenarios (or delete) #{__FILE__}"
 end

--- a/lib/generators/rspec/generator/templates/generator_spec.rb
+++ b/lib/generators/rspec/generator/templates/generator_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "<%= class_name.pluralize %>", <%= type_metatag(:generator) %> do
+RSpec.describe "<%= class_name.pluralize %>" do
 
   pending "add some scenarios (or delete) #{__FILE__}"
 end

--- a/lib/generators/rspec/helper/templates/helper_spec.rb
+++ b/lib/generators/rspec/helper/templates/helper_spec.rb
@@ -11,7 +11,7 @@ require 'rails_helper'
 #   end
 # end
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>Helper, <%= type_metatag(:helper) %> do
+RSpec.describe <%= class_name %>Helper do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/lib/generators/rspec/job/templates/job_spec.rb.erb
+++ b/lib/generators/rspec/job/templates/job_spec.rb.erb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %><%= "Job" unless class_name.end_with?("Job")%>, <%= type_metatag(:job) %> do
+RSpec.describe <%= class_name %><%= "Job" unless class_name.end_with?("Job")%> do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/lib/generators/rspec/mailbox/templates/mailbox_spec.rb.erb
+++ b/lib/generators/rspec/mailbox/templates/mailbox_spec.rb.erb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>Mailbox, <%= type_metatag(:mailbox) %> do
+RSpec.describe <%= class_name %>Mailbox do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/lib/generators/rspec/mailer/templates/mailer_spec.rb
+++ b/lib/generators/rspec/mailer/templates/mailer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name.sub(/(Mailer)?$/, 'Mailer') %>, <%= type_metatag(:mailer) %> do
+RSpec.describe <%= class_name.sub(/(Mailer)?$/, 'Mailer') %> do
 <% for action in actions -%>
   describe "<%= action %>" do
     let(:mail) { <%= class_name.sub(/(Mailer)?$/, 'Mailer') %>.<%= action %> }

--- a/lib/generators/rspec/model/templates/model_spec.rb
+++ b/lib/generators/rspec/model/templates/model_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% module_namespacing do -%>
-RSpec.describe <%= class_name %>, <%= type_metatag(:model) %> do
+RSpec.describe <%= class_name %> do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>

--- a/lib/generators/rspec/request/templates/request_spec.rb
+++ b/lib/generators/rspec/request/templates/request_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "<%= class_name.pluralize %>", <%= type_metatag(:request) %> do
+RSpec.describe "<%= class_name.pluralize %>" do
   describe "GET /<%= name.underscore.pluralize %>" do
     it "works! (now write some real specs)" do
       get <%= index_helper %>_path

--- a/lib/generators/rspec/scaffold/templates/api_controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/api_controller_spec.rb
@@ -24,7 +24,7 @@ require 'rails_helper'
 # `rails-controller-testing` gem.
 
 <% module_namespacing do -%>
-RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:controller) %> do
+RSpec.describe <%= controller_class_name %>Controller do
 
   # This should return the minimal set of attributes required to create a valid
   # <%= class_name %>. As you add validations to <%= class_name %>, be sure to

--- a/lib/generators/rspec/scaffold/templates/api_request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/api_request_spec.rb
@@ -13,7 +13,7 @@ require 'rails_helper'
 # sticking to rails and rspec-rails APIs to keep things simple and stable.
 
 <% module_namespacing do -%>
-RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %> do
+RSpec.describe "/<%= name.underscore.pluralize %>" do
   # This should return the minimal set of attributes required to create a valid
   # <%= class_name %>. As you add validations to <%= class_name %>, be sure to
   # adjust the attributes here as well.

--- a/lib/generators/rspec/scaffold/templates/controller_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/controller_spec.rb
@@ -24,7 +24,7 @@ require 'rails_helper'
 # `rails-controller-testing` gem.
 
 <% module_namespacing do -%>
-RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:controller) %> do
+RSpec.describe <%= controller_class_name %>Controller do
 
   # This should return the minimal set of attributes required to create a valid
   # <%= class_name %>. As you add validations to <%= class_name %>, be sure to

--- a/lib/generators/rspec/scaffold/templates/edit_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/edit_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-RSpec.describe "<%= ns_table_name %>/edit", <%= type_metatag(:view) %> do
+RSpec.describe "<%= ns_table_name %>/edit" do
   let(:<%= singular_table_name %>) {
     <%= class_name %>.create!(<%= ')' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>

--- a/lib/generators/rspec/scaffold/templates/index_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/index_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-RSpec.describe "<%= ns_table_name %>/index", <%= type_metatag(:view) %> do
+RSpec.describe "<%= ns_table_name %>/index" do
   before(:each) do
     assign(:<%= table_name %>, [
 <% [1,2].each_with_index do |id, model_index| -%>

--- a/lib/generators/rspec/scaffold/templates/new_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/new_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-RSpec.describe "<%= ns_table_name %>/new", <%= type_metatag(:view) %> do
+RSpec.describe "<%= ns_table_name %>/new" do
   before(:each) do
     assign(:<%= singular_table_name %>, <%= class_name %>.new(<%= '))' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>

--- a/lib/generators/rspec/scaffold/templates/request_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/request_spec.rb
@@ -13,7 +13,7 @@ require 'rails_helper'
 # sticking to rails and rspec-rails APIs to keep things simple and stable.
 
 <% module_namespacing do -%>
-RSpec.describe "/<%= name.underscore.pluralize %>", <%= type_metatag(:request) %> do
+RSpec.describe "/<%= name.underscore.pluralize %>" do
   <% if mountable_engine? -%>
     include Engine.routes.url_helpers
   <% end -%>

--- a/lib/generators/rspec/scaffold/templates/routing_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/routing_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 <% module_namespacing do -%>
-RSpec.describe <%= controller_class_name %>Controller, <%= type_metatag(:routing) %> do
+RSpec.describe <%= controller_class_name %>Controller do
   describe "routing" do
 <% unless options[:singleton] -%>
     it "routes to #index" do

--- a/lib/generators/rspec/scaffold/templates/show_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/show_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 <% output_attributes = attributes.reject{|attribute| [:datetime, :timestamp, :time, :date].index(attribute.type) } -%>
-RSpec.describe "<%= ns_table_name %>/show", <%= type_metatag(:view) %> do
+RSpec.describe "<%= ns_table_name %>/show" do
   before(:each) do
     assign(:<%= singular_table_name %>, <%= class_name %>.create!(<%= '))' if output_attributes.empty? %>
 <% output_attributes.each_with_index do |attribute, attribute_index| -%>

--- a/lib/generators/rspec/system/templates/system_spec.rb
+++ b/lib/generators/rspec/system/templates/system_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "<%= class_name.pluralize %>", <%= type_metatag(:system) %> do
+RSpec.describe "<%= class_name.pluralize %>" do
   before do
     driven_by(:rack_test)
   end

--- a/lib/generators/rspec/view/templates/view_spec.rb
+++ b/lib/generators/rspec/view/templates/view_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "<%= file_path %>/<%= @action %>", <%= type_metatag(:view) %> do
+RSpec.describe "<%= file_path %>/<%= @action %>" do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/lib/rspec/rails/feature_check.rb
+++ b/lib/rspec/rails/feature_check.rb
@@ -42,10 +42,6 @@ module RSpec
       def has_action_mailbox?
         defined?(::ActionMailbox)
       end
-
-      def type_metatag(type)
-        "type: :#{type}"
-      end
     end
   end
 end

--- a/spec/generators/rspec/channel/channel_generator_spec.rb
+++ b/spec/generators/rspec/channel/channel_generator_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Rspec::Generators::ChannelGenerator, type: :generator, skip: !RSp
   subject(:channel_spec) { file("spec/channels/chat_channel_spec.rb") }
 
   it "generates a channel spec file" do
-    expect(channel_spec).to contain(/require 'rails_helper'/).and(contain(/describe ChatChannel, #{type_metatag(:channel)}/))
+    expect(channel_spec).to contain(/require 'rails_helper'/).and(contain(/describe ChatChannel/))
   end
 end

--- a/spec/generators/rspec/controller/controller_generator_spec.rb
+++ b/spec/generators/rspec/controller/controller_generator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Rspec::Generators::ControllerGenerator, type: :generator do
 
       it 'includes the standard boilerplate' do
         expect(filename).to contain(/require 'rails_helper'/)
-                              .and(contain(/^RSpec.describe "Posts", #{type_metatag(:request)}/))
+                              .and(contain(/^RSpec.describe "Posts"/))
                               .and(contain('pending'))
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe Rspec::Generators::ControllerGenerator, type: :generator do
       end
 
       it 'includes the standard boilerplate' do
-        expect(filename).to contain(/^RSpec.describe "Admin::External::Users", #{type_metatag(:request)}/)
+        expect(filename).to contain(/^RSpec.describe "Admin::External::Users"/)
                              .and(contain('get "/admin/external/users/index"'))
                              .and(contain('get "/admin/external/users/custom_action"'))
       end
@@ -112,7 +112,7 @@ RSpec.describe Rspec::Generators::ControllerGenerator, type: :generator do
 
           it 'includes the standard boilerplate' do
             expect(filename).to contain(/require 'rails_helper'/)
-                                 .and(contain(/^RSpec.describe "posts\/index.html.erb", #{type_metatag(:view)}/))
+                                 .and(contain(/^RSpec.describe "posts\/index.html.erb"/))
           end
         end
 
@@ -121,7 +121,7 @@ RSpec.describe Rspec::Generators::ControllerGenerator, type: :generator do
 
           it 'includes the standard boilerplate' do
             expect(filename).to contain(/require 'rails_helper'/)
-                                 .and(contain(/^RSpec.describe "posts\/show.html.erb", #{type_metatag(:view)}/))
+                                 .and(contain(/^RSpec.describe "posts\/show.html.erb"/))
           end
         end
       end
@@ -136,7 +136,7 @@ RSpec.describe Rspec::Generators::ControllerGenerator, type: :generator do
 
           it 'includes the standard boilerplate' do
             expect(filename).to contain(/require 'rails_helper'/)
-                                 .and(contain(/^RSpec.describe "posts\/index.html.haml", #{type_metatag(:view)}/))
+                                 .and(contain(/^RSpec.describe "posts\/index.html.haml"/))
           end
         end
       end
@@ -180,7 +180,7 @@ RSpec.describe Rspec::Generators::ControllerGenerator, type: :generator do
 
         it 'includes the standard boilerplate' do
           expect(filename).to contain(/require 'rails_helper'/)
-                                .and(contain(/^RSpec.describe 'PostsController', #{type_metatag(:routing)}/))
+                                .and(contain(/^RSpec.describe 'PostsController'/))
                                 .and(contain(/describe 'routing'/))
                                 .and(contain(/it 'routes to #seek'/))
                                 .and(contain(/expect\(get: "\/posts\/seek"\).to route_to\("posts#seek"\)/))
@@ -214,7 +214,7 @@ RSpec.describe Rspec::Generators::ControllerGenerator, type: :generator do
       describe 'the spec' do
         it 'includes the standard boilerplate' do
           expect(filename).to contain(/require 'rails_helper'/)
-                               .and(contain(/^RSpec.describe PostsController, #{type_metatag(:controller)}/))
+                               .and(contain(/^RSpec.describe PostsController/))
         end
       end
     end

--- a/spec/generators/rspec/feature/feature_generator_spec.rb
+++ b/spec/generators/rspec/feature/feature_generator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Rspec::Generators::FeatureGenerator, type: :generator do
         it 'includes the standard boilerplate' do
           expect(
             feature_spec
-          ).to contain(/require 'rails_helper'/).and(contain(/^RSpec.feature "Posts", #{type_metatag(:feature)}/))
+          ).to contain(/require 'rails_helper'/).and(contain(/^RSpec.feature "Posts"/))
         end
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe Rspec::Generators::FeatureGenerator, type: :generator do
         subject(:feature_spec) { file('spec/features/folder/posts_spec.rb') }
 
         it 'includes the standard boilerplate' do
-          expect(feature_spec).to contain(/^RSpec.feature "Folder::Posts", #{type_metatag(:feature)}/)
+          expect(feature_spec).to contain(/^RSpec.feature "Folder::Posts"/)
         end
       end
     end
@@ -45,7 +45,7 @@ RSpec.describe Rspec::Generators::FeatureGenerator, type: :generator do
         subject(:feature_spec) { file('spec/features/post_spec.rb') }
 
         it "contains the singularized feature" do
-          expect(feature_spec).to contain(/^RSpec.feature "Post", #{type_metatag(:feature)}/)
+          expect(feature_spec).to contain(/^RSpec.feature "Post"/)
         end
       end
     end

--- a/spec/generators/rspec/generator/generator_generator_spec.rb
+++ b/spec/generators/rspec/generator/generator_generator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Rspec::Generators::GeneratorGenerator, type: :generator do
     end
 
     it "include the standard boilerplate" do
-      expect(generator_spec).to contain(/require 'rails_helper'/).and(contain(/^RSpec.describe "Posts", #{type_metatag(:generator)}/))
+      expect(generator_spec).to contain(/require 'rails_helper'/).and(contain(/^RSpec.describe "Posts"/))
     end
   end
 end

--- a/spec/generators/rspec/helper/helper_generator_spec.rb
+++ b/spec/generators/rspec/helper/helper_generator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Rspec::Generators::HelperGenerator, type: :generator do
     end
 
     it 'includes the standard boilerplate' do
-      expect(helper_spec).to contain(/require 'rails_helper'/).and(contain(/^RSpec.describe PostsHelper, #{type_metatag(:helper)}/))
+      expect(helper_spec).to contain(/require 'rails_helper'/).and(contain(/^RSpec.describe PostsHelper/))
     end
   end
 

--- a/spec/generators/rspec/job/job_generator_spec.rb
+++ b/spec/generators/rspec/job/job_generator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Rspec::Generators::JobGenerator, type: :generator, skip: !RSpec::
       let(:file_name) { 'user' }
 
       it 'creates the standard boiler plate' do
-        expect(job_spec).to contain(/require 'rails_helper'/).and(contain(/describe UserJob, #{type_metatag(:job)}/))
+        expect(job_spec).to contain(/require 'rails_helper'/).and(contain(/describe UserJob/))
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe Rspec::Generators::JobGenerator, type: :generator, skip: !RSpec::
       let(:file_name) { 'user_job' }
 
       it 'creates the standard boiler plate' do
-        expect(job_spec).to contain(/require 'rails_helper'/).and(contain(/describe UserJob, #{type_metatag(:job)}/))
+        expect(job_spec).to contain(/require 'rails_helper'/).and(contain(/describe UserJob/))
       end
     end
   end

--- a/spec/generators/rspec/mailbox/mailbox_generator_spec.rb
+++ b/spec/generators/rspec/mailbox/mailbox_generator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Rspec::Generators::MailboxGenerator, type: :generator, skip: !RSp
     it 'generates the file' do
       expect(
         mailbox_spec
-      ).to contain(/require 'rails_helper'/).and contain(/describe ForwardsMailbox, #{type_metatag(:mailbox)}/)
+      ).to contain(/require 'rails_helper'/).and contain(/describe ForwardsMailbox/)
     end
   end
 end

--- a/spec/generators/rspec/mailer/mailer_generator_spec.rb
+++ b/spec/generators/rspec/mailer/mailer_generator_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Rspec::Generators::MailerGenerator, type: :generator do
           filename
         ).to(
           contain(/require "rails_helper"/)
-            .and(contain(/^RSpec.describe PostsMailer, #{type_metatag(:mailer)}/))
+            .and(contain(/^RSpec.describe PostsMailer/))
             .and(contain(/describe "index" do/))
             .and(contain(/describe "show" do/))
         )

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
           filename
         ).to(
           contain("require 'rails_helper'")
-            .and(contain(/^RSpec.describe "\/posts", #{type_metatag(:request)}/))
+            .and(contain(/^RSpec.describe "\/posts"/))
             .and(contain('GET /new'))
             .and(contain(/"redirects to the created post"/))
             .and(contain('get post_url(post)'))
@@ -60,7 +60,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
           filename
         ).to(
           contain(/require 'rails_helper'/)
-            .and(contain(/^RSpec.describe "\/posts", #{type_metatag(:request)}/))
+            .and(contain(/^RSpec.describe "\/posts"/))
             .and(contain('as: :json'))
             .and(contain('renders a JSON response with the new post'))
             .and(contain('renders a JSON response with errors for the new post'))
@@ -97,7 +97,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
           filename
         ).to(
           contain(/require 'rails_helper'/)
-            .and(contain(/^RSpec.describe PostsController, #{type_metatag(:controller)}/))
+            .and(contain(/^RSpec.describe PostsController/))
             .and(contain(/GET #new/))
             .and(contain(/"redirects to the created \w+"/))
             .and(contain(/GET #edit/))
@@ -133,7 +133,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
 
       it "includes the standard boilerplate" do
         expect(filename).to contain(/require 'rails_helper'/)
-                             .and(contain(/^RSpec.describe PostsController, #{type_metatag(:controller)}/))
+                             .and(contain(/^RSpec.describe PostsController/))
                              .and(contain(/"renders a JSON response with the new \w+"/))
                              .and(contain(/"renders a JSON response with errors for the new \w+"/))
                              .and(contain(/"renders a JSON response with the \w+"/))
@@ -157,7 +157,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
       before { run_generator %w[admin/posts] }
 
       it "includes the standard boilerplate" do
-        expect(filename).to contain(/^RSpec.describe "\/admin\/posts", #{type_metatag(:request)}/)
+        expect(filename).to contain(/^RSpec.describe "\/admin\/posts"/)
                            .and(contain('post admin_posts_url, params: { admin_post: valid_attributes }'))
                            .and(contain('admin_post_url(post)'))
                            .and(contain('Admin::Post.create'))
@@ -205,7 +205,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
       before { run_generator %w[admin/posts --controller_specs] }
 
       it "includes the standard boilerplate" do
-        expect(filename).to contain(/^RSpec.describe Admin::PostsController, #{type_metatag(:controller)}/)
+        expect(filename).to contain(/^RSpec.describe Admin::PostsController/)
                              .and(contain('post :create, params: {admin_post: valid_attributes}'))
                              .and(contain('Admin::Post.create'))
       end
@@ -254,7 +254,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
 
         it "includes the standard boilerplate" do
           expect(filename).to contain(/require 'rails_helper'/)
-                             .and(contain(/^RSpec.describe "(.*)\/edit", #{type_metatag(:view)}/))
+                             .and(contain(/^RSpec.describe "(.*)\/edit"/))
                              .and(contain(/assign\(:post, post\)/))
                              .and(contain(/it "renders the edit (.*) form"/))
         end
@@ -265,7 +265,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
 
         it "includes the standard boilerplate" do
           expect(filename).to contain(/require 'rails_helper'/)
-                             .and(contain(/^RSpec.describe "(.*)\/index", #{type_metatag(:view)}/))
+                             .and(contain(/^RSpec.describe "(.*)\/index"/))
                              .and(contain(/assign\(:posts, /))
                              .and(contain(/it "renders a list of (.*)"/))
         end
@@ -276,7 +276,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
 
         it "includes the standard boilerplate" do
           expect(filename).to contain(/require 'rails_helper'/)
-                             .and(contain(/^RSpec.describe "(.*)\/new", #{type_metatag(:view)}/))
+                             .and(contain(/^RSpec.describe "(.*)\/new"/))
                              .and(contain(/assign\(:post, /))
                              .and(contain(/it "renders new (.*) form"/))
         end
@@ -287,7 +287,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
 
         it "includes the standard boilerplate" do
           expect(filename).to contain(/require 'rails_helper'/)
-                             .and(contain(/^RSpec.describe "(.*)\/show", #{type_metatag(:view)}/))
+                             .and(contain(/^RSpec.describe "(.*)\/show"/))
                              .and(contain(/assign\(:post, /))
                              .and(contain(/it "renders attributes in <p>"/))
         end
@@ -524,7 +524,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
 
       it 'includes the standard boilerplate' do
         expect(filename).to contain(/require "rails_helper"/)
-                             .and(contain(/^RSpec.describe PostsController, #{type_metatag(:routing)}/))
+                             .and(contain(/^RSpec.describe PostsController/))
                              .and(contain(/describe "routing"/))
                              .and(contain(/routes to #new/))
                              .and(contain(/routes to #edit/))
@@ -556,7 +556,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
         before { run_generator %w[api/v1/posts] }
 
         it 'includes the standard boilerplate' do
-          expect(filename).to contain(/^RSpec.describe Api::V1::PostsController, #{type_metatag(:routing)}/)
+          expect(filename).to contain(/^RSpec.describe Api::V1::PostsController/)
                                .and(contain('route_to("api/v1/posts#new")'))
         end
       end

--- a/spec/generators/rspec/system/system_generator_spec.rb
+++ b/spec/generators/rspec/system/system_generator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Rspec::Generators::SystemGenerator, type: :generator do
 
       describe "the spec" do
         it "contains the standard boilerplate" do
-          expect(system_spec).to contain(/require 'rails_helper'/).and(contain(/^RSpec.describe "Posts", #{type_metatag(:system)}/))
+          expect(system_spec).to contain(/require 'rails_helper'/).and(contain(/^RSpec.describe "Posts"/))
         end
       end
     end

--- a/spec/generators/rspec/view/view_generator_spec.rb
+++ b/spec/generators/rspec/view/view_generator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Rspec::Generators::ViewGenerator, type: :generator do
       run_generator %w[posts index]
       file('spec/views/posts/index.html.erb_spec.rb').tap do |f|
         expect(f).to contain(/require 'rails_helper'/)
-        expect(f).to contain(/^RSpec.describe "posts\/index", #{type_metatag(:view)}/)
+        expect(f).to contain(/^RSpec.describe "posts\/index"/)
       end
     end
 
@@ -19,7 +19,7 @@ RSpec.describe Rspec::Generators::ViewGenerator, type: :generator do
         run_generator %w[admin/posts index]
         file('spec/views/admin/posts/index.html.erb_spec.rb').tap do |f|
           expect(f).to contain(/require 'rails_helper'/)
-          expect(f).to contain(/^RSpec.describe "admin\/posts\/index", #{type_metatag(:view)}/)
+          expect(f).to contain(/^RSpec.describe "admin\/posts\/index"/)
         end
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe Rspec::Generators::ViewGenerator, type: :generator do
       run_generator %w[posts index --template_engine haml]
       file('spec/views/posts/index.html.haml_spec.rb').tap do |f|
         expect(f).to contain(/require 'rails_helper'/)
-        expect(f).to contain(/^RSpec.describe "posts\/index", #{type_metatag(:view)}/)
+        expect(f).to contain(/^RSpec.describe "posts\/index"/)
       end
     end
   end

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -27,7 +27,7 @@ module RSpec
             subject(:model_spec) { file("spec/models/#{name}_spec.rb") }
 
             it 'contains the standard boilerplate' do
-              expect(model_spec).to contain(/require 'rails_helper'/).and(contain(/^RSpec.describe #{class_name}, #{type_metatag(:model)}/))
+              expect(model_spec).to contain(/require 'rails_helper'/).and(contain(/^RSpec.describe #{class_name}/))
             end
           end
 
@@ -66,7 +66,7 @@ module RSpec
 
               it 'contains the standard boilerplate' do
                 expect(request_spec).to contain(/require 'rails_helper'/)
-                                          .and(contain(/^RSpec.describe "Posts", #{type_metatag(:request)}/))
+                                          .and(contain(/^RSpec.describe "Posts"/))
                                           .and(contain(/describe "GET \/posts"/))
                                           .and(contain(/get posts_index_path/))
               end
@@ -78,7 +78,7 @@ module RSpec
 
               it 'contains the standard boilerplate' do
                 expect(request_spec).to contain(/require 'rails_helper'/)
-                                          .and(contain(/^RSpec.describe "Api::Posts", #{type_metatag(:request)}/))
+                                          .and(contain(/^RSpec.describe "Api::Posts"/))
                                           .and(contain(/describe "GET \/api\/posts"/))
                                           .and(contain(/get api_posts_index_path\n/))
               end


### PR DESCRIPTION
rspec-rails will generate spec/rails_helper.rb with `config.infer_spec_type_from_file_location!` enabled. So by default it assumes a project that does not explicitly specify type metadata.

https://github.com/rspec/rspec-rails/blob/06d05aba209565f5bc940aa9e67232c8616e5197/lib/generators/rspec/install/templates/spec/ rails_helper.rb#L78

Therefore, shouldn't the generators also generate a test file skeleton that does not explicitly specify type metadata?