### PR TITLE
Verify ActiveJob job signature matches arguments

### DIFF
--- a/lib/rspec/rails/matchers/have_enqueued_mail.rb
+++ b/lib/rspec/rails/matchers/have_enqueued_mail.rb
@@ -89,6 +89,10 @@ module RSpec
           super(job)
         end
 
+        def verify_arguments_match_signature!(_job, _args)
+          # Not implemented for mailers
+        end
+
         def base_mailer_args
           [mailer_class_name, @method_name.to_s, MAILER_JOB_METHOD]
         end

--- a/lib/rspec/rails/matchers/have_enqueued_mail.rb
+++ b/lib/rspec/rails/matchers/have_enqueued_mail.rb
@@ -89,8 +89,19 @@ module RSpec
           super(job)
         end
 
-        def verify_arguments_match_signature!(_job, _args)
-          # Not implemented for mailers
+        def verify_arguments_match_signature!(job, args)
+          return if @method_name.nil?
+
+          mailer_method = mailer_class_name.constantize.public_instance_method(@method_name)
+          mailer_args = args - base_mailer_args
+
+          if parameterized_mail?(job)
+            mailer_args = mailer_args[1..-1] # ignore parameterized params
+          elsif mailer_args.last.is_a?(Hash) && mailer_args.last.key?(:args)
+            mailer_args = args.last[:args]
+          end
+
+          verify_signature!(mailer_method, mailer_args)
         end
 
         def base_mailer_args

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
     it "fails when job is not enqueued" do
       expect {
         expect { }.to have_enqueued_job
-      }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
+      }.to fail_with(/expected to enqueue exactly 1 jobs, but enqueued 0/)
     end
 
     it "fails when too many jobs enqueued" do
@@ -161,20 +161,20 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
           heavy_lifting_job.perform_later
           heavy_lifting_job.perform_later
         }.to have_enqueued_job.exactly(1)
-      }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 2/)
+      }.to fail_with(/expected to enqueue exactly 1 jobs, but enqueued 2/)
     end
 
     it "reports correct number in fail error message" do
       heavy_lifting_job.perform_later
       expect {
         expect { }.to have_enqueued_job.exactly(1)
-      }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
+      }.to fail_with(/expected to enqueue exactly 1 jobs, but enqueued 0/)
     end
 
     it "fails when negated and job is enqueued" do
       expect {
         expect { heavy_lifting_job.perform_later }.not_to have_enqueued_job
-      }.to raise_error(/expected not to enqueue at least 1 jobs, but enqueued 1/)
+      }.to fail_with(/expected not to enqueue at least 1 jobs, but enqueued 1/)
     end
 
     it "fails when negated and several jobs enqueued" do
@@ -183,7 +183,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
           heavy_lifting_job.perform_later
           heavy_lifting_job.perform_later
         }.not_to have_enqueued_job
-      }.to raise_error(/expected not to enqueue at least 1 jobs, but enqueued 2/)
+      }.to fail_with(/expected not to enqueue at least 1 jobs, but enqueued 2/)
     end
 
     it "passes with job name" do
@@ -238,7 +238,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
     it "generates failure message with at least hint" do
       expect {
         expect { }.to have_enqueued_job.at_least(:once)
-      }.to raise_error(/expected to enqueue at least 1 jobs, but enqueued 0/)
+      }.to fail_with(/expected to enqueue at least 1 jobs, but enqueued 0/)
     end
 
     it "generates failure message with at most hint" do
@@ -247,7 +247,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
           hello_job.perform_later
           hello_job.perform_later
         }.to have_enqueued_job.at_most(:once)
-      }.to raise_error(/expected to enqueue at most 1 jobs, but enqueued 2/)
+      }.to fail_with(/expected to enqueue at most 1 jobs, but enqueued 2/)
     end
 
     it "passes with provided queue name as string" do
@@ -291,7 +291,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
       travel_to time do
         expect {
           expect { hello_job.set(wait: 5).perform_later }.to have_enqueued_job.at(time + 5)
-        }.to raise_error(/expected to enqueue exactly 1 jobs/)
+        }.to fail_with(/expected to enqueue exactly 1 jobs/)
       end
     end
 
