### PR TITLE
Support chages to show_helper in Rails 7

### DIFF
--- a/lib/generators/rspec/scaffold/scaffold_generator.rb
+++ b/lib/generators/rspec/scaffold/scaffold_generator.rb
@@ -4,7 +4,7 @@ require 'rails/generators/resource_helpers'
 module Rspec
   module Generators
     # @private
-    class ScaffoldGenerator < Base
+    class ScaffoldGenerator < Base # rubocop:disable Metrics/ClassLength
       include ::Rails::Generators::ResourceHelpers
       source_paths << File.expand_path('../helper/templates', __dir__)
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
@@ -128,8 +128,14 @@ module Rspec
         self.class.banner
       end
 
-      def show_helper(resource_name = file_name)
-        "#{singular_route_name}_url(#{resource_name})"
+      if Rails::VERSION::STRING.to_f < 7.0
+        def show_helper(resource_name = file_name, type: :url)
+          "#{singular_route_name}_#{type}(#{resource_name})"
+        end
+      else
+        def show_helper(arg = file_name, type: :url)
+          super
+        end
       end
     end
   end

--- a/lib/generators/rspec/scaffold/templates/edit_spec.rb
+++ b/lib/generators/rspec/scaffold/templates/edit_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "<%= ns_table_name %>/edit", <%= type_metatag(:view) %> do
   it "renders the edit <%= ns_file_name %> form" do
     render
 
-    assert_select "form[action=?][method=?]", <%= ns_file_name %>_path(<%= singular_table_name %>), "post" do
+    assert_select "form[action=?][method=?]", <%= show_helper(singular_table_name, type: :path) %>, "post" do
 <% for attribute in output_attributes -%>
       <%- name = attribute.respond_to?(:column_name) ? attribute.column_name : attribute.name %>
       assert_select "<%= attribute.input_type -%>[name=?]", "<%= ns_file_name %>[<%= name %>]"

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -242,6 +242,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
           expect(filename).to contain(/require 'rails_helper'/)
                              .and(contain(/^RSpec.describe "(.*)\/edit", #{type_metatag(:view)}/))
                              .and(contain(/assign\(:post, post\)/))
+                             .and(contain(/assert_select "form\[action=\?\]\[method=\?\]", post_path\(post\), "post" do/))
                              .and(contain(/it "renders the edit (.*) form"/))
         end
       end


### PR DESCRIPTION
This is a continuation of #2741

#2492 overrode `show_helper`, which in Rails 6 looks like:

```ruby
def show_helper
  "#{singular_route_name}_url(@#{singular_table_name})"
end
```

But Rails 7 changed it to

```ruby
def show_helper(arg = "@#{singular_table_name}", type: :url) # :doc:
  "#{singular_route_name}_#{type}(#{arg})"
end
```

This change supports the arguments in Rails 7 while maintaining support for Rails 6.

I've updated the `edit_spec.rb` template to use the `show_helper` helper rather than building the path itself, and have added a test to confirm the expected path is generated.