### PR TITLE
Rework spec checking for active job leaks to handle new ActiveJob::TestHelper implementation

### DIFF
--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -65,7 +65,7 @@ module RSpec::Rails
       if ::Rails.version.to_f > 8.1
         # Rails 8.2 started storing test adapters in such a way as to override the settings
         # with a cached version, we need to clear that cache after changing the adapter to
-        # our isolated one. See rspec/rspec-rails#
+        # our isolated one. See rspec/rspec-rails#2919
         ActiveJob::TestHelper::TestQueueAdapter.reset
         expect(ActiveJob::Base.queue_adapter).to eq(test_adapter)
       end

--- a/spec/rspec/rails/example/rails_example_group_spec.rb
+++ b/spec/rspec/rails/example/rails_example_group_spec.rb
@@ -59,8 +59,18 @@ module RSpec::Rails
 
     it 'will not leak enqueued ActiveJob jobs between examples', skip: !RSpec::Rails::FeatureCheck.has_active_job? do
       original_adapter = ActiveJob::Base.queue_adapter
+      test_adapter = ActiveJob::QueueAdapters::TestAdapter.new
+      ActiveJob::Base.queue_adapter = test_adapter
+
+      if ::Rails.version.to_f > 8.1
+        # Rails 8.2 started storing test adapters in such a way as to override the settings
+        # with a cached version, we need to clear that cache after changing the adapter to
+        # our isolated one. See rspec/rspec-rails#
+        ActiveJob::TestHelper::TestQueueAdapter.reset
+        expect(ActiveJob::Base.queue_adapter).to eq(test_adapter)
+      end
+
       original_logger = ActiveJob::Base.logger
-      ActiveJob::Base.queue_adapter = :test
       ActiveJob::Base.logger = Logger.new(nil)
 
       leaky_job = Class.new(ActiveJob::Base) do


### PR DESCRIPTION
Rails 8.2 changed the active job [test helper](https://github.com/rails/rails/commit/77b6966720d4f2e2cf975de6ae9ccafc0cd0681e) in such a way that in certain load orders, the adapter for `ActiveJob::Base` is cached, this implementation then overrides the configuration which results in our setup during a regression test for checking that queues don't leak between jobs breaking because the job and test have different queues, and the test never sees the job at all let alone leak.

You can verify this locally by using a seed such as `40770`, or running the spec in isolation and changing the assertion for the adapter to:

```
expect {
  ActiveJob::TestHelper::TestQueueAdapter.reset
}.to change { ActiveJob::Base.queue_adapter }.to(test_adapter)
```