### PR TITLE
Comment out `infer_spec_type_from_file_location!` in generated helper.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Enhancements:
 
 * Improve implicit description for ActionCable matchers `have_broadcasted_to` /
   `have_broadcast`. (Simon Fish, #2795)
+* Comment out `infer_spec_type_from_file_location!` in newly generated
+  `rails_helper.rb` files. (Jon Rowe, #2804)
 
 Bug Fixes:
 

--- a/features/matchers/redirect_to_matcher.feature
+++ b/features/matchers/redirect_to_matcher.feature
@@ -12,7 +12,7 @@ Feature: `redirect_to` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe WidgetsController do
+      RSpec.describe WidgetsController , type: :controller do
 
         describe "#create" do
           subject { post :create, :params => { :widget => { :name => "Foo" } } }

--- a/features/matchers/render_template_matcher.feature
+++ b/features/matchers/render_template_matcher.feature
@@ -14,7 +14,7 @@ Feature: `render_template` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe GadgetsController do
+      RSpec.describe GadgetsController , type: :controller do
         describe "GET #index" do
           subject { get :index }
 
@@ -38,7 +38,7 @@ Feature: `render_template` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe GadgetsController do
+      RSpec.describe GadgetsController , type: :controller do
         describe "GET #index" do
           subject { get :index }
 
@@ -60,7 +60,7 @@ Feature: `render_template` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe "gadgets/index" do
+      RSpec.describe "gadgets/index" , type: :view do
         it "renders the index template" do
           assign(:gadgets, [Gadget.create!])
           render

--- a/features/matchers/send_email_matcher.feature
+++ b/features/matchers/send_email_matcher.feature
@@ -16,7 +16,7 @@ Feature: `send_email` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe NotificationsMailer do
+      RSpec.describe NotificationsMailer , type: :mailer do
         it "checks email sending by multiple params" do
           expect {
             NotificationsMailer.signup.deliver_now
@@ -36,7 +36,7 @@ Feature: `send_email` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe NotificationsMailer do
+      RSpec.describe NotificationsMailer , type: :mailer do
         it "checks email sending by one param only" do
           expect {
             NotificationsMailer.signup.deliver_now
@@ -54,7 +54,7 @@ Feature: `send_email` matcher
       """ruby
       require "rails_helper"
 
-      RSpec.describe NotificationsMailer do
+      RSpec.describe NotificationsMailer , type: :mailer do
         it "checks email not sent" do
           expect {
             NotificationsMailer.signup.deliver_now

--- a/features/view_specs/inferred_controller_path.feature
+++ b/features/view_specs/inferred_controller_path.feature
@@ -5,7 +5,7 @@ Feature: View specs infer controller's path and action
       """ruby
       require "rails_helper"
 
-      RSpec.describe "widgets/new" do
+      RSpec.describe "widgets/new" , type: :view do
         it "infers the controller path" do
           expect(controller.request.path_parameters[:controller]).to eq("widgets")
           expect(controller.controller_path).to eq("widgets")
@@ -20,7 +20,7 @@ Feature: View specs infer controller's path and action
       """ruby
       require "rails_helper"
 
-      RSpec.describe "widgets/new" do
+      RSpec.describe "widgets/new" , type: :view do
         it "infers the controller action" do
           expect(controller.request.path_parameters[:action]).to eq("new")
         end
@@ -34,7 +34,7 @@ Feature: View specs infer controller's path and action
       """ruby
       require "rails_helper"
 
-      RSpec.describe "widgets/_form" do
+      RSpec.describe "widgets/_form" , type: :view do
         it "includes a link to new" do
           expect(controller.request.path_parameters[:action]).to be_nil
         end

--- a/features/view_specs/stub_template.feature
+++ b/features/view_specs/stub_template.feature
@@ -8,7 +8,7 @@ Feature: Using `stub_template`
       """ruby
       require "rails_helper"
 
-      RSpec.describe "gadgets/list" do
+      RSpec.describe "gadgets/list" , type: :view do
         it "renders the gadget partial for each gadget" do
           assign(:gadgets, [
             double(:name => "First"),
@@ -34,7 +34,7 @@ Feature: Using `stub_template`
       """ruby
       require "rails_helper"
 
-      RSpec.describe "gadgets/edit" do
+      RSpec.describe "gadgets/edit" , type: :view do
         before(:each) do
           @gadget = assign(:gadget, Gadget.create!)
         end

--- a/features/view_specs/view_spec.feature
+++ b/features/view_specs/view_spec.feature
@@ -27,7 +27,7 @@ Feature: View specs
       """ruby
       require "rails_helper"
 
-      RSpec.describe "widgets/index" do
+      RSpec.describe "widgets/index" , type: :view do
         it "displays all the widgets" do
           assign(:widgets, [
             Widget.create!(:name => "slicer"),
@@ -49,7 +49,7 @@ Feature: View specs
       """ruby
       require "rails_helper"
 
-      RSpec.describe "widgets/index" do
+      RSpec.describe "widgets/index" , type: :view do
 
         context "with 2 widgets" do
           before(:each) do
@@ -76,7 +76,7 @@ Feature: View specs
       """ruby
       require "rails_helper"
 
-      RSpec.describe "rendering the widget template" do
+      RSpec.describe "rendering the widget template" , type: :view do
         it "displays the widget" do
           assign(:widget, Widget.create!(:name => "slicer"))
 
@@ -98,7 +98,7 @@ Feature: View specs
       """ruby
       require "rails_helper"
 
-      RSpec.describe "rendering the widget template" do
+      RSpec.describe "rendering the widget template" , type: :view do
         context "with the inventory layout" do
           it "displays the widget" do
             assign(:widget, Widget.create!(:name => "slicer"))
@@ -126,7 +126,7 @@ Feature: View specs
       """ruby
       require "rails_helper"
 
-      RSpec.describe "widgets/widget.html.erb" do
+      RSpec.describe "widgets/widget.html.erb" , type: :view do
         it "renders the HTML template" do
           render
 
@@ -134,7 +134,7 @@ Feature: View specs
         end
       end
 
-      RSpec.describe "widgets/widget.xml.erb" do
+      RSpec.describe "widgets/widget.xml.erb" , type: :view do
         it "renders the XML template" do
           render
 
@@ -158,7 +158,7 @@ Feature: View specs
       """ruby
       require "rails_helper"
 
-      RSpec.describe "widgets/index" do
+      RSpec.describe "widgets/index" , type: :view do
         it "displays the widget" do
           widget = Widget.create!(:name => "slicer")
 
@@ -180,7 +180,7 @@ Feature: View specs
       """ruby
       require "rails_helper"
 
-      RSpec.describe "rendering locals in a partial" do
+      RSpec.describe "rendering locals in a partial" , type: :view do
         it "displays the widget" do
           widget = Widget.create!(:name => "slicer")
 
@@ -202,7 +202,7 @@ Feature: View specs
       """ruby
       require "rails_helper"
 
-      RSpec.describe "rendering locals in a partial" do
+      RSpec.describe "rendering locals in a partial" , type: :view do
         it "displays the widget" do
           widget = Widget.create!(:name => "slicer")
 
@@ -224,7 +224,7 @@ Feature: View specs
       """ruby
       require "rails_helper"
 
-      RSpec.describe "rendering text directly" do
+      RSpec.describe "rendering text directly" , type: :view do
         it "displays the given text" do
 
           render :plain => "This is directly rendered"
@@ -255,7 +255,7 @@ Feature: View specs
       """ruby
       require 'rails_helper'
 
-      RSpec.describe 'secrets/index' do
+      RSpec.describe 'secrets/index' , type: :view do
         before do
           allow(view).to receive(:admin?).and_return(true)
         end
@@ -274,7 +274,7 @@ Feature: View specs
       """ruby
       require "rails_helper"
 
-      RSpec.describe "controller.request.path_parameters" do
+      RSpec.describe "controller.request.path_parameters" , type: :view do
         it "matches the Rails environment by using symbols for keys" do
           [:controller, :action].each { |k| expect(controller.request.path_parameters.keys).to include(k) }
         end
@@ -288,7 +288,7 @@ Feature: View specs
     """ruby
       require "rails_helper"
 
-      RSpec.describe "widgets/index" do
+      RSpec.describe "widgets/index" , type: :view do
         it "has a request.fullpath that is defined" do
           expect(controller.request.fullpath).to eq widgets_path
         end
@@ -302,7 +302,7 @@ Feature: View specs
     """ruby
       require "rails_helper"
 
-      RSpec.describe "widgets/show" do
+      RSpec.describe "widgets/show" , type: :view do
         it "displays the widget with id: 1" do
           widget = Widget.create!(:name => "slicer")
           controller.extra_params = { :id => widget.id }

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -67,20 +67,22 @@ RSpec.configure do |config|
   # config.use_transactional_fixtures = true
 
 <% end -%>
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
+  # RSpec Rails uses metadata to mix in different behaviours to your tests,
+  # for example enabling you to call `get` and `post` in request specs. e.g.:
   #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, type: :controller do
+  #     RSpec.describe UsersController, type: :request do
   #       # ...
   #     end
   #
   # The different available types are documented in the features, such as in
   # https://rspec.info/features/7-0/rspec-rails
-  config.infer_spec_type_from_file_location!
+  #
+  # You can also this infer these behaviours automatically by location, e.g.
+  # /spec/models would pull in the same behaviour as `type: :model` but this
+  # behaviour is considered legacy and will be removed in a future version.
+  #
+  # To enable this behaviour uncomment the line below.
+  # config.infer_spec_type_from_file_location!
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!


### PR DESCRIPTION
We would prefer that people tag their specs manually (or via generators) and whilst our generators do generate tags we never removed the generated `infer_spec_type_from_file_location!`  as a default.

Fixes #2803