### PR TITLE
Update method name in HaveEnqueuedMail (job_match? to job_matches?)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v7.0.1...main)
 
+Bug Fixes:
+
+* Fix `have_enqueued_mail` wrongful failure when expecting no enqueued mail but
+  a non-mail job is enqueued. (David Runger, #2793)
+
 ### 7.0.1 / 2024-09-03
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v7.0.0...v7.0.1)
 

--- a/lib/rspec/rails/matchers/have_enqueued_mail.rb
+++ b/lib/rspec/rails/matchers/have_enqueued_mail.rb
@@ -72,7 +72,7 @@ module RSpec
           @mailer_class ? @mailer_class.name : 'ActionMailer::Base'
         end
 
-        def job_match?(job)
+        def job_matches?(job)
           legacy_mail?(job) || parameterized_mail?(job) || unified_mail?(job)
         end
 
@@ -123,7 +123,7 @@ module RSpec
 
         def unmatching_mail_jobs
           @unmatching_jobs.select do |job|
-            job_match?(job)
+            job_matches?(job)
           end
         end
 


### PR DESCRIPTION
This change fixes a bug wherein a spec that expects no mail to have been enqueued will fail (falsely claiming that a mail _was_ enqueued) if any _non-mail_ job is enqueued, even if indeed no _mail_ job is actually enqueued.

This bug was introduced in ab6e6e83 / #2780 , which was first included in the 7.0.0 release.

In that change, the `RSpec::Rails::Matchers::ActiveJob::Base` `job_match?` instance method was renamed to `job_matches?`. The problem is that `RSpec::Rails::Matchers::HaveEnqueuedMail`, which inherits from `RSpec::Rails::Matchers::ActiveJob::Base` (via
`RSpec::Rails::Matchers::ActiveJob::HaveEnqueuedJob`), intends to override that method, which it does by defining its own `job_match?` instance method. However, because this `job_match?` method name is no longer the same as the (now so called) `job_matches?` method that it intends to override, the `job_match?` method of
`RSpec::Rails::Matchers::HaveEnqueuedMail` is no longer having the intended override effect on the behavior of the matcher, producing the aforementioned bug.

This change resolves the issue by updating the method name in the `RSpec::Rails::Matchers::HaveEnqueuedMail` subclass from `job_match?` to `job_matches?`, reflecting that renaming that was done in the parent class in ab6e6e83 .