### PR TITLE
Fix failing fixture support test on Rails main

### DIFF
--- a/spec/rspec/rails/fixture_support_spec.rb
+++ b/spec/rspec/rails/fixture_support_spec.rb
@@ -39,14 +39,21 @@ module RSpec::Rails
       end
     end
 
-    it "will allow #setup_fixture to run successfully" do
-      group = RSpec::Core::ExampleGroup.describe do
-        include FixtureSupport
+    context "with use_transactional_tests set to false" do
+      it "does not wrap the test in a transaction" do
+        allow(RSpec.configuration).to receive(:use_transactional_fixtures) { true }
+        group = RSpec::Core::ExampleGroup.describe do
+          include FixtureSupport
 
-        self.use_transactional_tests = false
+          self.use_transactional_tests = false
+
+          it "doesn't run in transaction" do
+            expect(ActiveRecord::Base.connection.transaction_open?).to eq(false)
+          end
+        end
+
+        expect_to_pass(group)
       end
-
-      expect { group.new.setup_fixtures }.to_not raise_error
     end
 
     it "handles namespaced fixtures" do


### PR DESCRIPTION
This test is failing since `setup_fixtures` was made private in https://github.com/rails/rails/pull/51021.

It was added in https://github.com/rspec/rspec-rails/pull/2215 to exercise the call to `name` in Rails' `run_in_transaction?` method: https://github.com/rails/rails/blob/b4ab1f19d8bcc4639c7379b560f000f01753b5b0/activerecord/lib/active_record/test_fixtures.rb#L101

However since https://github.com/rspec/rspec-rails/pull/2461, RSpec Rails overrides `run_in_transaction?`, so `name` is no longer called. We can get even better integration coverage of an example group with `use_transactional_tests` set to false by actually running an example.