### PR TITLE
Explain how to set a default driver for system specs

### DIFF
--- a/features/system_specs/system_specs.feature
+++ b/features/system_specs/system_specs.feature
@@ -25,7 +25,7 @@ Feature: System specs
   you can use the configuration helpers to do this for every system spec,
   for example by adding the following to `spec/rails_helper.rb`:
 
-  ```
+  ```ruby
   RSpec.configure do |config|
     ...
     config.before(type: :system) do

--- a/features/system_specs/system_specs.feature
+++ b/features/system_specs/system_specs.feature
@@ -26,8 +26,12 @@ Feature: System specs
   for example by adding the following to `spec/rails_helper.rb`:
 
   ```
-  config.before(type: :system) do
-    driven_by :selenium_headless # Or your preferred default driver
+  RSpec.configure do |config|
+    ...
+    config.before(type: :system) do
+      driven_by :selenium_headless # Or your preferred default driver
+    end
+    ...
   end
   ```
 

--- a/features/system_specs/system_specs.feature
+++ b/features/system_specs/system_specs.feature
@@ -19,7 +19,15 @@ Feature: System specs
 
   RSpec **does not** use your `ApplicationSystemTestCase` helper. Instead it
   uses the default `driven_by(:selenium)` from Rails. If you want to override
-  this behaviour you can call `driven_by` manually in a test.
+  this behaviour you can call `driven_by` manually in a test. Alternatively, 
+  if you want to specify a default driver for all system specs (rather than
+  using `driven_by` in every spec), add the following to `spec/rails_helper.rb`:
+
+  ```
+  config.before(type: :system) do
+    driven_by :selenium_headless    # Or your preferred default driver
+  end
+  ```
 
   System specs run in a transaction. So unlike feature specs with
   javascript, you do not need [DatabaseCleaner](https://github.com/DatabaseCleaner/database_cleaner).

--- a/features/system_specs/system_specs.feature
+++ b/features/system_specs/system_specs.feature
@@ -19,9 +19,11 @@ Feature: System specs
 
   RSpec **does not** use your `ApplicationSystemTestCase` helper. Instead it
   uses the default `driven_by(:selenium)` from Rails. If you want to override
-  this behaviour you can call `driven_by` manually in a test. Alternatively, 
-  if you want to specify a default driver for all system specs (rather than
-  using `driven_by` in every spec), add the following to `spec/rails_helper.rb`:
+  this behaviour you need to call `driven_by` in your specs.
+
+  This can either be done manually in the spec files themselves or
+  you can use the configuration helpers to do this for every system spec,
+  for example by adding the following to `spec/rails_helper.rb`:
 
   ```
   config.before(type: :system) do

--- a/features/system_specs/system_specs.feature
+++ b/features/system_specs/system_specs.feature
@@ -27,7 +27,7 @@ Feature: System specs
 
   ```
   config.before(type: :system) do
-    driven_by :selenium_headless    # Or your preferred default driver
+    driven_by :selenium_headless # Or your preferred default driver
   end
   ```
 


### PR DESCRIPTION
Current docs explain how to specify the system spec driver for each spec/suite using `driven_by`, but I felt it lacked explanation on how to set a default driver for all system specs (especially since `Capybara.default_driver = ...` will not do so).

**First PR here so please share if I am missing a step in your approval procedure.**