### PR TITLE
Fix build for Rails main, Rails 7.0 and Ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,6 @@ gem 'ffi', '> 1.15.5'
 gem 'rake', '> 12'
 gem 'rubocop', '~> 1.28.2'
 
-if RUBY_VERSION.to_f > 3.3
-  gem 'cucumber', git: 'https://github.com/cucumber/cucumber-ruby', branch: 'main'
-end
-
 custom_gemfile = File.expand_path('Gemfile-custom', __dir__)
 eval_gemfile custom_gemfile if File.exist?(custom_gemfile)
 

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -48,7 +48,6 @@ when nil, false, ""
   gem 'selenium-webdriver', require: false
 else
   version_number = version.split(' ').last
-  add_net_gems_dependency if version_number < '7.0'
 
   gem "rails", version
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -49,6 +49,8 @@ when nil, false, ""
 else
   version_number = version.split(' ').last
 
+  gem 'concurrent-ruby', '1.3.4' if version_number < '7.1'
+
   gem "rails", version
   gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
 

--- a/example_app_generator/spec/support/default_preview_path
+++ b/example_app_generator/spec/support/default_preview_path
@@ -7,6 +7,7 @@ end
 ENV['RAILS_ENV'] ||= 'development'
 # Pick the frameworks you want:
 begin
+  require "openssl"
   require "active_storage"
   require "active_storage/engine"
 rescue LoadError

--- a/example_app_generator/spec/verify_mailer_preview_path_spec.rb
+++ b/example_app_generator/spec/verify_mailer_preview_path_spec.rb
@@ -40,12 +40,6 @@ RSpec.describe 'Action Mailer railtie hook' do
     CaptureExec.new(out, $?.exitstatus)
   end
 
-  if ENV['RAILS_VERSION'] == 'main' && Rails::VERSION::STRING == "8.0.0.alpha"
-    before do
-      skip('This is broken on Rails main but is skipped for green builds, please fix')
-    end
-  end
-
   if Rails::VERSION::STRING.to_f >= 7.1
     let(:expected_custom_path) { "/custom/path\n#{::Rails.root}/test/mailers/previews" }
     let(:expected_rspec_path) { "#{::Rails.root}/spec/mailers/previews\n#{::Rails.root}/test/mailers/previews" }


### PR DESCRIPTION
Changes to the internals made openssl a requirement which isn't loaded in our verify mailer test, so fix that, and remove un-needed skip that wasn't doing anything anyway.