### PR TITLE
Reduce sandboxing to prevent swallowed deprecations

### DIFF
--- a/spec/rspec/rails/configuration_spec.rb
+++ b/spec/rspec/rails/configuration_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Configuration" do
     end
   end
 
-  describe "#infer_spec_type_from_file_location!" do
+  describe "#infer_spec_type_from_file_location!", :with_isolated_config do
     def in_inferring_type_from_location_environment
       in_sub_process do
         RSpec.configuration.infer_spec_type_from_file_location!

--- a/spec/rspec/rails/example/channel_example_group_spec.rb
+++ b/spec/rspec/rails/example/channel_example_group_spec.rb
@@ -1,7 +1,7 @@
 require "rspec/rails/feature_check"
 
 module RSpec::Rails
-  RSpec.describe ChannelExampleGroup do
+  RSpec.describe ChannelExampleGroup, :with_isolated_config do
     if RSpec::Rails::FeatureCheck.has_action_cable_testing?
       it_behaves_like "an rspec-rails example group mixin", :channel,
                       './spec/channels/', '.\\spec\\channels\\'

--- a/spec/rspec/rails/example/controller_example_group_spec.rb
+++ b/spec/rspec/rails/example/controller_example_group_spec.rb
@@ -3,7 +3,7 @@ class ::ApplicationController
 end
 
 module RSpec::Rails
-  RSpec.describe ControllerExampleGroup do
+  RSpec.describe ControllerExampleGroup, :with_isolated_config do
     it_behaves_like "an rspec-rails example group mixin", :controller,
                     './spec/controllers/', '.\\spec\\controllers\\'
 

--- a/spec/rspec/rails/example/feature_example_group_spec.rb
+++ b/spec/rspec/rails/example/feature_example_group_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe FeatureExampleGroup do
+  RSpec.describe FeatureExampleGroup, :with_isolated_config do
     it_behaves_like "an rspec-rails example group mixin", :feature,
                     './spec/features/', '.\\spec\\features\\'
 

--- a/spec/rspec/rails/example/helper_example_group_spec.rb
+++ b/spec/rspec/rails/example/helper_example_group_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe HelperExampleGroup do
+  RSpec.describe HelperExampleGroup, :with_isolated_config do
     module ::FoosHelper
       class InternalClass
       end

--- a/spec/rspec/rails/example/job_example_group_spec.rb
+++ b/spec/rspec/rails/example/job_example_group_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe JobExampleGroup do
+  RSpec.describe JobExampleGroup, :with_isolated_config do
     if defined?(ActiveJob)
       it_behaves_like "an rspec-rails example group mixin", :job,
                       './spec/jobs/', '.\\spec\\jobs\\'

--- a/spec/rspec/rails/example/mailbox_example_group_spec.rb
+++ b/spec/rspec/rails/example/mailbox_example_group_spec.rb
@@ -14,7 +14,7 @@ end
 
 module RSpec
   module Rails
-    RSpec.describe MailboxExampleGroup, skip: !RSpec::Rails::FeatureCheck.has_action_mailbox? do
+    RSpec.describe MailboxExampleGroup, :with_isolated_config, skip: !RSpec::Rails::FeatureCheck.has_action_mailbox? do
       it_behaves_like "an rspec-rails example group mixin", :mailbox,
                       './spec/mailboxes/', '.\\spec\\mailboxes\\'
 

--- a/spec/rspec/rails/example/mailer_example_group_spec.rb
+++ b/spec/rspec/rails/example/mailer_example_group_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe MailerExampleGroup do
+  RSpec.describe MailerExampleGroup, :with_isolated_config do
     module ::Rails; end
     before do
       allow(Rails).to receive_message_chain(:application, :routes, :url_helpers).and_return(Rails)

--- a/spec/rspec/rails/example/model_example_group_spec.rb
+++ b/spec/rspec/rails/example/model_example_group_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe ModelExampleGroup do
+  RSpec.describe ModelExampleGroup, :with_isolated_config do
     it_behaves_like "an rspec-rails example group mixin", :model,
                     './spec/models/', '.\\spec\\models\\'
   end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe RailsExampleGroup do
+  RSpec.describe RailsExampleGroup, :with_isolated_config do
     it 'supports tagged_logger' do
       expect(described_class.private_instance_methods).to include(:tagged_logger)
     end

--- a/spec/rspec/rails/example/request_example_group_spec.rb
+++ b/spec/rspec/rails/example/request_example_group_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe RequestExampleGroup do
+  RSpec.describe RequestExampleGroup, :with_isolated_config do
     it_behaves_like "an rspec-rails example group mixin", :request,
                     './spec/requests/', '.\\spec\\requests\\',
                     './spec/integration/', '.\\spec\\integration\\',

