### PR TITLE
Allow sqlite3 gem to float to version 2

### DIFF
--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -16,7 +16,7 @@ if RUBY_VERSION.to_f < 3
   # sqlite3 1.7.x doesn't work on all platforms for Ruby 2.x
   gem 'sqlite3', '~> 1.4', '< 1.7', platforms: [:ruby]
 else
-  gem 'sqlite3', '~> 1.4', platforms: [:ruby]
+  gem 'sqlite3', '>= 1.4', platforms: [:ruby]
 end
 
 if RUBY_VERSION.to_f < 2.7

--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -33,7 +33,7 @@ in_root do
   if RUBY_VERSION.to_f < 3
     gsub_file "Gemfile", /.*gem..sqlite3.*/, "gem 'sqlite3', '~> 1.4', '< 1.7'"
   else
-    gsub_file "Gemfile", /.*gem..sqlite3.*/, "gem 'sqlite3', '~> 1.4'"
+    gsub_file "Gemfile", /.*gem..sqlite3.*/, "gem 'sqlite3', '>= 1.4'"
   end
 
   # remove webdrivers


### PR DESCRIPTION
Rails main requires `sqlite3` version 2:
https://github.com/rails/rails/pull/51958