### PR TITLE
Fix Bundler 4.0 compatibility in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           ruby-version: '3.3'
       - run: script/update_rubygems_and_install_bundler
-      - run: bundle install --standalone
+      - run: bundle install
       - run: bundle binstubs --all
       - run: script/run_rubocop
 
@@ -36,14 +36,11 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         # Edge Rails (?) builds >= 3.1
+         # Edge Rails builds >= 3.3
          - ruby: 3.4
            env:
              RAILS_VERSION: 'main'
          - ruby: 3.3
-           env:
-             RAILS_VERSION: 'main'
-         - ruby: 3.2
            env:
              RAILS_VERSION: 'main'
 
@@ -88,6 +85,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - run: script/update_rubygems_and_install_bundler
       - run: script/clone_all_rspec_repos
-      - run: bundle install --binstubs
+      - run: bundle install
+      - run: bundle binstubs --all
       - run: script/run_build
         continue-on-error: ${{ matrix.allow_failure || false }}

--- a/example_app_generator/ci_retry_bundle_install.sh
+++ b/example_app_generator/ci_retry_bundle_install.sh
@@ -4,4 +4,5 @@ set -e
 source FUNCTIONS_SCRIPT_FILE
 
 echo "Starting bundle install using shared bundle path"
-ci_retry eval "RUBYOPT=$RUBYOPT:' --enable rubygems' bundle install --gemfile ./Gemfile --path REPLACE_BUNDLE_PATH --retry=3 --jobs=3"
+RUBYOPT="$RUBYOPT --enable rubygems" bundle config set --local path REPLACE_BUNDLE_PATH
+ci_retry eval "RUBYOPT=$RUBYOPT:' --enable rubygems' bundle install --gemfile ./Gemfile --retry=3 --jobs=3"


### PR DESCRIPTION
Bundler 4.0 removed the --binstubs and --path flags from bundle install, breaking all CI jobs.                                                                                              
- Replace bundle install --binstubs with bundle install + bundle binstubs --all in CI workflow
- Replace bundle install --path with bundle config set --local path in example app install script
- Replace bundle install --standalone with bundle install in rubocop job (--standalone breaks bundle binstubs --all on clean CI environments)
- Remove Ruby 3.2 from Rails main builds (activesupport-8.2.0.alpha requires ruby >= 3.3.0)


References from
1. https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.0                                                                                                                           
2. https://github.com/ruby/rubygems/pull/8978                                                    
3. https://github.com/ruby/rubygems/pull/8958                                                                                                                                               
4. https://blog.rubygems.org/2025/12/03/upgrade-to-rubygems-bundler-4.html                                                                                                                  
5. https://github.com/ruby/rubygems/issues/8650


Verified locally
- bundler --version → 4.0.6
- bundle install --binstubs → exits 15 (The --binstubs option has been removed)
- bundle install --path → exits 15 (The --path flag has been removed)
- Full test suite passes: specs (984 examples), acceptance (smoke apps + cucumber 177 scenarios), and rubocop