### PR TITLE
Fix sticky queue_adapter in our specs

### DIFF
--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -58,9 +58,7 @@ module RSpec::Rails
     end
 
     it 'will not leak enqueued ActiveJob jobs between examples', skip: !RSpec::Rails::FeatureCheck.has_active_job? do
-      original_adapter = ActiveJob::Base.queue_adapter
       original_logger = ActiveJob::Base.logger
-      ActiveJob::Base.queue_adapter = :test
       ActiveJob::Base.logger = Logger.new(nil)
 
       leaky_job = Class.new(ActiveJob::Base) do
@@ -74,6 +72,10 @@ module RSpec::Rails
       group =
         RSpec::Core::ExampleGroup.describe("A group", order: :defined) do
           include RSpec::Rails::RailsExampleGroup
+
+          def queue_adapter_for_test
+            ActiveJob::QueueAdapters::TestAdapter.new
+          end
 
           it 'enqueues a job' do
             leaky_job.perform_later
@@ -89,7 +91,6 @@ module RSpec::Rails
         group.run(failure_reporter) ? true : failure_reporter.exceptions
       ).to be true
     ensure
-      ActiveJob::Base.queue_adapter = original_adapter
       ActiveJob::Base.logger = original_logger
     end
   end


### PR DESCRIPTION
Reading ActiveJob::Base.queue_adapter before assigning anything started breaking on Rails 8.2-pre

ActiveJob::TestHelper::TestQueueAdapter.adapter_for caches an adapter and makes further assigning to queue_adapter an NOP.

Rails commit: https://github.com/rails/rails/commit/77b6966720d4f2e2cf975de6ae9ccafc0cd0681e

It caused flakiness due to order-dependency. Passes whenever another file, eg matchers/active_job_spec.rb, has already assigned an adapter, and fails when it runs first. Seeds 999 and 12345 fail while eg seed 1 passes.

Only our internal build is affected. `active_job.set_configs` sets

    config.active_job.queue_adapter ||= (Rails.env.test? ? :test : :async)

and assigns it on boot, so an application always has an adapter on the class attribute and a bare read can never fill the cache.

In our specs, ActiveJob::Base._queue_adapter starts with nil.

Drop the read and the assignment, and hand the adapter over through queue_adapter_for_test, the hook ActiveJob::TestHelper calls per example.

Fixes eg https://github.com/rspec/rspec-rails/actions/runs/32901535965/job/97976281083?pr=2915#step:7:96