### PR TITLE
Extract `cell_selector` method in scaffold index view spec generator

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Enhancements:
 * Verify ActiveJob arguments by comparing to the method signature. (Oli Peate, #2745)
 * Add suggestion to rails_helper.rb to skip when not in test most. (Glauco Custódio, #2751)
 * Add `at_priority` qualifier to `have_enqueued_job` set of matchers. (mbajur, #2759)
+* Remove Rails version-specific conditional from index scaffold generation. (Matt Jankowski, #2777)
 
 Bug Fixes:
 

--- a/lib/generators/rspec/scaffold/templates/index_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/index_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "<%= ns_table_name %>/index", <%= type_metatag(:view) %> do
 
   it "renders a list of <%= ns_table_name %>" do
     render
-    cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td'
+    cell_selector = <%= Rails::VERSION::STRING >= '7' ? "'div>p'" : "'tr>td'" %>
 <% for attribute in output_attributes -%>
     assert_select cell_selector, text: Regexp.new(<%= value_for(attribute) %>.to_s), count: 2
 <% end -%>

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -268,6 +268,12 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
                              .and(contain(/^RSpec.describe "(.*)\/index", #{type_metatag(:view)}/))
                              .and(contain(/assign\(:posts, /))
                              .and(contain(/it "renders a list of (.*)"/))
+
+          if ::Rails::VERSION::STRING >= '7.0.0'
+            expect(filename).to contain(/'div>p'/)
+          else
+            expect(filename).to contain(/'tr>td'/)
+          end
         end
       end
 


### PR DESCRIPTION
Basically same change as described in https://github.com/rspec/rspec-rails/pull/2619 - re-attempting only because of last comment - https://github.com/rspec/rspec-rails/pull/2619#issuecomment-1250240003 - which seemed to indicate a desire to get the logic into the generator and out of the generated spec file.

I read the linked discussion and it wasn't totally clear to me which portions involved people talking slightly past each other (about CI vs developer env) and which were genuine issues (that I may have not resolved here, if they exist?) so apologies if that's the case, and I can close and/or attempt to resolve. From my current understanding this does seem safe -- in CI environments or dev environments for working on rspec-rails itself, you'd presumably either have a fresh/clean run and/or clobber first and it should be ok; and for local rails-app development, if you had a prior-version generated spec+view they'd work in conjunction with each other, and this would continue to be true if you switched versions and started generating new ones, I think?

I agree with one of the comments in the linked discussion about how you would likely change this value pretty early on, but also that having the rails version conditional in the generated spec is slightly confusing when you first see it.