### PR TITLE
Fix Mailer Specs heading typo

### DIFF
--- a/features/mailer_specs/README.md
+++ b/features/mailer_specs/README.md
@@ -1,4 +1,4 @@
-# Mailer sepcs
+# Mailer specs
 
 By default Mailer specs reside in the `spec/mailers` folder. Adding the metadata
 `type: :mailer` to any context makes its examples be treated as mailer specs.


### PR DESCRIPTION
Fixes a small typo on the docs for testing mailers.