### PR TITLE
Pin cucumber to 9.x

### DIFF
--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -54,5 +54,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'ammeter',  '~> 1.1.5'
   s.add_development_dependency 'aruba',    '~> 0.14.12'
-  s.add_development_dependency 'cucumber', '> 7.0'
+  s.add_development_dependency 'cucumber', '> 7.0', '< 10.0'
 end


### PR DESCRIPTION
Changes to cucumber broken our existing aruba implementation, they need upgrading together so temporarily pin to 9.x