### PR TITLE
Remove unnecessary routing assertions require

### DIFF
--- a/lib/rspec/rails/example/routing_example_group.rb
+++ b/lib/rspec/rails/example/routing_example_group.rb
@@ -1,5 +1,3 @@
-require "action_dispatch/testing/assertions/routing"
-
 module RSpec
   module Rails
     # @private


### PR DESCRIPTION
`ActionDispatch::Assertions` has an autoload defined: https://github.com/rails/rails/blob/v7.1.3/actionpack/lib/action_dispatch.rb#L130

That file requires `action_dispatch/testing/assertions/routing.rb`:
https://github.com/rails/rails/blob/v7.1.3/actionpack/lib/action_dispatch/testing/assertions.rb#L5

So `ActionDispatch::Assertions::RoutingAssertions` can be referenced without being explicitly required.

`rspec/rails/example/controller_example_group.rb`, which is loaded before this file, already references it and triggers the autoload, which means this require never has any effect:
https://github.com/rspec/rspec-rails/blob/v6.1.1/lib/rspec/rails/example/controller_example_group.rb#L5

Requiring `action_dispatch/testing/assertions/routing.rb` on its own doesn't actually work, because it autoloads `ActionDispatch::Assertions` which then fails to find `ActionDispatch::Assertions::RoutingAssertions` since it hasn't been defined yet:

```
$ ruby -r action_dispatch -e "p ActionDispatch::Assertions::RoutingAssertions"
ActionDispatch::Assertions::RoutingAssertions
```

```
$ ruby -r action_dispatch -r action_dispatch/testing/assertions/routing -e "p ActionDispatch::Assertions::RoutingAssertions"
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3/lib/action_dispatch/testing/assertions.rb:12:in `<module:Assertions>': uninitialized constant ActionDispatch::Assertions::RoutingAssertions (NameError)
```

(This is a prerequisite to a larger change, but I wanted to propose it first since it requires a fair bit of explanation.)