### PR TITLE
Discover spec directories without globbing every spec file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v8.0.4...main)
 
+Enhancements:
+
+* Speed up the `rails stats` initializer by discovering the spec subdirectories directly, rather
+  than enumerating every spec file in `spec/`. (Connor Shea, rspec/rspec-rails#2914)
+
 Bug Fixes:
 
 * Include `ActiveJob::TestHelper` in all rails example groups to ensure jobs are reset

--- a/lib/rspec-rails.rb
+++ b/lib/rspec-rails.rb
@@ -15,15 +15,14 @@ module RSpec
         initializer "rspec_rails.code_statistics" do
           require 'rails/code_statistics'
 
-          root = ::Rails.root
-          dirs = Dir[root.join('spec', '**', '*_spec.rb').to_s]
-                   .map { |f| f.sub(%r{^#{Regexp.escape(root.to_s)}/(spec/\w+)/.*}, '\\1') }
-                   .uniq
-                   .select { |f| File.directory?(root.join(f)) }
+          Dir[::Rails.root.join('spec', '*').to_s].sort.each do |dir|
+            type = File.basename(dir)
+            next unless type.match?(/\A\w+\z/) && File.directory?(dir) && !File.symlink?(dir)
+            # Check the top level of each directory first, so that the common case doesn't
+            # require walking the directory; only fall back to a full walk if that finds nothing.
+            next if Dir.glob('*_spec.rb', base: dir).empty? && Dir.glob('**/*_spec.rb', base: dir).empty?
 
-          Hash[dirs.map { |d| [d.split('/').last, d] }].each do |type, dir|
-            name = type.singularize.capitalize
-            ::Rails::CodeStatistics.register_directory "#{name} specs", root.join(dir).to_s, test_directory: true
+            ::Rails::CodeStatistics.register_directory "#{type.singularize.capitalize} specs", dir, test_directory: true
           end
         end
       end

--- a/spec/rspec/rails/railtie_spec.rb
+++ b/spec/rspec/rails/railtie_spec.rb
@@ -1,0 +1,64 @@
+require 'tmpdir'
+require 'rspec-rails'
+require 'rails/code_statistics'
+
+if ::Rails::VERSION::STRING >= "8.0.0"
+  RSpec.describe RSpec::Rails::Railtie do
+    describe "rspec_rails.code_statistics initializer" do
+      let(:initializer) { described_class.initializers.find { |i| i.name == "rspec_rails.code_statistics" } }
+      let(:registered) { [] }
+
+      around do |example|
+        Dir.mktmpdir do |dir|
+          @root = Pathname(dir)
+          example.run
+        end
+      end
+
+      before do
+        allow(::Rails).to receive(:root).and_return(@root)
+        allow(::Rails::CodeStatistics).to receive(:register_directory) { |name, dir, **| registered << [name, dir] }
+      end
+
+      def touch(path)
+        full = @root.join(path)
+        FileUtils.mkdir_p(full.dirname)
+        FileUtils.touch(full)
+      end
+
+      it "registers each `spec` subdirectory containing a spec file, at any depth" do
+        touch 'spec/models/user_spec.rb'
+        touch 'spec/features/admin/reports/monthly_spec.rb'
+        touch 'spec/support/helpers.rb'
+        touch 'spec/fixtures/files/users.yml'
+        touch 'spec/spec_helper.rb'
+        touch 'spec/root_spec.rb'
+
+        initializer.run
+
+        expect(registered).to eq([
+          ["Feature specs", @root.join('spec/features').to_s],
+          ["Model specs", @root.join('spec/models').to_s],
+        ])
+      end
+
+      it "ignores non-word directory names and symlinked directories" do
+        touch 'spec/models/user_spec.rb'
+        touch 'spec/my-features/a_spec.rb'
+        touch 'spec/.hidden/a_spec.rb'
+        touch 'spec/fixtures/.hidden/a_spec.rb'
+        File.symlink(@root.join('spec/models'), @root.join('spec/aliased'))
+
+        initializer.run
+
+        expect(registered.map(&:first)).to eq(["Model specs"])
+      end
+
+      it "registers nothing when there is no `spec` directory" do
+        initializer.run
+
+        expect(registered).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
AI Disclosure: This was generated with help from Claude Code, Opus 5/Fable 5. I have reviewed and tested this change manually, and written this PR description myself.

Fixes #2912.

Previously, the `rspec_rails.code_statistics` initializer was enumerating every file under every directory in `spec` with a `*_spec.rb` name just to find the spec directories that exist. This ran on every boot of the app, so it was done on all Rails 8+ apps whenever tests were run. It also meant that larger repositories would spend more time on this as they grew. It only ends up resulting in maybe 40ms of difference on my Mac when tested with our large production app at work, but that's a small boot penalty on every test run and CI runners are generally less powerful than my dev machine, so I think it's worth fixing.

This change gets the exact same results as the previous implementation, but it stops after the first `_spec.rb` file is found in each directory, and so we can avoid extra work in most cases. I have tested the `rails stats` command against mastodon, discourse, gitlab, canvas, my own small personal rails app, and our app at work, and gotten the exact same results before and after this PR on all of them, as well as some generated test apps to look for any risk of breakage.

Benchmarking, courtesy of Claude, 30 iterations each:

| Tree | Before | After | Change |
|---|---|---|---|
| This repo (`rspec-rails`, 2 spec dirs) | 0.56 ms | 0.31 ms | **1.8x faster** |
| [Mastodon](https://github.com/mastodon/mastodon) (22 spec dirs, 1,089 spec files) | 6.07 ms | 1.71 ms | **3.5x faster** |
| [Discourse](https://github.com/discourse/discourse) (21 spec dirs, 1,691 spec files) | 9.18 ms | 3.51 ms | **2.6x faster** |
| [Canvas](https://github.com/instructure/canvas-lms) (20 spec dirs, 2,680 spec files) | 15.63 ms | 2.38 ms | **6.6x faster** |
| [GitLab](https://gitlab.com/gitlab-org/gitlab) (47 spec dirs, 12,091 spec files) | 106.42 ms | 37.87 ms | **2.8x faster** |
| Synthetic, issue scale (960 dirs, 1,890 spec files, 30 top-level) | 24.10 ms | 1.15 ms | **21.0x faster** |
| Large, specs directly in every top-level dir (3,750 dirs, 10,000 spec files) | 113.19 ms | 4.19 ms | **27.0x faster** |
| Large, specs only in leaf dirs (6,500 dirs, 10,000 spec files) | 153.46 ms | 96.90 ms | **1.6x faster** |
| Large, specs only in leaves + spec-free 600-dir `spec/factories` (7,101 dirs, 10,000 spec files) | 161.90 ms | 108.55 ms | **1.5x faster** |
| Adversarial (900-subdir `spec/support` with no specs; one spec buried 5 deep) | 11.81 ms | 12.26 ms | **~1.0x — effectively the same** |

<details>
<summary>Benchmark script</summary>

```rb
#!/usr/bin/env ruby
# frozen_string_literal: true

# Benchmarks the spec directory discovery done by rspec-rails' `rspec_rails.code_statistics`
# initializer (Rails 8+), comparing the implementation before and after rspec/rspec-rails#2914.
#
# Only reads the filesystem: no Bundler, no Rails, and no need to `bundle install` the app.
#
#   ruby bench_code_statistics.rb /path/to/rails/app [iterations]

require 'benchmark'
require 'pathname'

root = Pathname(ARGV[0] || Dir.pwd).expand_path
iterations = Integer(ARGV[1] || 30)
abort "No spec directory found in #{root}" unless root.join('spec').directory?

# Before: rspec-rails 8.0.4 (lib/rspec-rails.rb)
before = lambda do
  dirs = Dir[root.join('spec', '**', '*_spec.rb').to_s]
           .map { |f| f.sub(%r{^#{Regexp.escape(root.to_s)}/(spec/\w+)/.*}, '\\1') }
           .uniq
           .select { |f| File.directory?(root.join(f)) }
  Hash[dirs.map { |d| [d.split('/').last, d] }].map { |type, dir| [type, root.join(dir).to_s] }.sort
end

# After: rspec/rspec-rails#2914
after = lambda do
  Dir[root.join('spec', '*').to_s].sort.filter_map do |dir|
    type = File.basename(dir)
    next unless type.match?(/\A\w+\z/) && File.directory?(dir) && !File.symlink?(dir)
    next if Dir.glob('*_spec.rb', base: dir).empty? && Dir.glob('**/*_spec.rb', base: dir).empty?

    [type, dir]
  end
end

before_result = before.call
after_result = after.call
unless before_result == after_result
  warn "Results differ!\n  before: #{before_result.map(&:first)}\n  after:  #{after_result.map(&:first)}"
  exit 1
end

measure = lambda do |impl|
  impl.call # warm up
  Benchmark.realtime { iterations.times { impl.call } } / iterations * 1000
end

before_ms = measure.call(before)
after_ms = measure.call(after)
spec_files = Dir.glob('spec/**/*_spec.rb', base: root).size.to_s.gsub(/(\d)(?=(\d{3})+$)/, '\1,')

puts "Discovered #{after_result.size} spec directories: #{after_result.map(&:first).join(', ')}"
puts "#{iterations} iterations, mean per run:"
puts
puts '| App | Before | After | Change |'
puts '|---|---|---|---|'
puts format('| %s (%d spec dirs, %s spec files) | %.2f ms | %.2f ms | **%.1fx faster** |',
            root.basename, after_result.size, spec_files, before_ms, after_ms, before_ms / after_ms)
```
</details>

The main reason the synthetics are significantly faster is because real apps have directories like `fixtures` and `factories` that never have spec files in them (so we have to read every file in them, we can't bail early), and every file in those directories has to be checked. We could potentially cut further time off by just excluding those two directories, but it _technically_ comes with the risk of someone having actual tests in one of those two directories. I'm unsure whether Rails/rspec would actually work if you did that, but I don't know for sure and I'd rather not complicate this change.

We can also bench the memory allocations and see that a lot less memory allocation churn is needed now that we aren't using a regex or loading nearly as many individual file paths. It's only KB or MB at most and is transient, but still nice for reducing GC pressure a bit:

| Repo | Before (allocations / memory) | After (allocations / memory) | Change |
|---|---|---|---|
| rspec-rails (2 spec dirs, 58 spec files) | 1,248 objects / 128 KB | 124 objects / 7 KB | **10x fewer objects, 18x less memory** |
| Mastodon (22 spec dirs, 1,089 spec files) | 20,258 objects / 2,100 KB | 821 objects / 62 KB | **25x fewer objects, 34x less memory** |
| Discourse (21 spec dirs, 1,691 spec files) | 30,418 objects / 3,263 KB | 1,430 objects / 116 KB | **21x fewer objects, 28x less memory** |
| Canvas LMS (20 spec dirs, 2,680 spec files) | 47,162 objects / 5,441 KB | 1,156 objects / 93 KB | **41x fewer objects, 58x less memory** |
| GitLab (47 spec dirs, 12,091 spec files) | 209,157 objects / 22,578 KB | 2,390 objects / 217 KB | **88x fewer objects, 104x less memory** |