@@ -315,7 +315,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
         expect {
           hello_job.perform_later
         }.to have_enqueued_job.at(date)
-      }.to raise_error(/expected to enqueue exactly 1 jobs, at .+ but enqueued 0/)
+      }.to fail_with(/expected to enqueue exactly 1 jobs, at .+ but enqueued 0/)
     end
 
     it "has an enqueued job when not providing at and there is a wait" do
@@ -343,10 +343,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
         expect {
           two_args_job.perform_later(1)
         }.to have_enqueued_job.with(1)
-      }.to raise_error(
-        RSpec::Expectations::ExpectationNotMetError,
-        /Incorrect arguments passed to TwoArgsJob: Wrong number of arguments/
-      )
+      }.to fail_with(/Incorrect arguments passed to TwoArgsJob: Wrong number of arguments/)
     end
 
     it "fails if the job's signature/arguments are mismatched keyword/positional arguments" do
@@ -354,10 +351,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
         expect {
           keyword_args_job.perform_later(1, 2)
         }.to have_enqueued_job.with(1, 2)
-      }.to raise_error(
-        RSpec::Expectations::ExpectationNotMetError,
-        /Incorrect arguments passed to KeywordArgsJob: Missing required keyword arguments/
-      )
+      }.to fail_with(/Incorrect arguments passed to KeywordArgsJob: Missing required keyword arguments/)
     end
 
     it "passes with provided arguments containing global id object" do
@@ -384,7 +378,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
         expect {
           hello_job.perform_later(1)
         }.to have_enqueued_job(hello_job).with(42).on_queue("low").at(date).exactly(2).times
-      }.to raise_error(message)
+      }.to fail_with(message)
     end
 
     it "throws descriptive error when no test adapter set" do
@@ -490,7 +484,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
     it "fails when job is not enqueued" do
       expect {
         expect(heavy_lifting_job).to have_been_enqueued
-      }.to raise_error(/expected to enqueue exactly 1 jobs, but enqueued 0/)
+      }.to fail_with(/expected to enqueue exactly 1 jobs, but enqueued 0/)
     end
 
     it "fails if the arguments do not match the job's signature" do
@@ -498,10 +492,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
 
       expect {
         expect(two_args_job).to have_been_enqueued.with(1)
-      }.to raise_error(
-        RSpec::Expectations::ExpectationNotMetError,
-        /Incorrect arguments passed to TwoArgsJob: Wrong number of arguments/
-      )
+      }.to fail_with(/Incorrect arguments passed to TwoArgsJob: Wrong number of arguments/)
     end
 
     it "fails if the job's signature/arguments are mismatched keyword/positional arguments" do
@@ -509,10 +500,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
 
       expect {
         expect(keyword_args_job).to have_been_enqueued.with(1, 2)
-      }.to raise_error(
-        RSpec::Expectations::ExpectationNotMetError,
-        /Incorrect arguments passed to KeywordArgsJob: Missing required keyword arguments/
-      )
+      }.to fail_with(/Incorrect arguments passed to KeywordArgsJob: Missing required keyword arguments/)
     end
 
     it "fails when negated and several jobs enqueued" do
@@ -520,7 +508,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
       heavy_lifting_job.perform_later
       expect {
         expect(heavy_lifting_job).not_to have_been_enqueued
-      }.to raise_error(/expected not to enqueue at least 1 jobs, but enqueued 2/)
+      }.to fail_with(/expected not to enqueue at least 1 jobs, but enqueued 2/)
     end
 
     it "accepts composable matchers as an at date" do
@@ -569,7 +557,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
     it "fails when job is not performed" do
       expect {
         expect { }.to have_performed_job
-      }.to raise_error(/expected to perform exactly 1 jobs, but performed 0/)
+      }.to fail_with(/expected to perform exactly 1 jobs, but performed 0/)
     end
 
     it "fails when too many jobs performed" do
