### PR TITLE
Clone rspec-metagem correctly

### DIFF
--- a/Gemfile-rspec-dependencies
+++ b/Gemfile-rspec-dependencies
@@ -4,6 +4,10 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path, :require => false
   else
-    gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch, :require => false
+    if lib == 'rspec'
+      gem 'rspec', :git => "https://github.com/rspec/rspec-metagem.git", :branch => branch, :require => false
+    else
+      gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch, :require => false
+    end
   end
 end

--- a/script/clone_all_rspec_repos
+++ b/script/clone_all_rspec_repos
@@ -7,7 +7,7 @@ source script/functions.sh
 
 pushd ..
 
-clone_repo "rspec"
+clone_repo "rspec-metagem" "rspec"
 clone_repo "rspec-core"
 clone_repo "rspec-expectations"
 clone_repo "rspec-mocks"

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -54,8 +54,14 @@ function documentation_enforced {
 }
 
 function clone_repo {
-  if [ ! -d $1 ]; then # don't clone if the dir is already there
-    ci_retry eval "git clone https://github.com/rspec/$1 --depth 1 --branch $MAINTENANCE_BRANCH"
+  if [ -z "$2" ]; then
+    DIR_TARGET="$1"
+  else
+    DIR_TARGET="$2"
+  fi
+
+  if [ ! -d $DIR_TARGET ]; then # don't clone if the dir is already there
+    ci_retry eval "git clone https://github.com/rspec/$1 --depth 1 --branch $MAINTENANCE_BRANCH $DIR_TARGET"
   fi;
 }
 


### PR DESCRIPTION
We renamed this repo a while ago but there was a redirect in place which I promptly forgot about when renaming a monorepo prototype. This should fix the build.