### PR TITLE
Clear ActiveJob queues between examples in job specs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,13 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v8.0.4...main)
 
+Bug Fixes:
+
+* Include `ActiveJob::TestHelper` in `RailsExampleGroup` so enqueued and
+  performed jobs are reset before each example, matching `ActiveJob::TestCase`.
+  Fixes `have_been_enqueued` and `have_been_performed` leaking state between
+  examples. (Hammad Khan, rspec/rspec-rails#2900)
+
 ### 8.0.4 / 2026-03-10
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v8.0.3...v8.0.4)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,10 +3,8 @@
 
 Bug Fixes:
 
-* Include `ActiveJob::TestHelper` in `RailsExampleGroup` so enqueued and
-  performed jobs are reset before each example, matching `ActiveJob::TestCase`.
-  Fixes `have_been_enqueued` and `have_been_performed` leaking state between
-  examples. (Hammad Khan, rspec/rspec-rails#2900)
+* Include `ActiveJob::TestHelper` in all rails example groups to ensure jobs are reset
+  between examples matching Rails in-build behaviour. (Hammad Khan, rspec/rspec-rails#2901)
 
 ### 8.0.4 / 2026-03-10
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v8.0.3...v8.0.4)

--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -16,9 +16,12 @@ module RSpec
       include RSpec::Rails::MinitestAssertionAdapter
       include RSpec::Rails::FixtureSupport
       include RSpec::Rails::TaggedLoggingAdapter
-      include ActiveJob::TestHelper if RSpec::Rails::FeatureCheck.has_active_job?
       include ActiveSupport::CurrentAttributes::TestHelper
       include ActiveSupport::ExecutionContext::TestHelper
+
+      if RSpec::Rails::FeatureCheck.has_active_job?
+        include ActiveJob::TestHelper
+      end
     end
   end
 end

--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -16,6 +16,7 @@ module RSpec
       include RSpec::Rails::MinitestAssertionAdapter
       include RSpec::Rails::FixtureSupport
       include RSpec::Rails::TaggedLoggingAdapter
+      include ActiveJob::TestHelper if RSpec::Rails::FeatureCheck.has_active_job?
       include ActiveSupport::CurrentAttributes::TestHelper
       include ActiveSupport::ExecutionContext::TestHelper
     end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -59,7 +59,9 @@ module RSpec::Rails
 
     it 'will not leak enqueued ActiveJob jobs between examples', skip: !RSpec::Rails::FeatureCheck.has_active_job? do
       original_adapter = ActiveJob::Base.queue_adapter
+      original_logger = ActiveJob::Base.logger
       ActiveJob::Base.queue_adapter = :test
+      ActiveJob::Base.logger = Logger.new(nil)
 
       leaky_job = Class.new(ActiveJob::Base) do
         def perform; end
@@ -88,6 +90,7 @@ module RSpec::Rails
       ).to be true
     ensure
       ActiveJob::Base.queue_adapter = original_adapter
+      ActiveJob::Base.logger = original_logger
     end
   end
 end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -56,5 +56,39 @@ module RSpec::Rails
         group.run(failure_reporter) ? true : failure_reporter.exceptions
       ).to be true
     end
+
+    if RSpec::Rails::FeatureCheck.has_active_job?
+      it 'will not leak enqueued ActiveJob jobs between examples' do
+        original_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+        leaky_job = Class.new(ActiveJob::Base) do
+          def perform; end
+
+          def self.name
+            'LeakyJob'
+          end
+        end
+
+        group =
+          RSpec::Core::ExampleGroup.describe("A group", order: :defined) do
+            include RSpec::Rails::RailsExampleGroup
+
+            it 'enqueues a job' do
+              leaky_job.perform_later
+              expect(enqueued_jobs.size).to eq(1)
+            end
+
+            it 'does not see the job enqueued in the prior example' do
+              expect(enqueued_jobs).to be_empty
+            end
+          end
+
+        expect(
+          group.run(failure_reporter) ? true : failure_reporter.exceptions
+        ).to be true
+      ensure
+        ActiveJob::Base.queue_adapter = original_adapter
+      end
+    end
   end
 end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -57,38 +57,37 @@ module RSpec::Rails
       ).to be true
     end
 
