### PR TITLE
Fix ViewRendering after hook wiping controller view_paths when controller is nil in before hook

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -158,7 +158,7 @@ module RSpec
         end
 
         after do
-          controller.class.view_paths = @_original_path_set unless render_views?
+          controller.class.view_paths = @_original_path_set if @_original_path_set && !render_views?
         end
       end
     end

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -120,6 +120,50 @@ module RSpec::Rails
       end
     end
 
+    context "when controller is nil in before hook but set in after hook" do
+      it "does not wipe view_paths on the controller class" do
+        original_paths = ActionController::Base.view_paths
+
+        group_with_late_controller = RSpec::Core::ExampleGroup.describe do
+          include ViewRendering
+
+          def controller
+            @_controller
+          end
+
+          before { @_controller = ActionController::Base.new }
+
+          it("runs") { }
+        end
+
+        group_with_late_controller.run(double.as_null_object)
+
+        expect(ActionController::Base.view_paths).to eq(original_paths)
+      end
+    end
+
+    context "when a config-based before hook skips the example (issue #2602)" do
+      it "does not wipe view_paths for subsequent examples" do
+        original_paths = ActionController::Base.view_paths
+
+        RSpec.configuration.before(:each, skip_me_2602: true) { skip "skipped" }
+
+        group_with_skip = RSpec::Core::ExampleGroup.describe do
+          def controller
+            ActionController::Base.new
+          end
+          include ViewRendering
+
+          it("skipped example", skip_me_2602: true) { }
+          it("subsequent example") { }
+        end
+
+        group_with_skip.run(double.as_null_object)
+
+        expect(ActionController::Base.view_paths).to eq(original_paths)
+      end
+    end
+
     context 'when render_views? is false' do
       let(:controller) { ActionController::Base.new }
 


### PR DESCRIPTION
The `render_views?` instance method returns different values in the `before` and `after` hooks when `controller` changes between them. This happens in request specs where `controller` is nil before the first request but set to a real controller instance afterwards:

- `before`: controller is nil → NilClass doesn't respond_to?(:view_paths) → render_views? returns true → skips saving @_original_path_set
- `after`: controller is set → controller.class responds_to?(:view_paths) → render_views? returns false → restores @_original_path_set (nil) → wipes controller.class.view_paths to an empty PathSet

This class-level mutation persists across examples, causing ActionView::MissingTemplate errors in subsequent tests that depend on the same controller class having valid view paths.

The fix adds a nil guard on @_original_path_set in the after hook so the restore only runs when the before hook actually saved the paths.

Fixes #2602