### PR TITLE
Upgrade aruba

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,13 +2,14 @@ require 'aruba/cucumber'
 require 'fileutils'
 
 module ArubaExt
-  def run_command(cmd, timeout = nil)
+  def run_command_and_stop(cmd, opts = {})
     exec_cmd = cmd =~ /^rspec/ ? "bin/#{cmd}" : cmd
+
     unset_bundler_env_vars
     # Ensure the correct Gemfile and binstubs are found
     in_current_directory do
       with_unbundled_env do
-        super(exec_cmd, timeout)
+        super(exec_cmd, opts)
       end
     end
   end

--- a/rspec-rails.gemspec
+++ b/rspec-rails.gemspec
@@ -53,6 +53,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency 'ammeter',  '~> 1.1.5'
-  s.add_development_dependency 'aruba',    '~> 0.14.12'
-  s.add_development_dependency 'cucumber', '> 7.0'
+  s.add_development_dependency 'aruba',    '~> 2.3.1'
+  s.add_development_dependency 'cucumber', '>= 10.0'
 end


### PR DESCRIPTION
Cucumber 10 seems to require a, er, more modern version :joy: of Aruba, so lets upgrade!

To do this our extension which cleans up the env a command runs in needs updating.