### PR TITLE
Support `have_http_status` with `Rack::MockResponse`

### DIFF
--- a/lib/rspec/rails/matchers/have_http_status.rb
+++ b/lib/rspec/rails/matchers/have_http_status.rb
@@ -33,7 +33,7 @@ module RSpec
         # @param obj [Object] object to convert to a response
         # @return [ActionDispatch::TestResponse]
         def as_test_response(obj)
-          if ::ActionDispatch::Response === obj
+          if ::ActionDispatch::Response === obj || ::Rack::MockResponse === obj
             ::ActionDispatch::TestResponse.from_response(obj)
           elsif ::ActionDispatch::TestResponse === obj
             obj

--- a/spec/rspec/rails/matchers/have_http_status_spec.rb
+++ b/spec/rspec/rails/matchers/have_http_status_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe "have_http_status" do
       end
     end
 
+    context "given a Rack::MockResponse" do
+      it "returns true for a response with the same code" do
+        response = ::Rack::MockResponse.new(code, {}, "")
+
+        expect(matcher.matches?(response)).to be(true)
+      end
+    end
+
     context "given an ActionDispatch::TestResponse" do
       it "returns true for a response with the same code" do
         response = ::ActionDispatch::TestResponse.new(code).tap { |x|


### PR DESCRIPTION
When using `rack-test`, doing something like `expect(last_response).to have_http_status(:ok)` would fail with the error "expected a response object, but an instance of Rack::MockResponse was received".

This PR creates a `ActionDispatch::TestResponse` from the `Rack::MockResponse` to make `have_http_status` usable in specs relying on `rack-test` to perform requests.

It should fix rubocop/rubocop-rspec_rails#20.

Reproduction script:
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  gem "rails", "6.1.0"
  gem "rspec-rails"
end

require "rspec-rails"
require "action_controller/railtie"

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << "example.org"
  config.session_store :cookie_store, key: "cookie_store_key"
  secrets.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  routes.draw do
    get "/" => "test#index"
  end
end

class TestController < ActionController::Base
  include Rails.application.routes.url_helpers

  def index
    render plain: "Hello, World!"
  end
end

require "rspec/autorun"
require "rspec/rails/matchers"

RSpec.describe "additions", type: :request do
  include Rack::Test::Methods
  include RSpec::Rails::Matchers

  it do
    get "/"
    expect(last_response).to have_http_status(:ok)
  end

  private

  def app
    Rails.application
  end
end
```