### PR TITLE
Update GitHub URLs to the RSpec monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,6 @@ you can run the specs and Cucumber features, or submit a pull request.
 ### RSpec base libraries
 
 * https://github.com/rspec/rspec
-* https://github.com/rspec/rspec-core
-* https://github.com/rspec/rspec-expectations
-* https://github.com/rspec/rspec-mocks
 
 ### Recommended third-party extensions
 

--- a/benchmarks/before_block_capture_block_vs_yield.rb
+++ b/benchmarks/before_block_capture_block_vs_yield.rb
@@ -42,11 +42,11 @@ capturing the block and then performing an `instance_exec` on it later in the
 example context.
 
 rspec-core has already performed [many related benchmarks about
-this](https://github.com/rspec/rspec-core/tree/main/benchmarks):
+this](https://github.com/rspec/rspec/tree/main/rspec-core/benchmarks):
 
-- [call vs yield](https://github.com/rspec/rspec-core/blob/main/benchmarks/call_v_yield.rb)
-- [capture block vs yield](https://github.com/rspec/rspec-core/blob/main/benchmarks/capture_block_vs_yield.rb)
-- [flat map vs inject](https://github.com/rspec/rspec-core/blob/main/benchmarks/flat_map_vs_inject.rb)
+- [call vs yield](https://github.com/rspec/rspec/blob/main/rspec-core/benchmarks/call_v_yield.rb)
+- [capture block vs yield](https://github.com/rspec/rspec/blob/main/rspec-core/benchmarks/capture_block_vs_yield.rb)
+- [flat map vs inject](https://github.com/rspec/rspec/blob/main/rspec-core/benchmarks/flat_map_vs_inject.rb)
 
 The results are very interesting:
 
@@ -64,7 +64,7 @@ The results are very interesting:
 > See also `flat_map_vs_inject.rb`, which appears to contradict these
 > results a little bit.
 >
-> -- https://github.com/rspec/rspec-core/blob/main/benchmarks/capture_block_vs_yield.rb#L83-L95
+> -- https://github.com/rspec/rspec/blob/main/rspec-core/benchmarks/capture_block_vs_yield.rb#L83-L95
 
 and
 
@@ -75,7 +75,7 @@ and
 > version remains faster in my benchmarks here no matter how small
 > I shrink the `words` array. I'm not sure why!
 >
-> -- https://github.com/rspec/rspec-core/blob/main/benchmarks/flat_map_vs_inject.rb#L37-L42
+> -- https://github.com/rspec/rspec/blob/main/rspec-core/benchmarks/flat_map_vs_inject.rb#L37-L42
 
 This seems to show that the error margin is enough to negate any benefit from
 capturing the block initially. It also shows that not capturing the block is


### PR DESCRIPTION
The RSpec core gems, previously hosted in multiple repositores, were merged to a monorepo and had their repositories archived on Nov 30, 2024.

`rspec-rails` still has a few references to the archived repos.

This Pull Request removes them from the README, and updates the existing links to the monorepo.