### PR TITLE
Restore snippets on 3.1

### DIFF
--- a/script/run_build
+++ b/script/run_build
@@ -10,9 +10,7 @@ fold "specs" run_specs_and_record_done
 
 fold "acceptance" bin/rake acceptance --trace
 
-if is_ruby_3_2_plus; then
-  fold "snippets" script/run_snippets.sh
-fi
+fold "snippets" script/run_snippets.sh
 
 if documentation_enforced; then
   fold "doc check" check_documentation_coverage

--- a/snippets/avoid_fixture_name_collision.rb
+++ b/snippets/avoid_fixture_name_collision.rb
@@ -27,6 +27,10 @@ gemfile(false) do
     eval_gemfile 'Gemfile-rails-dependencies'
   end
 
+  if RUBY_VERSION.to_f < 3.2
+    gem "securerandom", ">= 0.3"
+  end
+
   gem "rspec-rails", path: "../"
 end
 


### PR DESCRIPTION
By forcing the correct version of securerandom, we can fix this snippet on Ruby 3.1