### PR TITLE
Add Rails 8 authentication generator

### DIFF
--- a/lib/generators/rspec/authentication/authentication_generator.rb
+++ b/lib/generators/rspec/authentication/authentication_generator.rb
@@ -1,0 +1,25 @@
+require 'generators/rspec'
+
+module Rspec
+  module Generators
+    # @private
+    class AuthenticationGenerator < Base
+      def initialize(args, *options)
+        args.replace(['User'])
+        super
+      end
+
+      def create_user_spec
+        template 'user_spec.rb', target_path('models', 'user_spec.rb')
+      end
+
+      hook_for :fixture_replacement
+
+      def create_fixture_file
+        return if options[:fixture_replacement]
+
+        template 'users.yml', target_path('fixtures', 'users.yml')
+      end
+    end
+  end
+end

--- a/lib/generators/rspec/authentication/templates/user_spec.rb
+++ b/lib/generators/rspec/authentication/templates/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, <%= type_metatag(:model) %> do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/lib/generators/rspec/authentication/templates/users.yml
+++ b/lib/generators/rspec/authentication/templates/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+<%% password_digest = BCrypt::Password.create("password") %>
+
+one:
+  email_address: one@example.com
+  password_digest: <%%= password_digest %>
+
+two:
+  email_address: two@example.com
+  password_digest: <%%= password_digest %>

--- a/spec/generators/rspec/authentication/authentication_generator_spec.rb
+++ b/spec/generators/rspec/authentication/authentication_generator_spec.rb
@@ -1,0 +1,34 @@
+# Generators are not automatically loaded by Rails
+require 'generators/rspec/authentication/authentication_generator'
+require 'support/generators'
+
+RSpec.describe Rspec::Generators::AuthenticationGenerator, type: :generator do
+  setup_default_destination
+
+  it 'runs both the model and fixture tasks' do
+    gen = generator
+    expect(gen).to receive :create_user_spec
+    expect(gen).to receive :create_fixture_file
+    gen.invoke_all
+  end
+
+  describe 'the generated files' do
+    it 'creates the user spec' do
+      run_generator
+
+      expect(File.exist?(file('spec/models/user_spec.rb'))).to be true
+    end
+
+    describe 'with fixture replacement' do
+      before do
+        run_generator ['--fixture-replacement=factory_bot']
+      end
+
+      describe 'the fixtures' do
+        it "will skip the file" do
+          expect(File.exist?(file('spec/fixtures/users.yml'))).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/rspec/rspec-rails/issues/2810.

## Problem

When running Rails 8's `bin/rails generate authentication`, generation ends with with the following error: `error  rspec [not found]`.

This is because the Rails `AuthenticationGenerator` [contains](https://github.com/rails/rails/pull/53165) [`hook_for :test_framework`](https://github.com/rails/rails/blob/d5be42897e09850ffbd31394ea9f805b9af055d5/railties/lib/rails/generators/rails/authentication/authentication_generator.rb#L55), which calls `rspec-rails`, but it errors out since `rspec-rails` does not have an authentication generator.

## Solution

Add authentication generator that creates a user test and possibly a fixture, similarly to Rails' [`TestUnit::Generators::AuthenticationGenerator`](https://github.com/rails/rails/blob/d5be42897e09850ffbd31394ea9f805b9af055d5/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb). The fixture is basically the same as the [Rails one](https://github.com/rails/rails/blob/d5be42897e09850ffbd31394ea9f805b9af055d5/railties/lib/rails/generators/test_unit/authentication/templates/test/fixtures/users.yml.tt) except that it has a comment similar to `rspec-rails`' model [fixture](https://github.com/rspec/rspec-rails/blob/01704c50c146f720db914724c25681781ecefb23/lib/generators/rspec/model/templates/fixtures.yml).

An alternative solution could be to somehow disable the authentication generator for `rspec-rails` so nothing is generated while not having any errors. This might be a viable option if Rails adds more generators in the future and playing catch-up is undesired.