### PR TITLE
Clean up generator for generator specs

### DIFF
--- a/lib/generators/rspec/generator/generator_generator.rb
+++ b/lib/generators/rspec/generator/generator_generator.rb
@@ -4,7 +4,7 @@ module Rspec
   module Generators
     # @private
     class GeneratorGenerator < Base
-      class_option :generator_specs, type: :boolean, default: true,  desc: "Generate generator specs"
+      class_option :generator_specs, type: :boolean, default: true, desc: 'Generate generator specs'
 
       def generate_generator_spec
         return unless options[:generator_specs]
@@ -17,7 +17,7 @@ module Rspec
       end
 
       def filename
-        "#{table_name}_generator_spec.rb"
+        "#{file_name}_generator_spec.rb"
       end
     end
   end

--- a/lib/generators/rspec/generator/templates/generator_spec.rb
+++ b/lib/generators/rspec/generator/templates/generator_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "<%= class_name.pluralize %>", <%= type_metatag(:generator) %> do
-
+RSpec.describe "<%= class_name %>Generator", <%= type_metatag(:generator) %> do
   pending "add some scenarios (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
Use singular name in file name to match the generator name and use the generator name in the spec description.

Also clean up an extra white-space and empty line in the template.

Note that the generator class name cannot be directly used as it isn't loaded by default.