### PR TITLE
Fix comment by removing extra word.

### DIFF
--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -77,7 +77,7 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://rspec.info/features/8-0/rspec-rails
   #
-  # You can also this infer these behaviours automatically by location, e.g.
+  # You can also infer these behaviours automatically by location, e.g.
   # /spec/models would pull in the same behaviour as `type: :model` but this
   # behaviour is considered legacy and will be removed in a future version.
   #


### PR DESCRIPTION
Was reading through the helper and was initially confused when reading this sentence, I believe that extra `this` should be removed.