### PR TITLE
Use headless driver for next Rails release

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -137,7 +137,11 @@ module RSpec
           self.class.before do
             # A user may have already set the driver, so only default if driver
             # is not set
-            driven_by(:selenium) unless @driver
+            if ::Rails::VERSION::STRING.to_f >= 7.2
+              driven_by(:selenium_chrome_headless) unless @driver
+            else
+              driven_by(:selenium) unless @driver
+            end
           end
         end
 

--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -137,7 +137,7 @@ module RSpec
           self.class.before do
             # A user may have already set the driver, so only default if driver
             # is not set
-            if ::Rails::VERSION::STRING.to_f >= 7.2
+            if ::Rails::VERSION::STRING == "main"
               driven_by(:selenium_chrome_headless) unless @driver
             else
               driven_by(:selenium) unless @driver

--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -137,7 +137,7 @@ module RSpec
           self.class.before do
             # A user may have already set the driver, so only default if driver
             # is not set
-            if ::Rails::VERSION::STRING == "main"
+            if ::Rails::VERSION::STRING.to_f >= 7.2
               driven_by(:selenium_chrome_headless) unless @driver
             else
               driven_by(:selenium) unless @driver

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -29,15 +29,15 @@ module RSpec::Rails
       end
     end
 
-    describe '#driver' do
-      it 'uses :selenium driver by default' do
+    describe '#driver', if: ::Rails::VERSION::STRING.to_f >= 7.2 do
+      it 'uses :selenium_chrome_headless driver by default' do
         group = RSpec::Core::ExampleGroup.describe do
           include SystemExampleGroup
         end
         example = group.new
         group.hooks.run(:before, :example, example)
 
-        expect(Capybara.current_driver).to eq :selenium
+        expect(Capybara.current_driver).to eq :selenium_chrome_headless
       end
 
       it 'sets :rack_test driver using by before_action' do
@@ -67,18 +67,6 @@ module RSpec::Rails
         group.hooks.run(:before, :example, example)
 
         expect(example).to have_received(:driven_by).once
-      end
-    end
-
-    describe '#driver', if: ::Rails::VERSION::STRING.to_f >= 7.2 do
-      it 'uses :selenium_chrome_headless driver by default' do
-        group = RSpec::Core::ExampleGroup.describe do
-          include SystemExampleGroup
-        end
-        example = group.new
-        group.hooks.run(:before, :example, example)
-
-        expect(Capybara.current_driver).to eq :selenium_chrome_headless
       end
     end
 

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -70,6 +70,18 @@ module RSpec::Rails
       end
     end
 
+    describe '#driver', if: ::Rails::VERSION::STRING.to_f >= 7.2 do
+      it 'uses :selenium_chrome_headless driver by default' do
+        group = RSpec::Core::ExampleGroup.describe do
+          include SystemExampleGroup
+        end
+        example = group.new
+        group.hooks.run(:before, :example, example)
+
+        expect(Capybara.current_driver).to eq :selenium_chrome_headless
+      end
+    end
+
     describe '#after' do
       it 'sets the :extra_failure_lines metadata to an array of STDOUT lines' do
         allow(Capybara::Session).to receive(:instance_created?).and_return(true)

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -28,9 +28,18 @@ module RSpec::Rails
         expect(example.send(:method_name).bytesize).to be <= 210
       end
     end
+    describe '#driver' do
+      it 'uses :selenium driver by default', if: ::Rails::VERSION::STRING.to_f < 7.2 do
+        group = RSpec::Core::ExampleGroup.describe do
+          include SystemExampleGroup
+        end
+        example = group.new
+        group.hooks.run(:before, :example, example)
 
-    describe '#driver', if: ::Rails::VERSION::STRING.to_f >= 7.2 do
-      it 'uses :selenium_chrome_headless driver by default' do
+        expect(Capybara.current_driver).to eq :selenium
+      end
+
+      it 'uses :selenium_chrome_headless driver by default', if: ::Rails::VERSION::STRING.to_f >= 7.2 do
         group = RSpec::Core::ExampleGroup.describe do
           include SystemExampleGroup
         end

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -28,6 +28,7 @@ module RSpec::Rails
         expect(example.send(:method_name).bytesize).to be <= 210
       end
     end
+
     describe '#driver' do
       it 'uses :selenium driver by default', if: ::Rails::VERSION::STRING.to_f < 7.2 do
         group = RSpec::Core::ExampleGroup.describe do


### PR DESCRIPTION
In the next release of Rails, the default driver was switched from `:chrome` to `:headless_chrome` as see in: https://github.com/rails/rails/pull/50512 This is to ensure the new [ci template][] will "work out of the box".

However, this will not work with applications using `rspec-rails`, since it still defaults to `:selenium`. Instead, GitHub actions will fail with the following error:

```
Selenium::WebDriver::Error::SessionNotCreatedError:
            session not created: Chrome failed to start: exited normally.
              (session not created: DevToolsActivePort file doesn't exist)
              (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```

[ci template]: https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt

---

I've created a [demo application](https://github.com/stevepolitodesign/rspec-rails-ci-demo) to highlight the problem, and test the proposed solution. The [commit history](https://github.com/stevepolitodesign/rspec-rails-ci-demo/commits/main/) aims to break everything out change by change, but I will highlight the important parts below.

1. This [commit](https://github.com/stevepolitodesign/rspec-rails-ci-demo/commit/d82c3cbd80505a078796c22028c26ff53e5d02af) replicates the bug. Here's the [corresponding failure](https://github.com/stevepolitodesign/rspec-rails-ci-demo/actions/runs/8302149308/job/22723821219).
2. Without changing the test, I simply [update the Gemfile](https://github.com/stevepolitodesign/rspec-rails-ci-demo/commit/0aab647ad538212ced4f7143e2b55c1517022ffe) to use this branch, resulting in a passing test.