@@ -578,20 +566,20 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
           heavy_lifting_job.perform_later
           heavy_lifting_job.perform_later
         }.to have_performed_job.exactly(1)
-      }.to raise_error(/expected to perform exactly 1 jobs, but performed 2/)
+      }.to fail_with(/expected to perform exactly 1 jobs, but performed 2/)
     end
 
     it "reports correct number in fail error message" do
       heavy_lifting_job.perform_later
       expect {
         expect { }.to have_performed_job.exactly(1)
-      }.to raise_error(/expected to perform exactly 1 jobs, but performed 0/)
+      }.to fail_with(/expected to perform exactly 1 jobs, but performed 0/)
     end
 
     it "fails when negated and job is performed" do
       expect {
         expect { heavy_lifting_job.perform_later }.not_to have_performed_job
-      }.to raise_error(/expected not to perform exactly 1 jobs, but performed 1/)
+      }.to fail_with(/expected not to perform exactly 1 jobs, but performed 1/)
     end
 
     it "passes with job name" do
@@ -646,7 +634,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
     it "generates failure message with at least hint" do
       expect {
         expect { }.to have_performed_job.at_least(:once)
-      }.to raise_error(/expected to perform at least 1 jobs, but performed 0/)
+      }.to fail_with(/expected to perform at least 1 jobs, but performed 0/)
     end
 
     it "generates failure message with at most hint" do
@@ -655,7 +643,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
           hello_job.perform_later
           hello_job.perform_later
         }.to have_performed_job.at_most(:once)
-      }.to raise_error(/expected to perform at most 1 jobs, but performed 2/)
+      }.to fail_with(/expected to perform at most 1 jobs, but performed 2/)
     end
 
     it "passes with provided queue name as string" do
@@ -707,7 +695,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
         expect {
           hello_job.perform_later(1)
         }.to have_performed_job(hello_job).with(42).on_queue("low").at(date).exactly(2).times
-      }.to raise_error(message)
+      }.to fail_with(message)
     end
 
     it "throws descriptive error when no test adapter set" do
@@ -792,7 +780,7 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
     it "fails when job is not performed" do
       expect {
         expect(heavy_lifting_job).to have_been_performed
-      }.to raise_error(/expected to perform exactly 1 jobs, but performed 0/)
+      }.to fail_with(/expected to perform exactly 1 jobs, but performed 0/)
     end
   end
 

--- a/spec/rspec/rails/matchers/active_job_spec.rb
+++ b/spec/rspec/rails/matchers/active_job_spec.rb
@@ -343,7 +343,10 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
         expect {
           two_args_job.perform_later(1)
         }.to have_enqueued_job.with(1)
-      }.to raise_error(ArgumentError, /Wrong number of arguments/)
+      }.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        /Incorrect arguments passed to TwoArgsJob: Wrong number of arguments/
+      )
     end
 
     it "fails if the job's signature/arguments are mismatched keyword/positional arguments" do
@@ -351,7 +354,10 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
         expect {
           keyword_args_job.perform_later(1, 2)
         }.to have_enqueued_job.with(1, 2)
-      }.to raise_error(ArgumentError, /Missing required keyword arguments/)
+      }.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        /Incorrect arguments passed to KeywordArgsJob: Missing required keyword arguments/
+      )
     end
 
     it "passes with provided arguments containing global id object" do
@@ -492,7 +498,10 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
 
       expect {
         expect(two_args_job).to have_been_enqueued.with(1)
-      }.to raise_error(ArgumentError, /Wrong number of arguments/)
+      }.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        /Incorrect arguments passed to TwoArgsJob: Wrong number of arguments/
+      )
     end
 
     it "fails if the job's signature/arguments are mismatched keyword/positional arguments" do
@@ -500,7 +509,10 @@ RSpec.describe "ActiveJob matchers", skip: !RSpec::Rails::FeatureCheck.has_activ
 
       expect {
         expect(keyword_args_job).to have_been_enqueued.with(1, 2)
-      }.to raise_error(ArgumentError, /Missing required keyword arguments/)
+      }.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        /Incorrect arguments passed to KeywordArgsJob: Missing required keyword arguments/
+      )
     end
 
     it "fails when negated and several jobs enqueued" do

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         expect {
           AnotherTestMailer.test_email.deliver_later
         }.to have_enqueued_mail(TestMailer)
