### PR TITLE
Document/suggest workaround to avoid crash when running rails generators

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -4,6 +4,11 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
+<% if RSpec::Rails::FeatureCheck.has_active_record_migration? -%>
+# Uncomment the line below in case you have `--require rails_helper` in the `.rspec` file
+# that will avoid rails generators crashing because migrations haven't been run yet
+# return unless Rails.env.test?
+<% end -%>
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
Hey guys, I just came across this issue https://github.com/rspec/rspec-rails/issues/2623 (rspec aborted my `rails g scaffold` because I have `--require rails_helper` in `.rspec`) 😕

As suggested by https://github.com/rspec/rspec-rails/issues/2623#issuecomment-1278603823, I am documenting the case and adding a possible workaround.

Please let me know your thoughts. Thank you.