### PR TITLE
Add 'ostruct' to example app Gemfile

### DIFF
--- a/example_app_generator/generate_app.rb
+++ b/example_app_generator/generate_app.rb
@@ -25,6 +25,7 @@ in_root do
   gsub_file "Gemfile", /.*puma.*/, ''
   gsub_file "Gemfile", /.*bootsnap.*/, ''
 
+  append_to_file 'Gemfile', "gem 'ostruct'\n"
   append_to_file 'Gemfile', "gem 'rails-controller-testing'\n"
 
   gsub_file "Gemfile", /.*rails-controller-testing.*/, "gem 'rails-controller-testing', git: 'https://github.com/rails/rails-controller-testing'"


### PR DESCRIPTION
Currently, specs are failing for the "Ruby: 3.3, Rails: ~> 7.1.0" and "Ruby: 3.3, Rails: ~> 7.2.0" matrix builds. This is caused by Ruby 3.3.5 (released yesterday, 2024-09-03) now warning if `ostruct` is loaded from the standard library, rather than from a gem.

This change fixes the failing specs by adding the `ostruct` gem to the `Gemfile` of the example app, which causes the problematic warning not to be emitted by Ruby.