### PR TITLE
Register AR verifying-double callback at load time, not in before :suite

### DIFF
--- a/lib/rspec/rails/active_record.rb
+++ b/lib/rspec/rails/active_record.rb
@@ -4,17 +4,28 @@ module RSpec
     # these are dynamically added to the normal RSpec configuration object.
     class ActiveRecordConfiguration
       # @private
-      def self.initialize_activerecord_configuration(config)
-        config.before :suite do
-          # This allows dynamic columns etc to be used on ActiveRecord models when creating instance_doubles
-          if defined?(ActiveRecord) && defined?(ActiveRecord::Base) && defined?(::RSpec::Mocks) && (::RSpec::Mocks.respond_to?(:configuration))
-            ::RSpec::Mocks.configuration.when_declaring_verifying_double do |possible_model|
-              target = possible_model.target
+      def self.initialize_activerecord_configuration(_config)
+        # This allows dynamic columns etc to be used on ActiveRecord models when creating instance_doubles.
+        #
+        # The callback is registered directly (not wrapped in `before :suite`)
+        # so it takes effect as soon as rspec-rails is required, even if that
+        # happens after `before :suite` has already fired in the current
+        # process. This matters for runners that interleave file loading and
+        # example execution per worker (e.g. test-queue), where the worker may
+        # require rails_helper — and thus rspec-rails — only after entering
+        # its `with_suite_hooks` block. With the previous before-suite
+        # wrapper, the registration in such workers would be queued for a
+        # before-suite firing that never happens, leaving instance_double
+        # checks unverified for AR-backed dynamic methods.
+        return unless defined?(::RSpec::Mocks) && ::RSpec::Mocks.respond_to?(:configuration)
 
-              if Class === target && ActiveRecord::Base > target && !target.abstract_class?
-                target.define_attribute_methods
-              end
-            end
+        ::RSpec::Mocks.configuration.when_declaring_verifying_double do |possible_model|
+          next unless defined?(ActiveRecord) && defined?(ActiveRecord::Base)
+
+          target = possible_model.target
+
+          if Class === target && ActiveRecord::Base > target && !target.abstract_class?
+            target.define_attribute_methods
           end
         end
       end


### PR DESCRIPTION
I had this problem while implementing https://github.com/tmm1/test-queue

Claude came up with this PR's patch to solve a problem I was having

I don't know rspec-rails enough to know if this is a good idea.

View the PR with whitespace disabled, it's very small.

Let me know what you think! Or if you feel I should put in more human legwork before submitting.

<details><summary>Claude copy</summary>

## Summary

`lib/rspec/rails/active_record.rb` registers its `when_declaring_verifying_double` callback *inside* `config.before :suite do ... end`. The before-suite block is the wrapper; the actual hook installation is the inner `RSpec::Mocks.configuration.when_declaring_verifying_double` call.

Under plain rspec this works: all spec files (and thus `rails_helper`, and thus rspec-rails) are loaded before `with_suite_hooks` fires `before(:suite)`. The before-suite block runs, invokes the inner registration, and the callback is in place for the first `instance_double` call.

It breaks under runners that interleave file loading and example execution per worker — test-queue and knapsack_pro queue mode are the cases I've hit. Worker processes fork from a master that hasn't loaded `rails_helper`. They enter `with_suite_hooks` and fire `before :suite` *before* requiring `rails_helper`. By the time rspec-rails loads in the worker (when it requires its first spec file's `rails_helper`), the inner `config.before :suite { ... register ... }` registration is queued for a `before :suite` firing that has already happened. The verifying-double callback never gets installed.

Symptom in the affected workers:

```
Failure/Error: let(:m) { instance_double(SomeModel, some_column: ...) }
  the SomeModel class does not implement the instance method: some_column
```

…which is exactly the failure mode this code was added to prevent.

## Fix

Register the callback directly at gem load time. Move the `defined?(ActiveRecord)` check into the callback body so the registration itself doesn't require ActiveRecord to be loaded at gem-load time.

## Verifying

Hit this migrating a ~1830-spec Rails codebase from `parallel_tests` to test-queue. Running one instance_double-heavy file (`spec/services/frontegg/tenant_validator_spec.rb`) under test-queue's `bin/test-queue-rspec` with rspec-rails as-is: 4 of 6 random seeds fail with "does not implement the instance method". With this patch applied: all 6 pass, all seeds.

Plain rspec on the same file passes regardless, because the load-then-fire-suite order doesn't expose the bug.

## Test plan

(Open to suggestions on the cleanest test. The fault is order-sensitive and only manifests when `before(:suite)` fires before `rails_helper` has been required, which is awkward to reproduce inside rspec-rails' own suite. Happy to add a regression test if there's a natural place — pointers welcome.)

## Related

There's a workaround in the affected codebase ([Healthie's test-queue migration PR](https://github.com/healthie/web/pull/28857)) that registers an equivalent callback directly via `spec/support/verifying_doubles.rb`. That file can be removed once a release containing this fix is in the bundle.
</details>