### PR TITLE
Fix uninitialized constant RSpec::Rails::OpenStruct error

### DIFF
--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 require 'support/group_failure_formatter'
 
 module RSpec::Rails
@@ -187,7 +188,7 @@ module RSpec::Rails
         Class.new do
           include ViewExampleGroup::ExampleMethods
           def controller
-            @controller ||= OpenStruct.new(params: nil)
+            @controller ||= ::OpenStruct.new(params: nil)
           end
         end.new
       end


### PR DESCRIPTION
This started to occur on recent test suite runs e.g. #2752, #2753. It may be related to a `json` gem update ([example](https://github.com/serpapi/turbo_tests/pull/49)) that removed the `ostruct` dependency as I encountered that with `turbo_tests` which I use to run my rspec test suite.