### PR TITLE
Fix rails stats not finding spec directories when run outside app root

### DIFF
--- a/features/rails_stats.feature
+++ b/features/rails_stats.feature
@@ -1,0 +1,16 @@
+Feature: Rails stats includes spec directories
+
+  Scenario: rails stats finds spec directories when run from a different working directory
+    Given rails 8 or later is available
+    Given a file named "spec/models/widget_spec.rb" with:
+      """ruby
+      require "rails_helper"
+
+      RSpec.describe Widget, type: :model do
+        it "works" do
+          expect(true).to be true
+        end
+      end
+      """
+    When I run `bash -c "APP=$PWD && cd /tmp && $APP/bin/rails stats"`
+    Then the output should contain "Model spec"

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -43,3 +43,9 @@ Given /action mailbox is available/ do
     pending "Action Mailbox is not available"
   end
 end
+
+Given /rails 8 or later is available/ do
+  unless ::Rails::VERSION::STRING >= "8.0.0"
+    pending "Rails 8.0+ is required"
+  end
+end

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -12,17 +12,19 @@ module RSpec
 
       # As of Rails 8.0.0 you can register directories to work with `rails stats`
       if ::Rails::VERSION::STRING >= "8.0.0"
-        require 'rails/code_statistics'
+        initializer "rspec_rails.code_statistics" do
+          require 'rails/code_statistics'
 
-        dirs = Dir['./spec/**/*_spec.rb']
-          .map { |f| f.sub(/^\.\/(spec\/\w+)\/.*/, '\\1') }
-          .uniq
-          .select { |f| File.directory?(f) }
+          root = ::Rails.root
+          dirs = Dir[root.join('spec', '**', '*_spec.rb').to_s]
+                   .map { |f| f.sub(%r{^#{Regexp.escape(root.to_s)}/(spec/\w+)/.*}, '\\1') }
+                   .uniq
+                   .select { |f| File.directory?(root.join(f)) }
 
-        Hash[dirs.map { |d| [d.split('/').last, d] }].each do |type, dir|
-          name = type.singularize.capitalize
-
-          ::Rails::CodeStatistics.register_directory "#{name} specs", dir, test_directory: true
+          Hash[dirs.map { |d| [d.split('/').last, d] }].each do |type, dir|
+            name = type.singularize.capitalize
+            ::Rails::CodeStatistics.register_directory "#{name} specs", root.join(dir).to_s, test_directory: true
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #2862 

The code statistics registration in the Railtie class body uses `Dir['./spec/**/*_spec.rb']` which resolves relative to `Dir.pwd`. When `bin/rails stats` is run from a directory other than the app root, no spec files are found and the output shows `Test LOC: 0`.

This moves the registration into an initializer and uses `Rails.root.join(...)` for absolute path resolution.
