### PR TITLE
Fix rails main for solid cache

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -188,7 +188,7 @@ namespace :no_active_record do
 
     desc "generate a bunch of stuff with generators"
     task :stuff do
-      in_example_app "bin/rake #{rails_template_command} LOCATION='../../example_app_generator/generate_stuff.rb'", app_dir: example_app_dir
+      in_example_app "bin/rake #{rails_template_command} LOCATION='../../example_app_generator/generate_stuff.rb' __RSPEC_NO_AR=true", app_dir: example_app_dir
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -105,6 +105,11 @@ namespace :smoke do
     in_example_app args.cmd.to_s
   end
 
+  desc "run rake routes in example app"
+  task :routes do
+    in_example_app "bin/rails routes"
+  end
+
   desc "run RSPEC_OPTS environment variable in the example app for local dev"
   task :rspec do
     in_example_app "LOCATION='../../example_app_generator/run_specs.rb' bin/rspec #{ENV.fetch("RSPEC_OPTS")}"
@@ -143,6 +148,11 @@ namespace :no_active_record do
       "no_active_record:generate:stuff",
       "no_active_record:smoke",
     ]
+
+    desc "run rake routes in example app"
+    task :routes do
+      in_example_app "bin/rails routes", app_dir: example_app_dir
+    end
 
     desc "run RSPEC_OPTS environment variable in the example app for local dev"
     task :rspec do

--- a/Rakefile
+++ b/Rakefile
@@ -165,7 +165,7 @@ namespace :no_active_record do
         sh "rm -f #{bindir}/rails"
         sh "bundle exec rails new #{example_app_dir} --no-rc --skip-active-record --skip-javascript --skip-bootsnap " \
            "--skip-sprockets --skip-git --skip-test-unit --skip-listen --skip-bundle --skip-spring " \
-           "--skip-action-text --template=example_app_generator/generate_app.rb"
+           "--skip-action-text --skip-solid --template=example_app_generator/generate_app.rb"
 
         in_example_app(app_dir: example_app_dir) do
           sh "./ci_retry_bundle_install.sh 2>&1"

--- a/example_app_generator/generate_stuff.rb
+++ b/example_app_generator/generate_stuff.rb
@@ -57,10 +57,10 @@ module ExampleAppHooks
   end
 
   def self.environment_hooks
-    if defined?(ActiveRecord)
-      AR
-    else
+    if ENV['__RSPEC_NO_AR']
       NoAR
+    else
+      AR
     end
   end
 end


### PR DESCRIPTION
Solid cache support has landed in rails main which brings it in by default, but it also brings in active record which causes havoc in our no active record smoke app (this is probably a bug in upstream rails, I think skipping active record should skip solid too like similar options but for now lets fix it here).

Theres also a slight tweak as to how we generate the app because it was causing havoc for me, but I think being explicit is better for the generation.