### PR TITLE
README: Fix link to `6-1-maintenance` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ According to [RSpec Rails new versioning strategy][] use:
 ## Installation
 
 **IMPORTANT** This README / branch refers to the current development build.
-See the [`6-1-maintenance` branch on Github](https://github.com/rspec/rspec-rails/tree/6-0-maintenance) if you want or require the latest stable release.
+See the [`6-1-maintenance` branch on Github](https://github.com/rspec/rspec-rails/tree/6-1-maintenance) if you want or require the latest stable release.
 
 1. Add `rspec-rails` to **both** the `:development` and `:test` groups
    of your app’s `Gemfile`:


### PR DESCRIPTION
Hi there!

Super tiny documentation update to correct the link to the `6-1-maintenance` branch. Want to make sure visitors are hitting the correct stable version.

Cheers 🍻