### PR TITLE
Register stats directories with Rails::CodeStatistics.register_directory

### DIFF
--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -9,6 +9,25 @@ module RSpec
       # As of Rails 5.1.0 you can register directories to work with `rake notes`
       require 'rails/source_annotation_extractor'
       ::Rails::SourceAnnotationExtractor::Annotation.register_directories("spec")
+
+      # As of Rails 8.0.0 you can register directories to work with `rails stats`
+      if ::Rails::VERSION::STRING >= "8.0.0"
+        require 'rails/code_statistics'
+        types = begin
+                  dirs = Dir['./spec/**/*_spec.rb']
+                    .map { |f| f.sub(/^\.\/(spec\/\w+)\/.*/, '\\1') }
+                    .uniq
+                    .select { |f| File.directory?(f) }
+                  Hash[dirs.map { |d| [d.split('/').last, d] }]
+                end
+        types.each do |type, dir|
+          name = type.singularize.capitalize
+
+          ::Rails::CodeStatistics.register_directory "#{name} specs", dir
+          ::Rails::CodeStatistics::TEST_TYPES << "#{name} specs"
+        end
+      end
+
       generators = config.app_generators
       generators.integration_tool :rspec
       generators.test_framework :rspec

--- a/lib/rspec/rails/tasks/rspec.rake
+++ b/lib/rspec/rails/tasks/rspec.rake
@@ -5,7 +5,9 @@ end
 
 task default: :spec
 
-task stats: "spec:statsetup"
+if ::Rails::VERSION::STRING < "8.0.0"
+  task stats: "spec:statsetup"
+end
 
 desc "Run all specs in spec directory (excluding plugin specs)"
 RSpec::Core::RakeTask.new(spec: "spec:prepare")


### PR DESCRIPTION
Rails `main` uses Thor for the `bin/rails stats` command instead of
Rake. This means stats directories need to be added in the Railtie.

The global constant STATS_DIRECTORIES defined by Rails, has been
deprecated in favor of Rails::CodeStatistics.register_directory.

https://github.com/rails/rails/blob/8c7754dfdf39ed94cc93bbc40ee721c311b6d32c/railties/CHANGELOG.md?plain=1#L1-L11