### PR TITLE
Handle frozen view path prefixes array on Rails main

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ Bug Fixes:
   (Federico Carrocera, rspec/rspec-rails#2907)
 * Fix `have_stream` (and related) matcher(s) by handling changes to stream test harness in Rails 8.2.
   (Jon Rowe, Phil Pirozhkov, rspec/rspec-rails#2909)
+* Handle Rails 8.2 ViewPaths::ClassMethods#\_prefixes returning a frozen array.
+  (Iliana Hadzhiatanasova, rspec/rspec-rails#2915)
 
 ### 8.0.4 / 2026-03-10
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v8.0.3...v8.0.4)

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@ Bug Fixes:
   (Federico Carrocera, rspec/rspec-rails#2907)
 * Fix `have_stream` (and related) matcher(s) by handling changes to stream test harness in Rails 8.2.
   (Jon Rowe, Phil Pirozhkov, rspec/rspec-rails#2909)
-* Handle Rails 8.2 ViewPaths::ClassMethods#\_prefixes returning a frozen array.
+  * Fix view specs manipulating a frozen array (for template prefixes) in `actionview` internals in Rails 8.2.
   (Iliana Hadzhiatanasova, rspec/rspec-rails#2915)
 
 ### 8.0.4 / 2026-03-10

--- a/lib/rspec/rails/example/view_example_group.rb
+++ b/lib/rspec/rails/example/view_example_group.rb
@@ -186,7 +186,7 @@ module RSpec
 
         before do
           _include_controller_helpers
-          view.lookup_context.prefixes.prepend(_controller_path)
+          view.lookup_context.prefixes = [_controller_path] + view.lookup_context.prefixes
 
           controller.controller_path = _controller_path
 


### PR DESCRIPTION
https://github.com/rails/rails/pull/58509 started freezing the array returned from `ViewPaths::ClassMethods#_prefixes` which resulted in this error for an app running Rails main:

```
Failure/Error: example.run

FrozenError:
  can't modify frozen Array: ["", "action_view/test_case/test"]
/bundler_cache/ruby/4.0.0/bundler/gems/rspec-rails-1fc6126ea2fa/lib/rspec/rails/example/view_example_group.rb:189:in 'Array#unshift'
/bundler_cache/ruby/4.0.0/bundler/gems/rspec-rails-1fc6126ea2fa/lib/rspec/rails/example/view_example_group.rb:189:in 'block (2 levels) in <module:ViewExampleGroup>'
```

This behaviour is also breaking when running `rspec-rails` CI against Rails main with:

```
 2) RSpec::Rails::ViewExampleGroup#view is accessible to configuration-level hooks
     Failure/Error: expect(failure_reporter.exceptions).to eq []

       expected: []
            got: [#<FrozenError: can't modify frozen Array: ["", "action_view/test_case/test"]>]

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -[]
       +[#<FrozenError: can't modify frozen Array: ["", "action_view/test_case/test"]>]
     # ./.bundle/gems/ruby/3.4.0/bundler/gems/rspec-bba959b0a2ec/rspec-support/lib/rspec/support.rb:110:in 'block in <module:Support>'
```
(see https://github.com/rspec/rspec-rails/actions/runs/32581938937/job/97059449323)

We can build a new prefixes array instead of mutating the frozen one



I also had a look at the remaining CI failures for Rails main, which should be fixed with https://github.com/rspec/rspec-rails/pull/2913