### PR TITLE
fix: link at mailer preview generator template

### DIFF
--- a/lib/generators/rspec/mailer/templates/preview.rb
+++ b/lib/generators/rspec/mailer/templates/preview.rb
@@ -1,9 +1,9 @@
 <% module_namespacing do -%>
-# Preview all emails at http://localhost:3000/rails/mailers/<%= file_path %>
+# Preview all emails at http://localhost:3000/rails/mailers/<%= file_path %>_mailer
 class <%= class_name %><%= 'Mailer' unless class_name.end_with?('Mailer') %>Preview < ActionMailer::Preview
 <% actions.each do |action| -%>
 
-  # Preview this email at http://localhost:3000/rails/mailers/<%= file_path %>/<%= action %>
+  # Preview this email at http://localhost:3000/rails/mailers/<%= file_path %>_mailer/<%= action %>
   def <%= action %>
     <%= class_name.sub(/(Mailer)?$/, 'Mailer') %>.<%= action %>
   end


### PR DESCRIPTION
When I execute:
```
rails g mailer users/confirmations
```
The link to the preview at the comment is this:
```
http://localhost:3000/rails/mailers/users/confirmations
```

This route raises this error:
```
Unknown action
Mailer preview 'users/confirmations' not found
```
So I fixed it.