### PR TITLE
Allow Ruby 3.0 to use older rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :documentation do
 end
 
 gem 'capybara'
-gem 'ffi', '~> 1.15.5'
+gem 'ffi', '> 1.15.5'
 gem 'rake', '> 12'
 gem 'rubocop', '~> 1.28.2'
 

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -11,8 +11,20 @@ function is_ruby_3_plus {
   fi
 }
 
-if is_ruby_3_plus; then
+function is_ruby_3_1_plus {
+  if ruby -e "exit(RUBY_VERSION.to_f >= 3.1)"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+
+if is_ruby_3_1_plus; then
   gem update --no-document --system
+  gem install --no-document bundler
+elif is_ruby_3_plus; then
+  gem update --no-document --system '3.5.23'
   gem install --no-document bundler
 else
   gem update --no-document --system '3.4.22'


### PR DESCRIPTION
Allow Ruby 3.0 to use older rubygems