### PR TITLE
Rework reset behaviour of ActiveSupport::CurrentAttributes

### DIFF
--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -138,30 +138,10 @@ module RSpec
 
     # @private
     #
-    # ActiveSupport::CurrentAttributes::TestHelper uses both before-setup and
-    # after-teardown hooks to clear attributes. These are run in an awkward
-    # order relative to RSpec hooks. Client suite-configured "around each"
-    # hooks run first, the attribute reset hooks next, and contexts or examples
-    # (along with whatever their defined hooks might be) run last. Consequently
-    # a suite which sets up around-each-example attributes could fail, because
-    # the attributes would have been reset by time tests actually run.
+    # Reset ActiveSupport::CurrentAttributes only *after* tests run, rather
+    # than before *and* after.
     #
-    # Reworking with "before" rather than "around" hooks sidesteps the problem.
-    # Unfortunately, "executes via a block to clean up after itself" cases such
-    # as with "ActsAsTenant.without_tenant ..." make such a rework either hard
-    # or impossible. Besides, even realising that you may need to do this can
-    # take some significant debugging effort and insight.
-    #
-    # The compromise is to use "half" of what ActiveSupport does - just add the
-    # after-hook. Attributes are now only reset after examples run, but still
-    # before a suite-wide "around" hook's call to "example.run()" returns. If a
-    # test suite depended upon current attribute data still being set *after*
-    # examples within its suite-wide "around" hook, it would fail. This is
-    # unlikely; it's overwhelmingly common to just *set up* data before a test,
-    # and usually the only things you're doing afterwards are cleanup.
-    #
-    # Include this module to reset under the above compromise, instead of
-    # including ActiveSupport::CurrentAttributes::TestHelper.
+    # See https://github.com/rspec/rspec-rails/pull/2774 for more details.
     #
     module ActiveSupportCurrentAttributesAdapter
       extend ActiveSupport::Concern

--- a/lib/rspec/rails/adapters.rb
+++ b/lib/rspec/rails/adapters.rb
@@ -148,7 +148,6 @@ module RSpec
 
       included do
         def after_teardown
-          puts "AFTER TEARDOWN"
           super
           ActiveSupport::CurrentAttributes.reset_all
         end

--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -19,7 +19,7 @@ module RSpec
       include RSpec::Rails::FixtureSupport
       if ::Rails::VERSION::MAJOR >= 7
         include RSpec::Rails::TaggedLoggingAdapter
-        include ActiveSupport::CurrentAttributes::TestHelper
+        include RSpec::Rails::ActiveSupportCurrentAttributesAdapter
         include ActiveSupport::ExecutionContext::TestHelper
       end
     end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -56,5 +56,85 @@ module RSpec::Rails
         group.run(failure_reporter) ? true : failure_reporter.exceptions
       ).to be true
     end
+
+    context 'with suite-level around-example hooks configured', if: ::Rails::VERSION::MAJOR >= 7 do
+      let(:uniquely_identifiable_metadata) do
+        { configured_around_example_hook: true }
+      end
+
+      class CurrentAttrsBetweenHooks < ActiveSupport::CurrentAttributes
+        attribute :request_id
+      end
+
+      # We have to modify the suite's around-each in RSpec.config, but don't
+      # want to pollute other tests with this (whether or not it is harmless
+      # to do so). There being no public API to read or remove hooks, instead
+      # it's necessary use some private APIs to be able to delete the added
+      # hook via 'ensure'.
+      #
+      around :each do | example |
+
+        # Client code might legitimately want to wrap examples to ensure
+        # all-conditions tidy-up, e.g. "ActsAsTenant.without_tenant do...",
+        # wherein an "around" hook is the only available solution, often used
+        # in the overall suite via "config.around". Tests would not expect
+        # anything set in CurrentAttributes here to suddenly be reset by the
+        # time their actual tests, or their test hooks ran.
+        #
+        RSpec.configure do | config |
+          config.around(:each, uniquely_identifiable_metadata()) do | example |
+            CurrentAttrsBetweenHooks.request_id = '123'
+            example.run()
+          end
+        end
+
+        example.run()
+
+      ensure
+        around_example_repository = RSpec.configuration.hooks.send(:hooks_for, :around, :example)
+        item_we_added = around_example_repository.items_for(uniquely_identifiable_metadata()).first
+        around_example_repository.delete(item_we_added, uniquely_identifiable_metadata())
+      end
+
+      it 'does not reset ActiveSupport::CurrentAttributes before examples' do
+        group =
+          RSpec::Core::ExampleGroup.describe('A group', uniquely_identifiable_metadata()) do
+            include RSpec::Rails::RailsExampleGroup
+
+            it 'runs normally' do
+              expect(CurrentAttrsBetweenHooks.request_id).to eq('123')
+            end
+          end
+
+        expect(
+          group.run(failure_reporter) ? true : failure_reporter.exceptions
+        ).to be true
+      end
+
+      it 'does not reset ActiveSupport::CurrentAttributes before before-each hooks' do
+        group =
+          RSpec::Core::ExampleGroup.describe('A group', uniquely_identifiable_metadata()) do
+            include RSpec::Rails::RailsExampleGroup
+
+            # Client code will often have test setup blocks within "*_spec.rb"
+            # files that might set up data or other environmental factors for a
+            # group of tests in e.g. a "before" hook, but would reasonably expect
+            # suite-wide 'around' settings to remain intact and not be reset.
+            #
+            before :each do | example |
+              expect(CurrentAttrsBetweenHooks.request_id).to eq('123')
+              CurrentAttrsBetweenHooks.request_id = '234'
+            end
+
+            it 'runs normally' do
+              expect(CurrentAttrsBetweenHooks.request_id).to eq('234')
+            end
+          end
+
+        expect(
+          group.run(failure_reporter) ? true : failure_reporter.exceptions
+        ).to be true
+      end
+    end # "context 'with suite-level around-example hooks configured' ..."
   end
 end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -91,7 +91,6 @@ module RSpec::Rails
       end
 
       it 'does not reset ActiveSupport::CurrentAttributes before examples' do
