### PR TITLE
Fix build for Rails 7.1 / Ruby 2.7 through vendoring capybara server fix

### DIFF
--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -11,6 +11,7 @@ ci_retry_script = File.join(
   'ci_retry_bundle_install.sh'
 )
 function_script_file = File.join(rspec_rails_repo_path, 'script/functions.sh')
+capybara_backport_path = File.join(rspec_rails_repo_path, 'example_app_generator/spec/support/capybara.rb')
 
 in_root do
   prepend_to_file "Rakefile", "require 'active_support/all'"
@@ -63,6 +64,8 @@ in_root do
             'REPLACE_BUNDLE_PATH',
             bundle_install_path
   chmod 'ci_retry_bundle_install.sh', 0755
+
+  copy_file capybara_backport_path, 'spec/support/capybara.rb'
 
   if Rails::VERSION::STRING > '7'
     create_file 'app/assets/config/manifest.js' do

--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -146,6 +146,7 @@ using_source_path(File.expand_path(__dir__)) do
 end
 
 gsub_file 'spec/spec_helper.rb', /^=(begin|end)/, ''
+gsub_file 'spec/rails_helper.rb', /^# Rails\.root\.glob\('spec.support/, "Rails.root.glob('spec/support"
 
 # Warnings are too noisy in the sample apps
 gsub_file 'spec/spec_helper.rb',

--- a/example_app_generator/spec/support/capybara.rb
+++ b/example_app_generator/spec/support/capybara.rb
@@ -1,0 +1,51 @@
+# This is a backport of a fix that was included in capybara 3.40.0 which was also Ruby version locked to 3.0+
+if RUBY_VERSION.to_f < 3 && Rails::VERSION::STRING.to_f >= 7.1
+  Capybara.register_server :puma do |app, port, host, **options|
+    begin
+      require 'rackup'
+    rescue LoadError # rubocop:disable Lint/SuppressedException
+    end
+    begin
+      require 'rack/handler/puma'
+    rescue LoadError
+      raise LoadError, 'Capybara is unable to load `puma` for its server, please add `puma` ' \
+        'to your project or specify a different server via something like `Capybara.server = :webrick`.'
+    end
+    puma_rack_handler = defined?(Rackup::Handler::Puma) ? Rackup::Handler::Puma : Rack::Handler::Puma
+
+    unless puma_rack_handler.respond_to?(:config)
+      raise LoadError, 'Capybara requires `puma` version 3.8.0 or higher,' \
+        ' please upgrade `puma` or register and specify your own server block'
+    end
+
+    # If we just run the Puma Rack handler it installs signal handlers which prevent us from being able to interrupt tests.
+    # Therefore construct and run the Server instance ourselves.
+    # puma_rack_handler.run(app, { Host: host, Port: port, Threads: "0:4", workers: 0, daemon: false }.merge(options))
+    default_options = { Host: host, Port: port, Threads: '0:4', workers: 0, daemon: false }
+    options = default_options.merge(options)
+
+    conf = puma_rack_handler.config(app, options)
+    conf.clamp
+
+    puma_ver = Gem::Version.new(Puma::Const::PUMA_VERSION)
+    require 'capybara/registrations/patches/puma_ssl' if Gem::Requirement.new('>=4.0.0', '< 4.1.0').satisfied_by?(puma_ver)
+
+    logger = (defined?(Puma::LogWriter) ? Puma::LogWriter : Puma::Events).then do |cls|
+      conf.options[:Silent] ? cls.strings : cls.stdio
+    end
+    conf.options[:log_writer] = logger
+
+    logger.log 'Capybara starting Puma...'
+    logger.log "* Version #{Puma::Const::PUMA_VERSION}, codename: #{Puma::Const::CODE_NAME}"
+    logger.log "* Min threads: #{conf.options[:min_threads]}, max threads: #{conf.options[:max_threads]}"
+
+    Puma::Server.new(
+      conf.app,
+      defined?(Puma::LogWriter) ? nil : logger,
+      conf.options
+    ).tap do |s|
+      s.binder.parse conf.options[:binds], (s.log_writer rescue s.events) # rubocop:disable Style/RescueModifier
+      s.min_threads, s.max_threads = conf.options[:min_threads], conf.options[:max_threads] if s.respond_to? :min_threads=
+    end.run.join
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -59,10 +59,20 @@ Before do
   # We want fresh `example_app` project with empty `spec` dir except helpers.
   # FileUtils.cp_r on Ruby 1.9.2 doesn't preserve permissions.
   system('cp', '-r', example_app_dir, aruba_dir)
-  helpers = %w[spec/spec_helper.rb spec/rails_helper.rb]
-  Dir["#{aruba_dir}/spec/*"].each do |path|
+  helpers = %w[spec/spec_helper.rb spec/rails_helper.rb spec/support/capybara.rb]
+  directories = []
+
+  Dir["#{aruba_dir}/spec/**/*"].each do |path|
     next if helpers.any? { |helper| path.end_with?(helper) }
+
+    # Because we now check for things like spec/support we only want to delete empty directories
+    if File.directory?(path)
+      directories << path
+      next
+    end
 
     FileUtils.rm_rf(path)
   end
+
+  directories.each { |dir| FileUtils.rm_rf(dir) if Dir.empty?(dir) }
 end

--- a/features/system_specs/system_specs.feature
+++ b/features/system_specs/system_specs.feature
@@ -87,7 +87,6 @@ Feature: System specs
     Given a file named "spec/system/widget_system_spec.rb" with:
       """ruby
       require "rails_helper"
-      require_relative "../support/capybara.rb"
 
       RSpec.describe "Widget management", type: :system do
         before do

--- a/features/system_specs/system_specs.feature
+++ b/features/system_specs/system_specs.feature
@@ -87,6 +87,7 @@ Feature: System specs
     Given a file named "spec/system/widget_system_spec.rb" with:
       """ruby
       require "rails_helper"
+      require_relative "../support/capybara.rb"
 
       RSpec.describe "Widget management", type: :system do
         before do


### PR DESCRIPTION
Ruby 2.7 / Rails 7.1 is broken due to a rack / rackup changes for puma which were released in capybara 3.40 but this version didn't support Ruby 2.7, this attempts to backport that fix into the driver manually (its based off #2768)