### PR TITLE
Reset CurrentAttributes on each rails example

### DIFF
--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -3,6 +3,7 @@
 require 'rspec/rails/matchers'
 
 if ::Rails::VERSION::MAJOR >= 7
+  require "active_support/current_attributes/test_helper"
   require 'active_support/execution_context/test_helper'
 end
 
@@ -18,6 +19,7 @@ module RSpec
       include RSpec::Rails::FixtureSupport
       if ::Rails::VERSION::MAJOR >= 7
         include RSpec::Rails::TaggedLoggingAdapter
+        include ActiveSupport::CurrentAttributes::TestHelper
         include ActiveSupport::ExecutionContext::TestHelper
       end
     end

--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -3,7 +3,7 @@
 require 'rspec/rails/matchers'
 
 if ::Rails::VERSION::MAJOR >= 7
-  require "active_support/current_attributes/test_helper"
+  require 'active_support/current_attributes/test_helper'
   require 'active_support/execution_context/test_helper'
 end
 

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -34,6 +34,8 @@ module RSpec::Rails
     end
 
     describe 'CurrentAttributes', order: :defined do
+      include RSpec::Rails::RailsExampleGroup
+
       class Current < ActiveSupport::CurrentAttributes
         attribute :request_id
       end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -1,13 +1,7 @@
 module RSpec::Rails
   RSpec.describe RailsExampleGroup do
-    if ::Rails::VERSION::MAJOR >= 7
-      class CurrentSample < ActiveSupport::CurrentAttributes
-        attribute :request_id
-      end
-
-      it 'supports tagged_logger' do
-        expect(described_class.private_instance_methods).to include(:tagged_logger)
-      end
+    it 'supports tagged_logger', if: ::Rails::VERSION::MAJOR >= 7 do
+      expect(described_class.private_instance_methods).to include(:tagged_logger)
     end
 
     it 'does not leak context between example groups', if: ::Rails::VERSION::MAJOR >= 7 do
@@ -37,17 +31,30 @@ module RSpec::Rails
       expect(results).to all be true
     end
 
-    describe 'CurrentAttributes', order: :defined, if: ::Rails::VERSION::MAJOR >= 7 do
-      include RSpec::Rails::RailsExampleGroup
+    it 'will not leak ActiveSupport::CurrentAttributes between examples', if: ::Rails::VERSION::MAJOR >= 7 do
+      group =
+        RSpec::Core::ExampleGroup.describe("A group", order: :defined) do
+          include RSpec::Rails::RailsExampleGroup
 
-      it 'sets a current attribute' do
-        CurrentSample.request_id = '123'
-        expect(CurrentSample.request_id).to eq('123')
-      end
+          # rubocop:disable Lint/ConstantDefinitionInBlock
+          class CurrentSample < ActiveSupport::CurrentAttributes
+            attribute :request_id
+          end
+          # rubocop:enable Lint/ConstantDefinitionInBlock
 
-      it 'does not leak current attributes' do
-        expect(CurrentSample.request_id).to eq(nil)
-      end
+          it 'sets a current attribute' do
+            CurrentSample.request_id = '123'
+            expect(CurrentSample.request_id).to eq('123')
+          end
+
+          it 'does not leak current attributes' do
+            expect(CurrentSample.request_id).to eq(nil)
+          end
+        end
+
+      expect(
+        group.run(failure_reporter) ? true : failure_reporter.exceptions
+      ).to be true
     end
   end
 end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -1,6 +1,10 @@
 module RSpec::Rails
-  RSpec.describe RailsExampleGroup do
+  RSpec.describe RailsExampleGroup do    
     if ::Rails::VERSION::MAJOR >= 7
+      class CurrentSample < ActiveSupport::CurrentAttributes
+        attribute :request_id
+      end
+
       it 'supports tagged_logger' do
         expect(described_class.private_instance_methods).to include(:tagged_logger)
       end
@@ -33,22 +37,16 @@ module RSpec::Rails
       expect(results).to all be true
     end
 
-    describe 'CurrentAttributes', order: :defined do
+    describe 'CurrentAttributes', order: :defined, if: ::Rails::VERSION::MAJOR >= 7 do
       include RSpec::Rails::RailsExampleGroup
 
-      class Current < ActiveSupport::CurrentAttributes
-        attribute :request_id
-      end
-
       it 'sets a current attribute' do
