### PR TITLE
Replace OpenStruct dependency with Struct

### DIFF
--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -1,4 +1,3 @@
-require 'ostruct'
 require 'support/group_failure_formatter'
 
 module RSpec::Rails
@@ -188,7 +187,7 @@ module RSpec::Rails
         Class.new do
           include ViewExampleGroup::ExampleMethods
           def controller
-            @controller ||= ::OpenStruct.new(params: nil)
+            @controller ||= Struct.new(:params).new(nil)
           end
         end.new
       end


### PR DESCRIPTION
Instead of reverting #2754 since it will still fail, this is a new attempt at replacing the OpenStruct dependency with a Struct from this suggestion: https://github.com/rspec/rspec-rails/pull/2754#discussion_r1556524959