### PR TITLE
Setup rspec-rails to allow main to be used without requiring git rspec

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -46,12 +46,9 @@ Gem::Specification.new do |s|
   # get released.
   %w[core expectations mocks support].each do |name|
     if ENV['RSPEC_CI']
-      s.add_runtime_dependency "rspec-#{name}", ENV.fetch('RSPEC_VERSION', '3.13.0.pre')
-    elsif RSpec::Rails::Version::STRING =~ /pre/ # prerelease builds
-      expected_rspec_version = "3.13.0.pre"
-      s.add_runtime_dependency "rspec-#{name}", "= #{expected_rspec_version}"
+      s.add_runtime_dependency "rspec-#{name}", ENV.fetch('RSPEC_VERSION', '3.14.0.pre')
     else
-      expected_rspec_version = "3.12.0"
+      expected_rspec_version = "3.13.0"
       s.add_runtime_dependency "rspec-#{name}", "~> #{expected_rspec_version.split(".")[0..1].join(".")}"
     end
   end


### PR DESCRIPTION
Increase the desired rspec version to recently released 3.13, but also drop the requirement for pre release versions of RSpec when using rspec-rails from this repo, we seperated rspec-rails from rspec's release cadence so theres no real reason for this to be here, I've kept the CI addition because it allows the build to test against the head but this should make it easier for other people to use pre release versions of rspec-rails