-        Current.request_id = '123'
-        expect(Current.request_id).to eq('123')
-        expect(Current.attributes).to eq(request_id: '123')
+        CurrentSample.request_id = '123'
+        expect(CurrentSample.request_id).to eq('123')
       end
 
       it 'does not leak current attributes' do
-        expect(Current.request_id).to eq(nil)
-        expect(Current.attributes).to eq({})
+        expect(CurrentSample.request_id).to eq(nil)
       end
     end
   end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -33,38 +33,20 @@ module RSpec::Rails
       expect(results).to all be true
     end
 
-    describe 'CurrentAttributes' do
-      let(:current_class) do 
-        Class.new(ActiveSupport::CurrentAttributes) do
-          attribute :request_id
-        end
+    describe 'CurrentAttributes', order: :defined do
+      class Current < ActiveSupport::CurrentAttributes
+        attribute :request_id
       end
 
-      it 'does not leak current attributes between example groups', if: ::Rails::VERSION::MAJOR >= 7 do
-        groups =
-          [
-            RSpec::Core::ExampleGroup.describe("A group") do
-              include RSpec::Rails::RailsExampleGroup
-              specify { expect(current_class.attributes).to eq({}) }
-            end,
-            RSpec::Core::ExampleGroup.describe("A controller group", type: :controller) do
-              specify do
-                current_class.request_id = "123"
-                expect(current_class.attributes).to eq(request_id: "123")
-              end
-            end,
-            RSpec::Core::ExampleGroup.describe("Another group") do
-              include RSpec::Rails::RailsExampleGroup
-              specify { expect(current_class.attributes).to eq({}) }
-            end
-          ]
-      
-        results =
-          groups.map do |group|
-            group.run(failure_reporter) ? true : failure_reporter.exceptions
-          end
-      
-        expect(results).to all be true
+      it 'sets a current attribute' do
+        Current.request_id = '123'
+        expect(Current.request_id).to eq('123')
+        expect(Current.attributes).to eq(request_id: '123')
+      end
+
+      it 'does not leak current attributes' do
+        expect(Current.request_id).to eq(nil)
+        expect(Current.attributes).to eq({})
       end
     end
   end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -32,5 +32,40 @@ module RSpec::Rails
 
       expect(results).to all be true
     end
+
+    describe 'CurrentAttributes' do
+      let(:current_class) do 
+        Class.new(ActiveSupport::CurrentAttributes) do
+          attribute :request_id
+        end
+      end
+
+      it 'does not leak current attributes between example groups', if: ::Rails::VERSION::MAJOR >= 7 do
+        groups =
+          [
+            RSpec::Core::ExampleGroup.describe("A group") do
+              include RSpec::Rails::RailsExampleGroup
+              specify { expect(current_class.attributes).to eq({}) }
+            end,
+            RSpec::Core::ExampleGroup.describe("A controller group", type: :controller) do
+              specify do
+                current_class.request_id = "123"
+                expect(current_class.attributes).to eq(request_id: "123")
+              end
+            end,
+            RSpec::Core::ExampleGroup.describe("Another group") do
+              include RSpec::Rails::RailsExampleGroup
+              specify { expect(current_class.attributes).to eq({}) }
+            end
+          ]
+      
+        results =
+          groups.map do |group|
+            group.run(failure_reporter) ? true : failure_reporter.exceptions
+          end
+      
+        expect(results).to all be true
+      end
+    end
   end
 end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe RailsExampleGroup do    
+  RSpec.describe RailsExampleGroup do
     if ::Rails::VERSION::MAJOR >= 7
       class CurrentSample < ActiveSupport::CurrentAttributes
         attribute :request_id


### PR DESCRIPTION
We need to include the `ActiveSupport::CurrentAttributes::TestHelper` in the rails example group, otherwise rspec does not reset `ActiveSupport::CurrentAttributes` around each example unless being reset manually. We need to [mimic what Rails v7 does for test setup](https://github.com/rails/rails/blob/v7.0.0/activesupport/lib/active_support/railtie.rb#L50-L61) for the "else" case until #2712 can be revisited. Related to #2713. This should address #2503 properly.

In the meantime, I've created #2753 which recreates #2712 with some new changes since the GHA logs for the original are no longer available, we can't address without a new attempt. Ideally, #2753 would replace this with the suggestion from https://github.com/rspec/rspec-rails/pull/2753#issuecomment-2041110829 if it would work.