### PR TITLE
Handle changes to streams in upcoming Rails 8.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Bug Fixes:
 
 * Include `ActiveJob::TestHelper` in all rails example groups to ensure jobs are reset
   between examples matching Rails in-build behaviour. (Hammad Khan, rspec/rspec-rails#2901)
+* Fix `have_stream` (and related) matcher(s) by handling changes to stream test harness in Rails 8.2.
+  (Jon Rowe, Phil Pirozhkov, rspec/rspec-rails#2909)
 
 ### 8.0.4 / 2026-03-10
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v8.0.3...v8.0.4)

--- a/lib/rspec/rails/example/channel_example_group.rb
+++ b/lib/rspec/rails/example/channel_example_group.rb
@@ -30,24 +30,32 @@ if RSpec::Rails::FeatureCheck.has_action_cable_testing?
         module ClassMethods
           # @private
           def channel_class
-            (_channel_class || described_class).tap do |klass|
-              next if klass <= ::ActionCable::Channel::Base
-
-              raise "Described class is not a channel class.\n" \
-                    "Specify the channel class in the `describe` statement " \
-                    "or set it manually using `tests MyChannelClass`"
-            end
+            (_channel_class || described_class).tap { |klass| check_class_type!(klass, "channel", ::ActionCable::Channel::Base) }
           end
 
           # @private
-          def connection_class
-            (_connection_class || described_class).tap do |klass|
-              next if klass <= ::ActionCable::Connection::Base
-
-              raise "Described class is not a connection class.\n" \
-                    "Specify the connection class in the `describe` statement " \
-                    "or set it manually using `tests MyConnectionClass`"
+          if ::Rails.version.to_f > 8.1
+            # :nocov:
+            def connection_class
+              (super || described_class).tap { |klass| check_class_type!(klass, "connection", ::ActionCable::Connection::Base) }
             end
+            # :nocov:
+          else
+            # :nocov:
+            def connection_class
+              (_connection_class || described_class).tap { |klass| check_class_type!(klass, "connection", ::ActionCable::Connection::Base) }
+            end
+            # :nocov:
+          end
+
+          private
+
+          def check_class_type!(klass, type, ancestor)
+            return true if klass && klass <= ancestor
+
+            raise "Described class is not a #{type} class.\n" \
+                  "Specify the #{type} class in the `describe` statement " \
+                  "or set it manually using `tests My#{type.capitialize}Class`"
           end
         end
 

--- a/lib/rspec/rails/matchers/action_cable/have_streams.rb
+++ b/lib/rspec/rails/matchers/action_cable/have_streams.rb
@@ -37,7 +37,7 @@ module RSpec
           def match(subscription)
             case subscription
             when ::ActionCable::Channel::Base
-              @actual = subscription.streams
+              @actual = extract_streams(subscription)
               no_expected? ? actual.any? : actual.any? { |i| expected === i }
             else
               raise ArgumentError, "have_stream, have_stream_from and have_stream_from support expectations on subscription only"
@@ -50,6 +50,12 @@ module RSpec
 
           def no_expected?
             !defined?(@expected)
+          end
+
+          if ::Rails.version.to_f > 8.1
+            def extract_streams(subscription) = subscription.stream_names
+          else
+            def extract_streams(subscription) = subscription.streams
           end
         end
       end


### PR DESCRIPTION
Use stream_names from the new extension, grab `connection_class` directly when possible.