-        in_sub_process do
           group =
             RSpec::Core::ExampleGroup.describe('A group', uniquely_identifiable_metadata) do
               include RSpec::Rails::RailsExampleGroup

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -73,7 +73,7 @@ module RSpec::Rails
       # This dirties global state, so tests *MUST* remember to use
       # "in_sub_process".
       #
-      before :each do
+      def configure_rspec_to_set_current_attrs_before_around_example
 
         # Client code might legitimately want to wrap examples to ensure
         # all-conditions tidy-up, e.g. "ActsAsTenant.without_tenant do...",

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -91,6 +91,7 @@ module RSpec::Rails
       end
 
       it 'does not reset ActiveSupport::CurrentAttributes before examples' do
+        configure_rspec_to_set_current_attrs_before_around_example
           group =
             RSpec::Core::ExampleGroup.describe('A group', uniquely_identifiable_metadata) do
               include RSpec::Rails::RailsExampleGroup

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -1,3 +1,5 @@
+require 'rspec/support/spec/in_sub_process'
+
 module RSpec::Rails
   RSpec.describe RailsExampleGroup do
     it 'supports tagged_logger', if: ::Rails::VERSION::MAJOR >= 7 do
@@ -68,13 +70,10 @@ module RSpec::Rails
       end
       # rubocop:enable Lint/ConstantDefinitionInBlock
 
-      # We have to modify the suite's around-each in RSpec.config, but don't
-      # want to pollute other tests with this (whether or not it is harmless
-      # to do so). There being no public API to read or remove hooks, instead
-      # it's necessary use some private APIs to be able to delete the added
-      # hook via 'ensure'.
+      # This dirties global state, so tests *MUST* remember to use
+      # "in_sub_process".
       #
-      around :each do | outer_example |
+      before :each do
 
         # Client code might legitimately want to wrap examples to ensure
         # all-conditions tidy-up, e.g. "ActsAsTenant.without_tenant do...",
@@ -84,58 +83,55 @@ module RSpec::Rails
         # time their actual tests, or their test hooks ran.
         #
         RSpec.configure do | config |
-          config.around(:each, uniquely_identifiable_metadata) do | inner_example |
+          config.around(:each, uniquely_identifiable_metadata) do | example |
             CurrentAttrsBetweenHooks.request_id = '123'
-            inner_example.run
+            example.run
           end
         end
-
-        outer_example.run
-
-      ensure
-        around_example_repository = RSpec.configuration.hooks.send(:hooks_for, :around, :example)
-        item_we_added = around_example_repository.items_for(uniquely_identifiable_metadata).first
-        around_example_repository.delete(item_we_added, uniquely_identifiable_metadata)
       end
 
       it 'does not reset ActiveSupport::CurrentAttributes before examples' do
-        group =
-          RSpec::Core::ExampleGroup.describe('A group', uniquely_identifiable_metadata) do
-            include RSpec::Rails::RailsExampleGroup
+        in_sub_process do
+          group =
+            RSpec::Core::ExampleGroup.describe('A group', uniquely_identifiable_metadata) do
+              include RSpec::Rails::RailsExampleGroup
 
-            it 'runs normally' do
-              expect(CurrentAttrsBetweenHooks.request_id).to eq('123')
+              it 'runs normally' do
+                expect(CurrentAttrsBetweenHooks.request_id).to eq('123')
+              end
             end
-          end
 
-        expect(
-          group.run(failure_reporter) ? true : failure_reporter.exceptions
-        ).to be true
+          expect(
+            group.run(failure_reporter) ? true : failure_reporter.exceptions
+          ).to be true
+        end
       end
 
       it 'does not reset ActiveSupport::CurrentAttributes before before-each hooks' do