-      }.to raise_error(/expected to enqueue TestMailer exactly 1 time but enqueued 0/)
+      }.to fail_with(/expected to enqueue TestMailer exactly 1 time but enqueued 0/)
     end
 
     it "counts only emails enqueued in the block" do
@@ -127,7 +127,7 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
           TestMailer.test_email.deliver_later
           TestMailer.test_email.deliver_later
         }.to have_enqueued_mail(TestMailer, :test_email).exactly(1)
-      }.to raise_error(/expected to enqueue TestMailer.test_email exactly 1 time/)
+      }.to fail_with(/expected to enqueue TestMailer.test_email exactly 1 time/)
     end
 
     it "matches based on mailer class and method name" do
@@ -149,7 +149,7 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         expect {
           TestMailer.test_email.deliver_later
         }.not_to have_enqueued_mail(TestMailer, :test_email)
-      }.to raise_error(/expected not to enqueue TestMailer.test_email at least 1 time but enqueued 1/)
+      }.to fail_with(/expected not to enqueue TestMailer.test_email at least 1 time but enqueued 1/)
     end
 
     it "passes with :once count" do
@@ -189,19 +189,19 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
     it "generates a failure message when given 0 argument" do
       expect {
         expect { }.to have_enqueued_mail.at_least(:once)
-      }.to raise_error(/expected to enqueue ActionMailer::Base at least 1 time but enqueued 0/)
+      }.to fail_with(/expected to enqueue ActionMailer::Base at least 1 time but enqueued 0/)
     end
 
     it "generates a failure message when given only mailer argument" do
       expect {
         expect { }.to have_enqueued_mail(TestMailer).at_least(:once)
-      }.to raise_error(/expected to enqueue TestMailer at least 1 time but enqueued 0/)
+      }.to fail_with(/expected to enqueue TestMailer at least 1 time but enqueued 0/)
     end
 
     it "generates a failure message with at least hint" do
       expect {
         expect { }.to have_enqueued_mail(TestMailer, :test_email).at_least(:once)
-      }.to raise_error(/expected to enqueue TestMailer.test_email at least 1 time but enqueued 0/)
+      }.to fail_with(/expected to enqueue TestMailer.test_email at least 1 time but enqueued 0/)
     end
 
     it "generates a failure message with at most hint" do
@@ -210,7 +210,7 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
           TestMailer.test_email.deliver_later
           TestMailer.test_email.deliver_later
         }.to have_enqueued_mail(TestMailer, :test_email).at_most(:once)
-      }.to raise_error(/expected to enqueue TestMailer.test_email at most 1 time but enqueued 2/)
+      }.to fail_with(/expected to enqueue TestMailer.test_email at most 1 time but enqueued 2/)
     end
 
     it "passes for mailer methods that accept arguments when the provided argument matcher is not used" do
@@ -248,22 +248,19 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         expect {
           TestMailer.email_with_args(1).deliver_later
         }.to have_enqueued_mail(TestMailer, :email_with_args).with(1)
-      }.to raise_error(
-        RSpec::Expectations::ExpectationNotMetError,
-        /Incorrect arguments passed to TestMailer: Wrong number of arguments/
-      )
+      }.to fail_with(/Incorrect arguments passed to TestMailer: Wrong number of arguments/)
     end
 
     it "generates a failure message" do
       expect {
         expect { }.to have_enqueued_email(TestMailer, :test_email)
-      }.to raise_error(/expected to enqueue TestMailer.test_email/)
+      }.to fail_with(/expected to enqueue TestMailer.test_email/)
     end
 
     it "generates a failure message with arguments" do
       expect {
         expect { }.to have_enqueued_email(TestMailer, :email_with_args).with(1, 2)
-      }.to raise_error(/expected to enqueue TestMailer.email_with_args exactly 1 time with \[1, 2\], but enqueued 0/)
+      }.to fail_with(/expected to enqueue TestMailer.email_with_args exactly 1 time with \[1, 2\], but enqueued 0/)
     end
 
     it "passes when deliver_later is called with a wait_until argument" do
