### PR TITLE
Clean up generator for generator specs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 Bug Fixes:
 
 * Fix generated mailer paths to match Rails convention. (Patrício dos Santos, #2735)
+* Fix class in generator generator template. (Nicolas Buduroi, #2744)
 
 ### 6.1.1 / 2024-01-25
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v6.1.0...v6.1.1)

--- a/features/generator_specs/generator_specs.feature
+++ b/features/generator_specs/generator_specs.feature
@@ -12,7 +12,7 @@ Feature: Generator spec
             create  lib/generators/my_generator/USAGE
             create  lib/generators/my_generator/templates
             invoke  rspec
-            create    spec/generator/my_generators_generator_spec.rb
+            create    spec/generator/my_generator_generator_spec.rb
       """
 
   Scenario: Use custom generator with customized `default-path`
@@ -29,5 +29,5 @@ Feature: Generator spec
             create  lib/generators/my_generator/USAGE
             create  lib/generators/my_generator/templates
             invoke  rspec
-            create    behaviour/generator/my_generators_generator_spec.rb
+            create    behaviour/generator/my_generator_generator_spec.rb
       """

--- a/lib/generators/rspec/generator/generator_generator.rb
+++ b/lib/generators/rspec/generator/generator_generator.rb
@@ -4,7 +4,7 @@ module Rspec
   module Generators
     # @private
     class GeneratorGenerator < Base
-      class_option :generator_specs, type: :boolean, default: true,  desc: "Generate generator specs"
+      class_option :generator_specs, type: :boolean, default: true, desc: 'Generate generator specs'
 
       def generate_generator_spec
         return unless options[:generator_specs]
@@ -17,7 +17,7 @@ module Rspec
       end
 
       def filename
-        "#{table_name}_generator_spec.rb"
+        "#{file_name}_generator_spec.rb"
       end
     end
   end

--- a/lib/generators/rspec/generator/templates/generator_spec.rb
+++ b/lib/generators/rspec/generator/templates/generator_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "<%= class_name.pluralize %>", <%= type_metatag(:generator) %> do
-
+RSpec.describe "<%= class_name %>Generator", <%= type_metatag(:generator) %> do
   pending "add some scenarios (or delete) #{__FILE__}"
 end

--- a/spec/generators/rspec/generator/generator_generator_spec.rb
+++ b/spec/generators/rspec/generator/generator_generator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Rspec::Generators::GeneratorGenerator, type: :generator do
     end
 
     it "include the standard boilerplate" do
-      expect(generator_spec).to contain(/require 'rails_helper'/).and(contain(/^RSpec.describe "Posts", #{type_metatag(:generator)}/))
+      expect(generator_spec).to contain(/require 'rails_helper'/).and(contain(/^RSpec.describe "PostsGenerator", #{type_metatag(:generator)}/))
     end
   end
 end


### PR DESCRIPTION
Don't force pluralization of the generator name in the generated spec and use the full generator name in the spec description.

Also clean up an extra whitespace and empty line in the template.

Note that the generator class constant cannot be directly used in the spec description as it isn't loaded by default.