### PR TITLE
Add .tool-versions to .gitignore and create AuthenticationGenerator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vendor
 Gemfile.lock
 bin
 .rvmrc
+.tool-versions
 *.rbc
 .yardoc
 .bundle

--- a/lib/generators/factory_bot/authentication/authentication_generator.rb
+++ b/lib/generators/factory_bot/authentication/authentication_generator.rb
@@ -1,0 +1,25 @@
+require 'generators/factory_bot'
+require 'factory_bot_rails'
+
+module FactoryBot
+  module Generators
+    class AuthenticationGenerator < Rails::Generators::Base
+      # Use the Source_root Setter correctly
+      def self.source_root
+        File.expand_path('templates', __dir__)
+      end
+
+      def create_fixture_file
+        # Detects whether it is RSPEC or minitest
+        factories_dir =
+          if Dir.exist?(Rails.root.join('spec'))
+            'spec/factories'
+          else
+            'test/factories'
+          end
+
+        template "users.rb", "#{factories_dir}/users.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/factory_bot/authentication/authentication_generator.rb
+++ b/lib/generators/factory_bot/authentication/authentication_generator.rb
@@ -18,6 +18,10 @@ module FactoryBot
             'test/factories'
           end
 
+        # Ensure the directory exists
+        FileUtils.mkdir_p(factories_dir)
+
+        # Copy the user factory template to the appropriate directory
         template "users.rb", "#{factories_dir}/users.rb"
       end
     end

--- a/lib/generators/factory_bot/authentication/templates/users.rb
+++ b/lib/generators/factory_bot/authentication/templates/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email_address { "john@example.com" }
+    password_digest { "MyString" }
+  end
+end

--- a/lib/generators/rspec/install/templates/spec/rails_helper.rb
+++ b/lib/generators/rspec/install/templates/spec/rails_helper.rb
@@ -32,10 +32,12 @@ require 'rspec/rails'
 # If there are pending migrations it will invoke `db:test:prepare` to
 # recreate the test database by loading the schema.
 # If you are not using ActiveRecord, you can remove these lines.
-begin
-  ActiveRecord::Migration.maintain_test_schema!
-rescue ActiveRecord::PendingMigrationError => e
-  abort e.to_s.strip
+if Rails.env.test? && !defined?(Rails::Generators)
+  begin
+    ActiveRecord::Migration.maintain_test_schema!
+  rescue ActiveRecord::PendingMigrationError => e
+    abort e.to_s.strip
+  end
 end
 <% end -%>
 RSpec.configure do |config|


### PR DESCRIPTION
## Description

This change addresses an issue where running the `factory_bot` generator could result in a `factory_bot [not found]` error.  
The problem occurred due to missing generator definitions and template files.

With this update, the authentication generator is properly defined and includes the necessary templates, ensuring that the `users.rb` factory file is generated regardless of whether the project is using RSpec (`spec/factories`) or Minitest (`test/factories`).  
This guarantees consistent behavior and avoids generator errors in environments without a `spec` directory.

## Background

Previously, projects without a `spec` directory or with incomplete generator/template setup would fail when invoking `factory_bot` generators, making it impossible to scaffold the necessary factory files automatically.

## Changes Introduced

- Added the missing `factory_bot:authentication` generator definition.
- Included `users.rb` template under `templates` directory.
- Implemented logic to detect the test framework and place the generated factory file in the correct directory (`spec/factories` or `test/factories`).
- Ensured generator runs successfully regardless of the presence of a `spec` directory.