@@ -281,7 +278,7 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         expect {
           TestMailer.test_email.deliver_later(wait_until: send_time + 1)
         }.to have_enqueued_email(TestMailer, :test_email).at(send_time)
-      }.to raise_error(/expected to enqueue TestMailer.test_email exactly 1 time at #{send_time.strftime('%F %T')}/)
+      }.to fail_with(/expected to enqueue TestMailer.test_email exactly 1 time at #{send_time.strftime('%F %T')}/)
     end
 
     it "accepts composable matchers as an at date" do
@@ -304,7 +301,7 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         expect {
           TestMailer.test_email.deliver_later(queue: 'not_urgent_mail')
         }.to have_enqueued_email(TestMailer, :test_email).on_queue('urgent_mail')
-      }.to raise_error(/expected to enqueue TestMailer.test_email exactly 1 time on queue urgent_mail/)
+      }.to fail_with(/expected to enqueue TestMailer.test_email exactly 1 time on queue urgent_mail/)
     end
 
     it "generates a failure message with unmatching enqueued mail jobs" do
@@ -327,7 +324,7 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
           TestMailer.test_email.deliver_later
           TestMailer.email_with_args(3, 4).deliver_later(wait_until: send_time, queue: queue)
         }.to have_enqueued_email(TestMailer, :email_with_args).with(1, 2)
-      }.to raise_error(message)
+      }.to fail_with(message)
     end
 
     it "throws descriptive error when no test adapter set" do
@@ -405,10 +402,7 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
           expect {
             TestMailer.with('foo' => 'bar').email_with_args(1).deliver_later
           }.to have_enqueued_mail(TestMailer, :email_with_args).with({ 'foo' => 'bar' }, 1)
-        }.to raise_error(
-          RSpec::Expectations::ExpectationNotMetError,
-          /Incorrect arguments passed to TestMailer: Wrong number of arguments/
-        )
+        }.to raise_error(/Incorrect arguments passed to TestMailer: Wrong number of arguments/)
       end
     end
 
@@ -465,10 +459,7 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
           }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(
             a_hash_including(params: { 'foo' => 'bar' }, args: [1])
           )
-        }.to raise_error(
-          RSpec::Expectations::ExpectationNotMetError,
-          /Incorrect arguments passed to UnifiedMailer: Wrong number of arguments/
-        )
+        }.to fail_with(/Incorrect arguments passed to UnifiedMailer: Wrong number of arguments/)
       end
     end
   end

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -243,6 +243,14 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
       }.not_to have_enqueued_mail(TestMailer, :email_with_args).with(3, 4)
     end
 
+    it "fails if the arguments do not match the mailer method's signature" do
+      expect {
+        expect {
+          TestMailer.email_with_args(1).deliver_later
+        }.to have_enqueued_mail(TestMailer, :email_with_args).with(1)
+      }.to raise_error(ArgumentError, /Wrong number of arguments/)
+    end
+
     it "generates a failure message" do
       expect {
         expect { }.to have_enqueued_email(TestMailer, :test_email)
@@ -388,6 +396,14 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
           TestMailer.with('foo' => 'bar').email_with_args(1, 2).deliver_later
         }.to have_enqueued_mail(TestMailer, :email_with_args).with({ 'foo' => 'bar' }, 1, 2)
       end
+
+      it "fails if the arguments do not match the mailer method's signature" do
+        expect {
+          expect {
+            TestMailer.with('foo' => 'bar').email_with_args(1).deliver_later
+          }.to have_enqueued_mail(TestMailer, :email_with_args).with({ 'foo' => 'bar' }, 1)
+        }.to raise_error(ArgumentError, /Wrong number of arguments/)
+      end
     end
 
     context 'mailer job is unified', skip: !RSpec::Rails::FeatureCheck.has_action_mailer_unified_delivery? do
