### PR TITLE
Improve consistency with official controller spec style

### DIFF
--- a/features/matchers/redirect_to_matcher.feature
+++ b/features/matchers/redirect_to_matcher.feature
@@ -13,25 +13,30 @@ Feature: `redirect_to` matcher
       require "rails_helper"
 
       RSpec.describe WidgetsController do
-
         describe "#create" do
-          subject { post :create, :params => { :widget => { :name => "Foo" } } }
-
           it "redirects to widget_url(@widget)" do
-            expect(subject).to redirect_to(widget_url(assigns(:widget)))
+            post :create, :params => { :widget => { :name => "Foo" } }
+
+            expect(response).to redirect_to(widget_url(assigns(:widget)))
           end
 
           it "redirects_to :action => :show" do
-            expect(subject).to redirect_to :action => :show,
+            post :create, :params => { :widget => { :name => "Foo" } }
+
+            expect(response).to redirect_to :action => :show,
                                            :id => assigns(:widget).id
           end
 
           it "redirects_to(@widget)" do
-            expect(subject).to redirect_to(assigns(:widget))
+            post :create, :params => { :widget => { :name => "Foo" } }
+
+            expect(response).to redirect_to(assigns(:widget))
           end
 
           it "redirects_to /widgets/:id" do
-            expect(subject).to redirect_to("/widgets/#{assigns(:widget).id}")
+            post :create, :params => { :widget => { :name => "Foo" } }
+
+            expect(response).to redirect_to("/widgets/#{assigns(:widget).id}")
           end
         end
       end

--- a/features/matchers/render_template_matcher.feature
+++ b/features/matchers/render_template_matcher.feature
@@ -16,16 +16,18 @@ Feature: `render_template` matcher
 
       RSpec.describe GadgetsController do
         describe "GET #index" do
-          subject { get :index }
-
           it "renders the index template" do
-            expect(subject).to render_template(:index)
-            expect(subject).to render_template("index")
-            expect(subject).to render_template("gadgets/index")
+            get :index
+
+            expect(response).to render_template(:index)
+            expect(response).to render_template("index")
+            expect(response).to render_template("gadgets/index")
           end
 
           it "does not render a different template" do
-            expect(subject).to_not render_template("gadgets/show")
+            get :index
+
+            expect(response).to_not render_template("gadgets/show")
           end
         end
       end
@@ -40,14 +42,16 @@ Feature: `render_template` matcher
 
       RSpec.describe GadgetsController do
         describe "GET #index" do
-          subject { get :index }
-
           it "renders the application layout" do
-            expect(subject).to render_template("layouts/application")
+            get :index
+
+            expect(response).to render_template("layouts/application")
           end
 
           it "does not render a different layout" do
-            expect(subject).to_not render_template("layouts/admin")
+            get :index
+
+            expect(response).to_not render_template("layouts/admin")
           end
         end
       end


### PR DESCRIPTION
Some feature specs use a controller spec style that is not [the "official" one](https://rspec.info/features/6-0/rspec-rails/controller-specs/controller-spec/).
```ruby
# bad?
describe "GET #index" do
  subject { get :index }

  it "renders the index template" do
    expect(subject).to render_template(:index)
  end
end

# vs.

# good?
describe "GET #index" do
  it "renders the index template" do
    get :index

    expect(response).to render_template(:index)
  end
end
```

Looking at the code base, `subject { get :index }` is not used anywhere else. It seems to me that this style has questionable semantics, so aligning the the feature spec content with the common approach for controller specs makes sense to me.

In general, I'd like to hear your opinion on using the `get`, `post`, `patch` call as a subject.