-        group =
-          RSpec::Core::ExampleGroup.describe('A group', uniquely_identifiable_metadata) do
-            include RSpec::Rails::RailsExampleGroup
+        in_sub_process do
+          group =
+            RSpec::Core::ExampleGroup.describe('A group', uniquely_identifiable_metadata) do
+              include RSpec::Rails::RailsExampleGroup
 
-            # Client code will often have test setup blocks within "*_spec.rb"
-            # files that might set up data or other environmental factors for a
-            # group of tests in e.g. a "before" hook, but would reasonably expect
-            # suite-wide 'around' settings to remain intact and not be reset.
-            #
-            before :each do
-              expect(CurrentAttrsBetweenHooks.request_id).to eq('123')
-              CurrentAttrsBetweenHooks.request_id = '234'
+              # Client code will often have test setup blocks within "*_spec.rb"
+              # files that might set up data or other environmental factors for a
+              # group of tests in e.g. a "before" hook, but would reasonably expect
+              # suite-wide 'around' settings to remain intact and not be reset.
+              #
+              before :each do
+                expect(CurrentAttrsBetweenHooks.request_id).to eq('123')
+                CurrentAttrsBetweenHooks.request_id = '234'
+              end
+
+              it 'runs normally' do
+                expect(CurrentAttrsBetweenHooks.request_id).to eq('234')
+              end
             end
 
-            it 'runs normally' do
-              expect(CurrentAttrsBetweenHooks.request_id).to eq('234')
-            end
-          end
-
-        expect(
-          group.run(failure_reporter) ? true : failure_reporter.exceptions
-        ).to be true
+          expect(
+            group.run(failure_reporter) ? true : failure_reporter.exceptions
+          ).to be true
+        end
       end
     end
   end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -82,8 +82,8 @@ module RSpec::Rails
         # anything set in CurrentAttributes here to suddenly be reset by the
         # time their actual tests, or their test hooks ran.
         #
-        RSpec.configure do | config |
-          config.around(:each, uniquely_identifiable_metadata) do | example |
+        RSpec.configure do |config|
+          config.around(:each) do |example|
             CurrentAttrsBetweenHooks.request_id = '123'
             example.run
           end


### PR DESCRIPTION
Compromise solution to [#2773](https://github.com/rspec/rspec-rails/issues/2773).
Fixes #2773

* TL;DR - only resets `ActiveSupport::CurrentAttributes` _after_ examples run, rather than both before and after.

Consider a `spec_helper.rb` that uses something like [ActsAsTenant](http://rubygems.org/gems/acts_as_tenant) to wrap all examples, or anything similar where a block is used in order for whatever it is you're calling to handle cleanup itself automatically when the block finishes executing.

```ruby
config.around :each do | example |
  ActsAsTenant.without_tenant do
    example.run()
  end
end
```

In RSpec Rails 6.1.3, inclusion of `ActiveSupport::CurrentAttributes::TestHelper` means that attributes get reset both (in Rails terms) before setup *and* after teardown. What this means for RSpec hooks is that the resets happen *between* the suite-wide configuration "around" hooks and any examples or contexts. So, if we subsequently have an innocent test like this:

```ruby
it 'does something that requires ActsAsTenant.without_tenant to be asserted' do
  some_operation()
end
```

...then the test will work with RSpec Rails 6.1.2 or earlier, but fail with 6.1.3, because ActsAsTenant uses `ActiveSupport::CurrentAttributes` under the hood and its no-tenancy assertion will have been reset between the "around" hook and the test run.

The most robust solution would to be to try and insert an RSpec around-hook that is at the very end of the chain, and resets *after* running the example. This is difficult to do cleanly within RSpec Rails and [there is a desire to not drift too far from what Rails does itself](https://github.com/rspec/rspec-rails/issues/2773#issuecomment-2205345723). Therefore, the compromise suggested here uses the "adapters" module pattern in RSpec Rails to add an adapter for attribute reset that does the after-teardown reset only. The compromise here is that yes, this still happens after any examples are finished, but going back to that code above:

```ruby
config.around :each do | example |
  ActsAsTenant.without_tenant do
    example.run()
  end
end
```

...once `example.run()` returned, code that cared to check would find attributes were now already reset. This is considered pretty unlikely, and a better compromise than the known and hard to fix use cases of things like asserting tenancy, or a logged in user suite-wide in an around-each hook. I'm not aware of cases where a suite-wide configured around-each hook would care *after* an example about attribute data that was set within it (except perhaps to verify that it was reset - and it will be!). Bear in mind that this behaviour is present in RSpec Rails 6.1.3 anyway since it also has the teardown callback; this patch just avoids the on-setup reset.

Test coverage is included and it's a bit gnarly because we do have to simulate an RSpec-configured "around each" hook without accidentally polluting subsequent tests with that configuration change (whether this would be harmless or not, it's bad behaviour and would very fractionally slow down the execution speed of RSpec Rails's test suite).