@@ -434,6 +450,16 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         expect {
           UnifiedMailerWithDeliveryJobSubClass.test_email.deliver_later
         }.to have_enqueued_mail(UnifiedMailerWithDeliveryJobSubClass, :test_email)
+      end
+
+      it "fails if the arguments do not match the mailer method's signature" do
+        expect {
+          expect {
+            UnifiedMailer.with('foo' => 'bar').email_with_args(1).deliver_later
+          }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(
+            a_hash_including(params: { 'foo' => 'bar' }, args: [1])
+          )
+        }.to raise_error(ArgumentError, /Wrong number of arguments/)
       end
     end
   end

--- a/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
+++ b/spec/rspec/rails/matchers/have_enqueued_mail_spec.rb
@@ -248,7 +248,10 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
         expect {
           TestMailer.email_with_args(1).deliver_later
         }.to have_enqueued_mail(TestMailer, :email_with_args).with(1)
-      }.to raise_error(ArgumentError, /Wrong number of arguments/)
+      }.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        /Incorrect arguments passed to TestMailer: Wrong number of arguments/
+      )
     end
 
     it "generates a failure message" do
@@ -402,7 +405,10 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
           expect {
             TestMailer.with('foo' => 'bar').email_with_args(1).deliver_later
           }.to have_enqueued_mail(TestMailer, :email_with_args).with({ 'foo' => 'bar' }, 1)
-        }.to raise_error(ArgumentError, /Wrong number of arguments/)
+        }.to raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          /Incorrect arguments passed to TestMailer: Wrong number of arguments/
+        )
       end
     end
 
@@ -459,7 +465,10 @@ RSpec.describe "HaveEnqueuedMail matchers", skip: !RSpec::Rails::FeatureCheck.ha
           }.to have_enqueued_mail(UnifiedMailer, :email_with_args).with(
             a_hash_including(params: { 'foo' => 'bar' }, args: [1])
           )
-        }.to raise_error(ArgumentError, /Wrong number of arguments/)
+        }.to raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          /Incorrect arguments passed to UnifiedMailer: Wrong number of arguments/
+        )
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ I18n.enforce_available_locales = true
 
 require 'rspec/support/spec'
 require 'rspec/core/sandbox'
+require 'rspec/matchers/fail_matchers'
 require 'rspec/rails'
 require 'ammeter/init'
 
@@ -37,6 +38,9 @@ end
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  # Bring in the failure matchers from rspec-expectations
+  config.include RSpec::Matchers::FailMatchers
+
   config.expect_with :rspec do |expectations|
     # include_chain_clauses_in_custom_matcher_descriptions is removed in RSpec Expectations 4
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true if expectations.respond_to?(:include_chain_clauses_in_custom_matcher_descriptions=)


### PR DESCRIPTION
Hello,

I'd like to suggest an improvement to the `have_enqueued_job` and `have_been_enqueued` matchers – ensuring the arguments passed by the subject/caller actually match the job's method signature.

## Motivation

At the moment it's possible to write an implementation and spec which calls & expects the wrong number of arguments, or mix up the positional/keyword arguments. This results in a passing test, but the implementation will fail at runtime.

This improvement would guard against these false-positives. This approach was inspired by RSpec's awesome verifying doubles.

## Example

```ruby
class KeywordArgsJob < ActiveJob::Base
  def perform(a:, b:) # expecting keyword arguments
  end
end

RSpec.describe "ensuring job arguments match the job signature" do
  it "throws an exception on mismatch" do
    expect { KeywordArgsJob.perform_later(1, 2) } # incorrectly passing positional args
      .to have_enqueued_job(KeywordArgsJob).with(1, 2) # incorrectly expecting positional args
  end
end
```

- Current outcome: Spec passes
- Desired outcome: `ArgumentError: Missing required keyword arguments: a, b`

## Notes / questions

I wasn't sure if this behaviour should initially be opt-in, then become the default in the next major version. For the initial PR I've not made the verifying arguments behaviour configurable because it seems like any resulting failures will always be underlying bugs which should be fixed.