### PR TITLE
Fix a Thor-related issue

### DIFF
--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -76,10 +76,7 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
     describe 'in an engine' do
       it 'generates files with Engine url_helpers' do
         in_sub_process do
-          # Stubbing defines the method on the class, and Thor registers every
-          # method defined on a generator as a command to run. `no_commands`
-          # keeps `mountable_engine?` out of the command list, which it is not
-          # a member of in the first place.
+          # Ensure Thor does not treat the stub as a command.
           ::Rails::Generators::NamedBase.no_commands do
             allow_any_instance_of(::Rails::Generators::NamedBase).to receive(:mountable_engine?).and_return(true)
           end

--- a/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
+++ b/spec/generators/rspec/scaffold/scaffold_generator_spec.rb
@@ -76,7 +76,14 @@ RSpec.describe Rspec::Generators::ScaffoldGenerator, type: :generator do
     describe 'in an engine' do
       it 'generates files with Engine url_helpers' do
         in_sub_process do
-          allow_any_instance_of(::Rails::Generators::NamedBase).to receive(:mountable_engine?).and_return(true)
+          # Stubbing defines the method on the class, and Thor registers every
+          # method defined on a generator as a command to run. `no_commands`
+          # keeps `mountable_engine?` out of the command list, which it is not
+          # a member of in the first place.
+          ::Rails::Generators::NamedBase.no_commands do
+            allow_any_instance_of(::Rails::Generators::NamedBase).to receive(:mountable_engine?).and_return(true)
+          end
+
           run_generator %w[posts --request_specs]
 
           expect(filename).to contain('Engine.routes.url_helpers')


### PR DESCRIPTION
     Thor::UndefinedCommandError:
       Could not find command "mountable_engine?".
     # ./.bundle/gems/ruby/3.4.0/gems/thor-1.5.0/lib/thor/base.rb:615:in 'Thor::Base::ClassMethods#handle_no_command_error'

Keep the stubbed `mountable_engine?` out of Thor's command list

Thor turns every public instance method defined on a generator into a command and runs all of them on `invoke_all`

Wrap the stub in `no_commands`, Thor's own escape hatch for defining methods that are not commands.

As seen in eg https://github.com/rspec/rspec-rails/actions/runs/33024598274/job/98418758302?pr=2914
