### PR TITLE
Update comment about `ActiveRecord::Migration.maintain_test_schema!`

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -28,7 +28,9 @@ require 'rspec/rails'
 # Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 <% if RSpec::Rails::FeatureCheck.has_active_record_migration? -%>
-# Checks for pending migrations and applies them before tests are run.
+# Ensures that the test database schema matches the current schema file.
+# This call checks for pending migrations and, if any are found,
+# purges and recreates the test database by loading the schema.
 # If you are not using ActiveRecord, you can remove these lines.
 begin
   ActiveRecord::Migration.maintain_test_schema!

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -29,8 +29,8 @@ require 'rspec/rails'
 
 <% if RSpec::Rails::FeatureCheck.has_active_record_migration? -%>
 # Ensures that the test database schema matches the current schema file.
-# This call checks for pending migrations and, if any are found,
-# purges and recreates the test database by loading the schema.
+#  If there are pending migrations it will invoke `db:test:prepare` to
+# recreate the test database by loading the schema.
 # If you are not using ActiveRecord, you can remove these lines.
 begin
   ActiveRecord::Migration.maintain_test_schema!

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -29,7 +29,7 @@ require 'rspec/rails'
 
 <% if RSpec::Rails::FeatureCheck.has_active_record_migration? -%>
 # Ensures that the test database schema matches the current schema file.
-#  If there are pending migrations it will invoke `db:test:prepare` to
+# If there are pending migrations it will invoke `db:test:prepare` to
 # recreate the test database by loading the schema.
 # If you are not using ActiveRecord, you can remove these lines.
 begin


### PR DESCRIPTION
@JonRowe @pirj Thanks for your comments on https://github.com/rspec/rspec-rails/issues/2830. This pull request suggests an update of the comment in `rails_helper.rb` as like @JonRowe mentioned in https://github.com/rspec/rspec-rails/issues/2830#issuecomment-2634238712.

## Change

The original comment implies that `maintain_test_schema!` applies pending migrations, but in reality, it purges and recreates a test database, then loads the schema. I think this change makes the behavior clearer.