### PR TITLE
rails_helper template: Restore old order of support files

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -25,7 +25,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
+# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 <% if RSpec::Rails::FeatureCheck.has_active_record_migration? -%>
 # Checks for pending migrations and applies them before tests are run.


### PR DESCRIPTION
Before #2678, the suggested code snippet for loading support files loaded files in directories (e.g. `spec/support/a/b.rb`) *after* files with the same basename as those directories (e.g. `spec/support/a.rb`).

This tends to be the preferrable load order, given how Ruby modules and classes are usually structured.

The root cause is a difference between the alphabetic ordering of string sorting compared to `Pathname#<=>`.