-    if RSpec::Rails::FeatureCheck.has_active_job?
-      it 'will not leak enqueued ActiveJob jobs between examples' do
-        original_adapter = ActiveJob::Base.queue_adapter
-        ActiveJob::Base.queue_adapter = :test
-        leaky_job = Class.new(ActiveJob::Base) do
-          def perform; end
+    it 'will not leak enqueued ActiveJob jobs between examples', skip: !RSpec::Rails::FeatureCheck.has_active_job? do
+      original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
 
-          def self.name
-            'LeakyJob'
+      leaky_job = Class.new(ActiveJob::Base) do
+        def perform; end
+
+        def self.name
+          'LeakyJob'
+        end
+      end
+
+      group =
+        RSpec::Core::ExampleGroup.describe("A group", order: :defined) do
+          include RSpec::Rails::RailsExampleGroup
+
+          it 'enqueues a job' do
+            leaky_job.perform_later
+            expect(enqueued_jobs.size).to eq(1)
+          end
+
+          it 'does not see the job enqueued in the prior example' do
+            expect(enqueued_jobs).to be_empty
           end
         end
 
-        group =
-          RSpec::Core::ExampleGroup.describe("A group", order: :defined) do
-            include RSpec::Rails::RailsExampleGroup
-
-            it 'enqueues a job' do
-              leaky_job.perform_later
-              expect(enqueued_jobs.size).to eq(1)
-            end
-
-            it 'does not see the job enqueued in the prior example' do
-              expect(enqueued_jobs).to be_empty
-            end
-          end
-
-        expect(
-          group.run(failure_reporter) ? true : failure_reporter.exceptions
-        ).to be true
-      ensure
-        ActiveJob::Base.queue_adapter = original_adapter
-      end
+      expect(
+        group.run(failure_reporter) ? true : failure_reporter.exceptions
+      ).to be true
+    ensure
+      ActiveJob::Base.queue_adapter = original_adapter
     end
   end
 end


### PR DESCRIPTION
Fixes #2900.

## Problem

`have_been_enqueued` and `have_been_performed` inspect the queue adapter's accumulated `enqueued_jobs` / `performed_jobs` arrays directly, without state-delta logic. When the queue adapter is configured once (the usual setup in `config/environments/test.rb`), the same `TestAdapter` instance is reused across the suite and jobs accumulate between examples. The matchers then see jobs left over from prior tests.

rspec-rails' own matcher suite doesn't expose this because it reassigns `ActiveJob::Base.queue_adapter = :test` in a `before` hook (`spec/rspec/rails/matchers/active_job_spec.rb:88`), which creates a fresh `TestAdapter` per example — masking the production behaviour. Issue #2900 has a clear writeup by @jasonkarns showing the leak in a real Rails app.

## Fix

Add a `before` hook in `RSpec::Rails::JobExampleGroup` that clears `enqueued_jobs` and `performed_jobs` on the queue adapter at the start of every example, mirroring what `ActiveJob::TestHelper#before_setup` does for `ActiveJob::TestCase`. Scoping to `JobExampleGroup` (rather than `RailsExampleGroup`) keeps the change minimal and matches how Rails layers the helper — only `ActiveJob::TestCase` gets the clearing behaviour.

The `respond_to?` guards are there in case a user has swapped in a non-test queue adapter.

## Tests

New spec `spec/rspec/rails/example/job_example_group_spec.rb` uses the same `order: :defined` sub-example-group pattern as the existing `CurrentAttributes` leak test in `rails_example_group_spec.rb`. It runs two examples in sequence — the first enqueues / performs a job, the second asserts both queues are empty — and fails without the fix.

## Test plan

- [x] `bundle exec rspec spec/rspec/rails/example/job_example_group_spec.rb` — 16/16 pass
- [x] `bundle exec rspec spec/rspec/rails/example/` — 280/280 pass
- [x] `bundle exec rspec spec/rspec/rails/matchers/active_job_spec.rb` — no regressions
- [x] `bundle exec rubocop` on changed files — clean