### PR TITLE
Fix typo in matcher failure message

### DIFF
--- a/lib/rspec/rails/matchers/send_email.rb
+++ b/lib/rspec/rails/matchers/send_email.rb
@@ -91,7 +91,7 @@ module RSpec
 
         def sent_emails_message
           if @diff.empty?
-            "\n\nThere were not any emails sent inside the expectation block."
+            "\n\nThere were no emails sent inside the expectation block."
           else
             sent_emails =
               @diff.map do |email|

--- a/spec/rspec/rails/matchers/send_email_spec.rb
+++ b/spec/rspec/rails/matchers/send_email_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "send_email" do
     }.to raise_error(RSpec::Expectations::ExpectationNotMetError, <<~MSG.strip)
       No matching emails were sent.
 
-      There were not any emails sent inside the expectation block.
+      There were no emails sent inside the expectation block.
     MSG
   end
 


### PR DESCRIPTION
Fix typo with `send_email` matcher.

```diff
-       There were no any emails sent inside the expectation block.
+       There were not any emails sent inside the expectation block.
```