### PR TITLE
Prepend controller path to lookup_context prefixes

### DIFF
--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -186,7 +186,7 @@ module RSpec
 
         before do
           _include_controller_helpers
-          view.lookup_context.prefixes << _controller_path
+          view.lookup_context.prefixes.prepend(_controller_path)
 
           controller.controller_path = _controller_path
 

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -255,6 +255,26 @@ module RSpec::Rails
         expect(failure_reporter.exceptions).to eq []
         expect(run_count).to eq 1
       end
+
+      # Rails expects the first prefix to be the controller path.
+      # @see ActionView::AbstractRenderer::ObjectRendering#initialize
+      # Regression test for rspec/rspec-rails#2729
+      it 'injects controller path as first prefix' do
+        prefixes = []
+        RSpec.describe "a view spec" do
+          include ::RSpec::Rails::ViewExampleGroup
+
+          def _controller_path
+            "example/path"
+          end
+
+          specify do
+            prefixes = view.lookup_context.prefixes
+          end
+        end.run
+
+        expect(prefixes).to start_with("example/path")
+      end
     end
 
     describe "#template" do


### PR DESCRIPTION
Rails rendering assumes that the first prefix encountered is 'special', specifically, it's the controller's prefix. This can be seen in `ActionView::AbstractRenderer::ObjectRendering#initialize`. This change injects the controller path at the start of the prefix list instead of the end to make sure this assumption is satisfied.

Resolves #2729.