### PR TITLE
Handle templates returned directly by resolvers

### DIFF
--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -92,6 +92,10 @@ module RSpec
         private
 
           def nullify_templates(collection)
+            if collection.is_a?(::ActionView::Template)
+              return EmptyTemplateResolver.nullify_template_rendering([collection]).first
+            end
+
             return collection unless collection.is_a?(Enumerable)
             return collection unless collection.all? { |element| element.is_a?(::ActionView::Template) }
 

--- a/spec/rspec/rails/view_rendering_spec.rb
+++ b/spec/rspec/rails/view_rendering_spec.rb
@@ -165,6 +165,25 @@ module RSpec::Rails
           expect(custom_method_called).to eq(true)
         end
 
+        it "prevents rendering when a custom resolver returns a single template" do
+          template = ActionView::Template.new(
+            "rendered",
+            "custom resolver template",
+            ViewRendering::EmptyTemplateHandler,
+            virtual_path: "custom/template",
+            format: :html,
+            locals: []
+          )
+          resolver = Class.new(ActionView::Resolver) do
+            define_method(:find) { |*| template }
+          end.new
+
+          decorated_template = ViewRendering::EmptyTemplateResolver.build(resolver).find
+
+          expect(decorated_template).to be_an(ActionView::Template)
+          expect(decorated_template.source).to eq("")
+        end
+
         it "works with strings" do
           decorated = false
           ActionController::Base.view_paths = ActionView::PathSet.new(['app/views', 'app/legacy_views'])


### PR DESCRIPTION
Rails main changed `ActionView::Resolver#find` to return a single template.

`ResolverDecorator#nullify_templates` only handled collections, so the template was returned unchanged and the real view could render when `render_views` was disabled.

This updates the resolver decorator to handle both single templates and collections.

Fixes #2905

## Testing

- Added a regression spec for a resolver returning a single template
- Ran `bundle exec rspec spec/rspec/rails/view_rendering_spec.rb`
- Ran RuboCop