### PR TITLE
HaveHttpStatus uses Rack's public API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Bug Fixes:
 
 * Reset `ActiveSupport::CurrentAttributes` between examples. (Javier Julio, #2752)
 * Fix a broken link in generated mailer previews. (Chiara Núñez, #2764)
+* Have HttpStatusMatcher use Rack's public API for http status code. (Darren Boyd, #2763)
 
 ### 6.1.2 / 2024-03-19
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v6.1.1...v6.1.2)

--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -216,11 +216,7 @@ module RSpec
           # @see Rack::Utils::SYMBOL_TO_STATUS_CODE
           # @raise [ArgumentError] if an associated code could not be found
           def set_expected_code!
-            @expected ||=
-              Rack::Utils::SYMBOL_TO_STATUS_CODE.fetch(expected_status) do
-                raise ArgumentError,
-                      "Invalid HTTP status: #{expected_status.inspect}"
-              end
+            @expected ||= Rack::Utils.status_code(expected_status)
           end
         end
 


### PR DESCRIPTION

Rack has recently changed the name of the 422 status code from `unprocessable_entity` to `unprocessable_content`. Since `HaveHttpStatus` was looking up the code directly through the constant in Rack, this forced developers to rename this value in their codebase in the same change upgrade Rack.  Using Rack's public API method (`Rack::Utils.status_code`) allows users to transition from the old name to the new name on their own schedule.

This change fixes #2763 