### PR TITLE
Assign default_url_options instead of mutating it

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Bug Fixes:
 
 * Include `ActiveJob::TestHelper` in all rails example groups to ensure jobs are reset
   between examples matching Rails in-build behaviour. (Hammad Khan, rspec/rspec-rails#2901)
+* Handle Rails 8.2 having a frozen hash for `default_url_options` by assigning rather than mutating it.
+  (Federico Carrocera, rspec/rspec-rails#2907)
 * Fix `have_stream` (and related) matcher(s) by handling changes to stream test harness in Rails 8.2.
   (Jon Rowe, Phil Pirozhkov, rspec/rspec-rails#2909)
 

--- a/lib/rspec/rails/example/feature_example_group.rb
+++ b/lib/rspec/rails/example/feature_example_group.rb
@@ -9,6 +9,9 @@ module RSpec
       # Default host to be used in Rails route helpers if none is specified.
       DEFAULT_HOST = "www.example.com"
 
+      # Default url options, merged into those of the example group.
+      DEFAULT_OPTIONS = { host: DEFAULT_HOST }.freeze
+
       included do
         app = ::Rails.application
         if app.respond_to?(:routes)
@@ -16,7 +19,7 @@ module RSpec
           include app.routes.mounted_helpers if app.routes.respond_to?(:mounted_helpers)
 
           if respond_to?(:default_url_options)
-            default_url_options[:host] ||= ::RSpec::Rails::FeatureExampleGroup::DEFAULT_HOST
+            self.default_url_options = DEFAULT_OPTIONS.merge(default_url_options)
           end
         end
       end

--- a/lib/rspec/rails/example/mailer_example_group.rb
+++ b/lib/rspec/rails/example/mailer_example_group.rb
@@ -21,8 +21,8 @@ if defined?(ActionMailer)
 
         included do
           include ::Rails.application.routes.url_helpers
-          options = ::Rails.configuration.action_mailer.default_url_options || {}
-          options.each { |key, value| default_url_options[key] = value }
+          options = ::Rails.configuration.action_mailer.default_url_options
+          self.default_url_options = default_url_options.merge(options) if options.present?
         end
 
         # Class-level DSL for mailer specs.

--- a/spec/rspec/rails/example/feature_example_group_spec.rb
+++ b/spec/rspec/rails/example/feature_example_group_spec.rb
@@ -18,6 +18,38 @@ module RSpec::Rails
       expect(group.new.foo_url).to eq("http://www.example.com/foo")
     end
 
+    it "does not mutate a frozen `default_url_options`" do
+      with_isolated_stderr do
+        Rails.application.routes.draw do
+          get "/foo", as: :foo, to: "foo#bar"
+        end
+      end
+
+      group = RSpec::Core::ExampleGroup.describe do
+        include ::Rails.application.routes.url_helpers
+        self.default_url_options = {}.freeze
+        include FeatureExampleGroup
+      end
+
+      expect(group.new.foo_url).to eq("http://www.example.com/foo")
+    end
+
+    it "does not override a host set by the example group" do
+      with_isolated_stderr do
+        Rails.application.routes.draw do
+          get "/foo", as: :foo, to: "foo#bar"
+        end
+      end
+
+      group = RSpec::Core::ExampleGroup.describe do
+        include ::Rails.application.routes.url_helpers
+        self.default_url_options = { host: "example.org" }.freeze
+        include FeatureExampleGroup
+      end
+
+      expect(group.new.foo_url).to eq("http://example.org/foo")
+    end
+
     context "when nested inside a request example group" do
       it "includes Rails route helpers" do
         Rails.application.routes.draw do

--- a/spec/rspec/rails/example/mailer_example_group_spec.rb
+++ b/spec/rspec/rails/example/mailer_example_group_spec.rb
@@ -3,5 +3,20 @@ module RSpec::Rails
 
     it_behaves_like "an rspec-rails example group mixin", :mailer,
                     './spec/mailers/', '.\\spec\\mailers\\'
+
+    it "applies `config.action_mailer.default_url_options` without mutating a frozen hash" do
+      original = ::Rails.configuration.action_mailer.default_url_options
+      ::Rails.configuration.action_mailer.default_url_options = { host: "example.org" }
+
+      group = RSpec::Core::ExampleGroup.describe do
+        include ::Rails.application.routes.url_helpers
+        self.default_url_options = {}.freeze
+        include MailerExampleGroup
+      end
+
+      expect(group.default_url_options).to include(host: "example.org")
+    ensure
+      ::Rails.configuration.action_mailer.default_url_options = original
+    end
   end
 end


### PR DESCRIPTION
Rails main freezes the controller `default_url_options` (rails/rails#58483),
so the in-place writes in `FeatureExampleGroup` and `MailerExampleGroup` now
raise `FrozenError` while the example group is being defined. We hit this
bumping an app to Rails main; rspec-rails' own suite fails the same way.

```
 RSpec::Rails::FeatureExampleGroup includes Rails route helpers
     Failure/Error: include FeatureExampleGroup

     FrozenError:
       can't modify frozen Hash: {}
     # ./lib/rspec/rails/example/feature_example_group.rb:19:in 'block in <module:FeatureExampleGroup>'
     # .../active_support/concern.rb:150:in 'ActiveSupport::Concern#append_features'
```
Assign through the `class_attribute` writer instead, as the same Rails commit
did when migrating its own suite.

Fixes #2906.