### PR TITLE
Expand file_fixture_path against Rails.root

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,14 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v8.0.4...main)
 
+Bug Fixes:
+
+* Expand `file_fixture_path` against `Rails.root` when applying it to example
+  groups so the value made available is absolute, matching how
+  `ActiveSupport::TestCase` configures it. User-supplied absolute paths pass
+  through unchanged.
+  (Hammad Khan, rspec/rspec-rails#2682)
+
 ### 8.0.4 / 2026-03-10
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v8.0.3...v8.0.4)
 

--- a/lib/rspec/rails/file_fixture_support.rb
+++ b/lib/rspec/rails/file_fixture_support.rb
@@ -8,10 +8,19 @@ module RSpec
       include ActiveSupport::Testing::FileFixtures
 
       included do
-        self.file_fixture_path = RSpec.configuration.file_fixture_path
+        self.file_fixture_path = FileFixtureSupport.expanded_fixture_path
         if defined?(ActiveStorage::FixtureSet)
-          ActiveStorage::FixtureSet.file_fixture_path = RSpec.configuration.file_fixture_path
+          ActiveStorage::FixtureSet.file_fixture_path = FileFixtureSupport.expanded_fixture_path
         end
+      end
+
+      # Expand the configured `file_fixture_path` against `Rails.root` so the
+      # value made available to example groups is absolute, matching how
+      # `ActiveSupport::TestCase` configures it. `File.expand_path` is a no-op
+      # when the path is already absolute, so user-supplied absolute paths are
+      # passed through unchanged.
+      def self.expanded_fixture_path
+        File.expand_path(RSpec.configuration.file_fixture_path, ::Rails.root)
       end
     end
   end

--- a/spec/rspec/rails/file_fixture_support_spec.rb
+++ b/spec/rspec/rails/file_fixture_support_spec.rb
@@ -1,0 +1,38 @@
+module RSpec::Rails
+  RSpec.describe FileFixtureSupport, :with_isolated_config do
+    it "expands a relative configured file_fixture_path against Rails.root" do
+      RSpec.configuration.file_fixture_path = 'spec/fixtures/files'
+
+      group = RSpec::Core::ExampleGroup.describe do
+        include FileFixtureSupport
+      end
+
+      expect(group.file_fixture_path)
+        .to eq(File.expand_path('spec/fixtures/files', ::Rails.root))
+    end
+
+    it "passes through an absolute configured file_fixture_path unchanged" do
+      absolute_path = File.expand_path('/tmp/custom/fixtures')
+      RSpec.configuration.file_fixture_path = absolute_path
+
+      group = RSpec::Core::ExampleGroup.describe do
+        include FileFixtureSupport
+      end
+
+      expect(group.file_fixture_path).to eq(absolute_path)
+    end
+
+    if defined?(ActiveStorage::FixtureSet)
+      it "applies the expanded path to ActiveStorage::FixtureSet" do
+        RSpec.configuration.file_fixture_path = 'spec/fixtures/files'
+
+        RSpec::Core::ExampleGroup.describe do
+          include FileFixtureSupport
+        end
+
+        expect(ActiveStorage::FixtureSet.file_fixture_path)
+          .to eq(File.expand_path('spec/fixtures/files', ::Rails.root))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2682.

## Problem

The configured default `file_fixture_path` is the relative string `'spec/fixtures/files'` (`lib/rspec/rails/configuration.rb:84`). When applied to example groups via `FileFixtureSupport`, it stays relative. But `ActiveSupport::TestCase` (and downstream consumers such as ActionMailer's `read_fixture`) treat `file_fixture_path` as absolute — they hand it directly to `Pathname.new` / `File.join` expecting a rooted path.

Issue reporter @jasonkarns hit this while fixing `read_fixture` and noted that all Rails-side defaults for `file_fixture_path` are absolute (either via `File.expand_path(__dir__)` or `Rails.root.join(...)`).

## Fix

Expand the configured value against `Rails.root` in `FileFixtureSupport.included` before assigning it to the example group and to `ActiveStorage::FixtureSet`. `File.expand_path` is a no-op on already-absolute paths, so users who override the config with an absolute path see no behavioural change.

The user-facing config default (`config.file_fixture_path = 'spec/fixtures/files'`) is intentionally left as the relative form — that's the conventional value people write in `RSpec.configure` and matches what documentation references. Only the value that gets exposed to example groups becomes absolute.

## Tests

New spec `spec/rspec/rails/file_fixture_support_spec.rb` covers three cases:
1. A relative configured path gets expanded against `Rails.root`.
2. An absolute configured path passes through unchanged.
3. `ActiveStorage::FixtureSet.file_fixture_path` receives the expanded value.

## Test plan

- [x] `bundle exec rspec spec/rspec/rails/file_fixture_support_spec.rb` — 3/3 pass
- [x] `bundle exec rspec spec/rspec/rails/configuration_spec.rb spec/rspec/rails/fixture_support_spec.rb` — 67/67 pass
- [x] `bundle exec rubocop` on changed files — clean