### PR TITLE
Add support for ActionDispatch::SystemTestCase.served_by

### DIFF
--- a/lib/rspec/rails/example/system_example_group.rb
+++ b/lib/rspec/rails/example/system_example_group.rb
@@ -153,6 +153,12 @@ module RSpec
           @driver = ::ActionDispatch::SystemTestCase.driven_by(driver, **driver_options, &blk).tap(&:use)
         end
 
+        if ::Rails::VERSION::STRING.to_f >= 7.2
+          def served_by(**options)
+            ::ActionDispatch::SystemTestCase.served_by(**options)
+          end
+        end
+
         before do
           @routes = ::Rails.application.routes
         end

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -79,7 +79,7 @@ module RSpec::Rails
         expect(example).to have_received(:driven_by).once
       end
 
-      it 'calls :served_by method only once' do
+      it 'calls :served_by method only once', if: ::Rails::VERSION::STRING.to_f >= 7.2 do
         group = RSpec::Core::ExampleGroup.describe do
           include SystemExampleGroup
 

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -78,6 +78,21 @@ module RSpec::Rails
 
         expect(example).to have_received(:driven_by).once
       end
+
+      it 'calls :served_by method only once' do
+        group = RSpec::Core::ExampleGroup.describe do
+          include SystemExampleGroup
+
+          before do
+            served_by(host: 'rails', port: 8080)
+          end
+        end
+        example = group.new
+        allow(example).to receive(:served_by).and_call_original
+        group.hooks.run(:before, :example, example)
+
+        expect(example).to have_received(:served_by).once
+      end
     end
 
     describe '#after' do


### PR DESCRIPTION
Fixes #2840

Adds support for the `served_by` method of https://api.rubyonrails.org/v8.0.2/classes/ActionDispatch/SystemTestCase.html