--- a/spec/rspec/rails/example/routing_example_group_spec.rb
+++ b/spec/rspec/rails/example/routing_example_group_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe RoutingExampleGroup do
+  RSpec.describe RoutingExampleGroup, :with_isolated_config do
     it_behaves_like "an rspec-rails example group mixin", :routing,
                     './spec/routing/', '.\\spec\\routing\\'
 

--- a/spec/rspec/rails/example/system_example_group_spec.rb
+++ b/spec/rspec/rails/example/system_example_group_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe SystemExampleGroup do
+  RSpec.describe SystemExampleGroup, :with_isolated_config do
     it_behaves_like "an rspec-rails example group mixin", :system,
                     './spec/system/', '.\\spec\\system\\'
 

--- a/spec/rspec/rails/example/view_example_group_spec.rb
+++ b/spec/rspec/rails/example/view_example_group_spec.rb
@@ -1,7 +1,7 @@
 require 'support/group_failure_formatter'
 
 module RSpec::Rails
-  RSpec.describe ViewExampleGroup do
+  RSpec.describe ViewExampleGroup, :with_isolated_config do
     it_behaves_like "an rspec-rails example group mixin", :view,
                     './spec/views/', '.\\spec\\views\\'
 

--- a/spec/rspec/rails/fixture_file_upload_support_spec.rb
+++ b/spec/rspec/rails/fixture_file_upload_support_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe FixtureFileUploadSupport do
+  RSpec.describe FixtureFileUploadSupport, :with_isolated_config do
     context 'with fixture paths set in config' do
       it 'resolves fixture file' do
         RSpec.configuration.fixture_paths = [File.dirname(__FILE__)]

--- a/spec/rspec/rails/fixture_support_spec.rb
+++ b/spec/rspec/rails/fixture_support_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe FixtureSupport do
+  RSpec.describe FixtureSupport, :with_isolated_config do
     context "with use_transactional_fixtures set to false" do
       it "still supports fixture_path/fixture_paths" do
         allow(RSpec.configuration).to receive(:use_transactional_fixtures) { false }

--- a/spec/rspec/rails/minitest_lifecycle_adapter_spec.rb
+++ b/spec/rspec/rails/minitest_lifecycle_adapter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RSpec::Rails::MinitestLifecycleAdapter do
+RSpec.describe RSpec::Rails::MinitestLifecycleAdapter, :with_isolated_config do
   it "invokes minitest lifecycle hooks at the appropriate times" do
     invocations = []
     example_group = RSpec::Core::ExampleGroup.describe("MinitestHooks") do

--- a/spec/rspec/rails/setup_and_teardown_adapter_spec.rb
+++ b/spec/rspec/rails/setup_and_teardown_adapter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RSpec::Rails::SetupAndTeardownAdapter do
+RSpec.describe RSpec::Rails::SetupAndTeardownAdapter, :with_isolated_config do
   describe ".setup" do
     it "registers before hooks in the order setup is received" do
       group = RSpec::Core::ExampleGroup.describe do

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -1,5 +1,5 @@
 module RSpec::Rails
-  RSpec.describe ViewRendering do
+  RSpec.describe ViewRendering, :with_isolated_config do
     let(:group) do
       RSpec::Core::ExampleGroup.describe do
         def controller

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,9 +71,11 @@ RSpec.configure do |config|
   config.warnings = true
   config.raise_on_warning = true
 
+  config.raise_errors_for_deprecations!
+
   # Execute a provided block with RSpec global objects (configuration,
   # world, current example) reset. This is used to test specs with RSpec.
-  config.around(:example) do |example|
+  config.around(:example, :with_isolated_config) do |example|
     RSpec::Core::Sandbox.sandboxed do |sandbox_config|
       # If there is an example-within-an-example, we want to make sure the inner
       # example does not get a reference to the outer example (the real spec) if

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,6 +77,8 @@ RSpec.configure do |config|
   # world, current example) reset. This is used to test specs with RSpec.
   config.around(:example, :with_isolated_config) do |example|
     RSpec::Core::Sandbox.sandboxed do |sandbox_config|
+      sandbox_config.raise_errors_for_deprecations! # Otherwise, deprecations are swallowed
+
       # If there is an example-within-an-example, we want to make sure the inner
       # example does not get a reference to the outer example (the real spec) if
       # it calls something like `pending`.


### PR DESCRIPTION
We used to sandbox everything, but it turns out that deprecations (`RSpec.deprecate("anything")`) were swallowed, as the temporary config has no deprecation stream set, or stderr is masked.
Found here https://github.com/rspec/rspec-rails/pull/2849#discussion_r2256730128

We're almost back to square one with deprecations as we were before https://github.com/rspec/rspec-rails/pull/2365

However, I'm not entirely happy with this approach. We still mute deprecations for those Rails-related example group specs and a few others, and there are chances deprecations will pop up there eventually.

:question: Would it be better to replay the configuration block on top of the sandboxed configuration? Probably not, and it might not work if stderr is intercepted.

Please consider this WIP
