### PR TITLE
Blank out templates found under a string view path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@ Bug Fixes:
   (Jon Rowe, Phil Pirozhkov, rspec/rspec-rails#2909)
 * Fix view specs manipulating a frozen array (for template prefixes) in `actionview` internals in Rails 8.2.
   (Iliana Hadzhiatanasova, rspec/rspec-rails#2915)
+* Keep controller specs from rendering views reached through a view path added as a string.
+  (Phil Pirozhkov, rspec/rspec-rails#2917)
 
 ### 8.0.4 / 2026-03-10
 [Full Changelog](https://github.com/rspec/rspec-rails/compare/v8.0.3...v8.0.4)

--- a/example_app_generator/spec/verify_custom_renderers_spec.rb
+++ b/example_app_generator/spec/verify_custom_renderers_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe "template rendering", type: :controller do
 
         expect(response).to render_template(:bar)
       end
+
+      it "renders an empty string" do
+        get :index
+
+        expect(response.body).to eq("")
+      end
     end
 
     context "with a custom renderer prepended to the view path" do

--- a/lib/rspec/rails/view_rendering.rb
+++ b/lib/rspec/rails/view_rendering.rb
@@ -99,16 +99,19 @@ module RSpec
           end
         end
 
-        # Delegates find_templates to the submitted path set and then returns
-        # templates with modified source
+        # Looks templates up on the file system and then returns them with
+        # modified source
         #
         # @private
         class FileSystemResolver < ::ActionView::FileSystemResolver
-          private
+          def find_all(*args)
+            EmptyTemplateResolver.nullify_template_rendering(super)
+          end
 
-          def find_templates(*args)
-            templates = super
-            EmptyTemplateResolver.nullify_template_rendering(templates)
+          # Rails 8.2 resolves a single template without going through
+          # `find_all`, so decorating `find_all` alone would miss it.
+          def find(*args)
+            find_all(*args).first
           end
         end
       end


### PR DESCRIPTION
Change the find_templates override that was never reached.

The file system resolver has always looked templates up on its own:

6.0, 6.1  `FileSystemResolver` inherits from PathResolver, overrides `_find_all` and reads the file system directly.
7.0-8.0   `PathResolver` is gone and `FileSystemResolver` overrides `_find_all` itself. Still no `find_templates`.
8.2       `_find_all` is gone; `FileSystemResolver` implements the public `find_all`, plus a `find` that resolves the single best match without going through `find_all`.

So the real template rendered even with `render_views` off, on every version we support.

Decorate the public `find_all`, and `find` alongside it, since on 8.2 one does not go through the other.

The acceptance app already covered this context, but only asserted which template was picked, never that its body came out empty.

Fixes https://github.com/rspec/rspec-rails/actions/runs/32901535965/job/97976281067?pr=2915#step:7:1644
