### PR TITLE
Drop support for rails versions < 7 in scaffold generator

### DIFF
--- a/lib/generators/rspec/scaffold/templates/index_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/index_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "<%= ns_table_name %>/index", <%= type_metatag(:view) %> do
 
   it "renders a list of <%= ns_table_name %>" do
     render
-    cell_selector = <%= Rails::VERSION::STRING >= '7' ? "'div>p'" : "'tr>td'" %>
+    cell_selector = 'div>p'
 <% for attribute in output_attributes -%>
     assert_select cell_selector, text: Regexp.new(<%= value_for(attribute) %>.to_s), count: 2
 <% end -%>

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -269,11 +269,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
                              .and(contain(/assign\(:posts, /))
                              .and(contain(/it "renders a list of (.*)"/))
 
-          if ::Rails::VERSION::STRING >= '7.0.0'
-            expect(filename).to contain(/'div>p'/)
-          else
-            expect(filename).to contain(/'tr>td'/)
-          end
+          expect(filename).to contain(/'div>p'/)
         end
       end
 


### PR DESCRIPTION
With rspec-rails 7.0.0 release, my assumption is that it's safe/desired to drop support for any rails-conditional stuff earlier than 7.0?

This is a followup on https://github.com/rspec/rspec-rails/pull/2777 which removes the conditional and just uses the style generated by rails 7.0 and higher.

Side note - opened this PR just b/c the prior one was mine and this change made sense to me from previous PR when I saw the 7.0.0 release version support. Would other PRs of this nature (cleaning up conditional support checks) be welcome?